### PR TITLE
Add boiler plate http transport code

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -3,25 +3,38 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
-	"log"
+	"os"
+	"os/signal"
+	"time"
 
 	ffproxy "github.com/harness/ff-proxy"
 	"github.com/harness/ff-proxy/cache"
 	"github.com/harness/ff-proxy/domain"
+	"github.com/harness/ff-proxy/log"
+	proxyservice "github.com/harness/ff-proxy/proxy-service"
 	"github.com/harness/ff-proxy/repository"
+	"github.com/harness/ff-proxy/transport"
 )
 
 var (
+	debug   bool
 	offline bool
+	host    string
+	port    int
 )
 
 func init() {
+	flag.BoolVar(&debug, "debug", false, "enables debug logging")
 	flag.BoolVar(&offline, "offline", false, "enables side loading of data from config dir")
+	flag.StringVar(&host, "host", "localhost", "host of the proxy service")
+	flag.IntVar(&port, "port", 7000, "port that the proxy service is exposed on")
 	flag.Parse()
 }
 
 func main() {
+	logger := log.NewLogger(os.Stderr, debug)
+	logger.Info("msg", "service config", "debug", debug, "offline", offline, "host", host, "port", port)
+
 	var (
 		featureConfig map[domain.FeatureConfigKey][]domain.FeatureConfig
 		targetConfig  map[domain.TargetKey][]domain.Target
@@ -30,38 +43,46 @@ func main() {
 	if offline {
 		config, err := ffproxy.NewFeatureFlagConfig(ffproxy.DefaultConfig, ffproxy.DefaultConfigDir)
 		if err != nil {
-			log.Fatal("failed to load config: ", err)
+			logger.Error("msg", "failed to load config", "err", err)
+			os.Exit(1)
 		}
 		featureConfig = config.FeatureConfig()
 		targetConfig = config.Targets()
 	}
 
+	// Create cache and repos
 	memCache := cache.NewMemCache()
 	tr, err := repository.NewTargetRepo(memCache, targetConfig)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("msg", "failed to create target repo", "err", err)
+		os.Exit(1)
 	}
 
 	fcr, err := repository.NewFeatureConfigRepo(memCache, featureConfig)
 	if err != nil {
-		log.Fatal(err)
+		logger.Error("msg", "failed to create feature config repo", "err", err)
+		os.Exit(1)
 	}
 
-	// We'll pass the above repos to the service once its been created but for
-	// now just get a target and feature config and print them out
+	service := transport.NewLoggingService(logger, proxyservice.NewProxyService(fcr, tr, logger))
+	endpoints := transport.NewEndpoints(service)
+	server := transport.NewHTTPServer(host, port, endpoints, logger)
 
-	ctx := context.Background()
+	go func() {
+		sigc := make(chan os.Signal, 1)
+		signal.Notify(sigc, os.Interrupt)
+		<-sigc
+		logger.Info("msg", "recevied interrupt, shutting down server...")
 
-	dave, err := tr.GetByIdentifier(ctx, domain.NewTargetKey("94ef7361-1f2d-40af-9b2c-c1145d537e5a"), "dave")
-	if err != nil {
-		log.Fatal(err)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			logger.Error("msg", "server error'd during shutdown", "err", err)
+			os.Exit(1)
+		}
+	}()
+
+	if err := server.Serve(); err != nil {
+		logger.Error("msg", "server stopped", "err", err)
 	}
-	fmt.Println("target: ", dave)
-
-	darkMode, err := fcr.GetByIdentifier(ctx, domain.NewFeatureConfigKey("94ef7361-1f2d-40af-9b2c-c1145d537e5a"), "harnessappdemodarkmode")
-	if err != nil {
-		log.Fatal(err)
-	}
-	fmt.Println("featureConfig: ", darkMode)
-
 }

--- a/domain/requests.go
+++ b/domain/requests.go
@@ -1,0 +1,51 @@
+package domain
+
+// AuthRequest contains the fields sent in an authentication request
+type AuthRequest struct {
+	APIKey string
+}
+
+// AuthResponse contains the fields returned in an authentication response
+type AuthResponse struct {
+	AuthToken string `json:"auth_token"`
+}
+
+// FeatureConfigRequest contains the fields sent in a GET /client/env/{environmentUUID}/feature-configs
+type FeatureConfigRequest struct {
+	EnvironmentID string
+}
+
+// FeatureConfigByIdentifierRequest contains the fields sent in a GET /client/env/{environmentUUID}/feature-configs/{identifier}
+type FeatureConfigByIdentifierRequest struct {
+	EnvironmentID string
+	Identifier    string
+}
+
+// TargetSegmentsRequest contains the fields sent in a GET /client/env/{environmentUUID}/target-segments
+type TargetSegmentsRequest struct {
+	EnvironmentID string
+}
+
+// TargetSegmentsByIdentifierRequest contains the fields sent in a GET /client/env/{environmentUUID}/target-segments/{identifier}
+type TargetSegmentsByIdentifierRequest struct {
+	EnvironmentID string
+	Identifier    string
+}
+
+// EvaluationsRequest contains the fields sent in a GET /client/env/{environmentUUID}/target/{target}/evaluations
+type EvaluationsRequest struct {
+	EnvironmentID    string
+	TargetIdentifier string
+}
+
+// EvaluationsByFeatureRequest contains the fields sent in a GET /client/env/{environmentUUID}/target/{target}/evaluations/{feature} request
+type EvaluationsByFeatureRequest struct {
+	EnvironmentID     string
+	TargetIdentifier  string
+	FeatureIdentifier string
+}
+
+// StreamRequest contains the fields sent in a GET /stream request
+type StreamRequest struct {
+	APIKey string `json:"api_key"`
+}

--- a/domain/stream.go
+++ b/domain/stream.go
@@ -1,0 +1,36 @@
+package domain
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// Stream is a type that writes to an io.Writer
+type Stream struct {
+	w io.Writer
+}
+
+// NewStream creates and returns a Stream with the passed io.Writer
+func NewStream(w io.Writer) Stream {
+	return Stream{w: w}
+}
+
+// Send marshals the event to bytes and writes them to the io.Writer
+func (s Stream) Send(event encoding.BinaryMarshaler) error {
+	flusher, ok := s.w.(http.Flusher)
+	if !ok {
+		return errors.New("not a flusher")
+	}
+
+	b, err := event.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(s.w, b)
+	flusher.Flush()
+	return nil
+}

--- a/gen/services.gen.go
+++ b/gen/services.gen.go
@@ -1284,4 +1284,3 @@ func GetSwagger() (swagger *openapi3.T, err error) {
 	}
 	return
 }
-

--- a/gen/types.gen.go
+++ b/gen/types.gen.go
@@ -213,4 +213,3 @@ type StreamParams struct {
 
 // AuthenticateJSONRequestBody defines body for Authenticate for application/json ContentType.
 type AuthenticateJSONRequestBody AuthenticateJSONBody
-

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,9 @@ go 1.17
 require (
 	github.com/deepmap/oapi-codegen v1.8.3
 	github.com/getkin/kin-openapi v0.80.0
+	github.com/go-kit/kit v0.12.0
 	github.com/go-redis/redis/v8 v8.11.4
+	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -15,6 +17,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-kit/log v0.2.0 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.5 // indirect
 	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,12 @@ github.com/getkin/kin-openapi v0.80.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSy
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-chi/chi/v5 v5.0.0/go.mod h1:BBug9lr0cqtdAhsu6R4AAdvufI0/XBzAQSsUqJpoZOs=
+github.com/go-kit/kit v0.12.0 h1:e4o3o3IsBfAKQh5Qbbiqyfu97Ku7jrO/JbohvztANh4=
+github.com/go-kit/kit v0.12.0/go.mod h1:lHd+EkCZPIwYItmGDDRdhinkzX2A1sj+M9biaEaizzs=
+github.com/go-kit/log v0.2.0 h1:7i2K3eKTos3Vc0enKCfnVcgHh2olr/MyfboYq7cAcFw=
+github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
@@ -39,6 +45,7 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,57 @@
+package log
+
+import (
+	"io"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// Logger is a logger with multiple logging levels
+type Logger interface {
+	Info(keyvals ...interface{})
+	Debug(keyvals ...interface{})
+	Error(keyvals ...interface{})
+}
+
+type logger struct {
+	log.Logger
+	debug bool
+}
+
+// NewLogger returns a new logger
+func NewLogger(w io.Writer, debug bool) Logger {
+	w = log.NewSyncWriter(w)
+	kitlogger := log.NewLogfmtLogger(w)
+
+	level.NewFilter(kitlogger, level.AllowAll())
+	return &logger{kitlogger, debug}
+}
+
+// Info logs keyvals at the info level
+func (l *logger) Info(keyvals ...interface{}) {
+	level.Info(l).Log(keyvals...)
+}
+
+// Debug logs keyvals at the debug level and adds the caller to the log
+func (l *logger) Debug(keyvals ...interface{}) {
+	if !l.debug {
+		return
+	}
+	logWithCaller := log.With(l, "caller", log.DefaultCaller)
+	level.Debug(logWithCaller).Log(keyvals...)
+}
+
+// Error logs keyvals at the error level
+func (l *logger) Error(keyvals ...interface{}) {
+	level.Error(l).Log(keyvals...)
+}
+
+// With returns a new Logger with keyvals prepended to log calls
+func With(l Logger, keyvals ...interface{}) Logger {
+	original, ok := l.(*logger)
+	if !ok {
+		return l
+	}
+	return &logger{Logger: log.With(original.Logger, keyvals...), debug: original.debug}
+}

--- a/log/noop_logger.go
+++ b/log/noop_logger.go
@@ -1,0 +1,19 @@
+package log
+
+// NoOpLogger is a type that implements the Logger interface but does nothing
+// when it's methods are called
+type NoOpLogger struct{}
+
+// NewNoOpLogger returns a NoOpLogger
+func NewNoOpLogger() NoOpLogger {
+	return NoOpLogger{}
+}
+
+// Info does nothing on a NoOpLogger
+func (n NoOpLogger) Info(keyvals ...interface{}) {}
+
+// Debug does nothing on a NoOpLogger
+func (n NoOpLogger) Debug(keyvals ...interface{}) {}
+
+// Error  does nothing on a NoOpLogger
+func (n NoOpLogger) Error(keyvals ...interface{}) {}

--- a/proxy-service/service.go
+++ b/proxy-service/service.go
@@ -1,0 +1,69 @@
+package proxyservice
+
+import (
+	"context"
+	"errors"
+
+	"github.com/harness/ff-proxy/domain"
+	"github.com/harness/ff-proxy/gen"
+	"github.com/harness/ff-proxy/log"
+	"github.com/harness/ff-proxy/repository"
+)
+
+var (
+	// ErrNotImplemented is the error returned when a method hasn't been implemented
+	ErrNotImplemented = errors.New("endpoint not implemented")
+)
+
+// ProxyService is the proxy service implementation
+type ProxyService struct {
+	logger      log.Logger
+	featureRepo repository.FeatureConfigRepo
+	targetRepo  repository.TargetRepo
+}
+
+// NewProxyService creates and returns a ProxyService
+func NewProxyService(fr repository.FeatureConfigRepo, tr repository.TargetRepo, l log.Logger) ProxyService {
+	l = log.With(l, "component", "ProxyService")
+	return ProxyService{logger: l, featureRepo: fr, targetRepo: tr}
+}
+
+// Authenticate performs authentication
+func (p ProxyService) Authenticate(ctx context.Context, req domain.AuthRequest) (domain.AuthResponse, error) {
+	return domain.AuthResponse{}, ErrNotImplemented
+}
+
+// FeatureConfig gets all FeatureConfig for an environment
+func (p ProxyService) FeatureConfig(ctx context.Context, req domain.FeatureConfigRequest) ([]domain.FeatureConfig, error) {
+	return []domain.FeatureConfig{}, ErrNotImplemented
+}
+
+// FeatureConfigByIdentifier gets the feature config for a feature
+func (p ProxyService) FeatureConfigByIdentifier(ctx context.Context, req domain.FeatureConfigByIdentifierRequest) (domain.FeatureConfig, error) {
+	return domain.FeatureConfig{}, ErrNotImplemented
+}
+
+// TargetSegments gets all of the TargetSegments in an environment
+func (p ProxyService) TargetSegments(ctx context.Context, req domain.TargetSegmentsRequest) ([]gen.Segment, error) {
+	return []gen.Segment{}, ErrNotImplemented
+}
+
+// TargetSegmentsByIdentifier get a TargetSegments from an environment by its identifier
+func (p ProxyService) TargetSegmentsByIdentifier(ctx context.Context, req domain.TargetSegmentsByIdentifierRequest) (gen.Segment, error) {
+	return gen.Segment{}, ErrNotImplemented
+}
+
+// Evaluations gets all of the evaluations in an environment for a target
+func (p ProxyService) Evaluations(ctx context.Context, req domain.EvaluationsRequest) ([]gen.Evaluation, error) {
+	return []gen.Evaluation{}, ErrNotImplemented
+}
+
+// EvaluationsByFeature gets all of the evaluations in an environment for a target for a particular feature
+func (p ProxyService) EvaluationsByFeature(ctx context.Context, req domain.EvaluationsByFeatureRequest) (gen.Evaluation, error) {
+	return gen.Evaluation{}, ErrNotImplemented
+}
+
+// Stream streams flag updates out to the client
+func (p ProxyService) Stream(ctx context.Context, req domain.StreamRequest, stream domain.Stream) error {
+	return ErrNotImplemented
+}

--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -1,0 +1,218 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/harness/ff-proxy/domain"
+	proxyservice "github.com/harness/ff-proxy/proxy-service"
+)
+
+var (
+	errBadRouting = errors.New("bad routing")
+	errBadRequest = errors.New("bad request")
+)
+
+// encodeResponse is the common method to encode all the non error response types
+// to the client. If we need to we can write specific encodeResponse functions
+// for endpoints that require one.
+func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	return json.NewEncoder(w).Encode(response)
+}
+
+// encodeError encodes error responses returned from handlers
+func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
+	if err == nil {
+		panic("encodeError with nil error")
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(codeFrom(err))
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"error": err.Error(),
+	})
+}
+
+// encodeStreamResponse sets the headers for a streaming response
+func encodeStreamResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	return nil
+}
+
+// codeFrom casts a service error to an http.StatusCode
+func codeFrom(err error) int {
+	switch err {
+	case proxyservice.ErrNotImplemented:
+		return http.StatusNotImplemented
+	default:
+		if errors.Is(err, errBadRequest) {
+			return http.StatusBadRequest
+		}
+		return http.StatusInternalServerError
+	}
+}
+
+// decodeAuthRequest decodes POST /client/auth requests into a domain.AuthRequest
+// that can be passed to the service. It returns a wrapped bad request error if
+// the request body is empty or if the apiKey is empty
+func decodeAuthRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	req := domain.AuthRequest{}
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) == 0 {
+		return nil, fmt.Errorf("%w: request body cannot be empty", errBadRequest)
+	}
+
+	if err := json.Unmarshal(b, &req); err != nil {
+		return nil, err
+	}
+
+	if req.APIKey == "" {
+		return nil, fmt.Errorf("%w: apiKey cannot be empty", errBadRequest)
+	}
+	return req, nil
+}
+
+// decodeGetFeatureConfigisRequest decodes GET /client/env/{environmentUUID}/feature-configs requests
+// into a domain.FeatureConfigRequest that can be passed to the ProxyService
+func decodeGetFeatureConfigsRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	envID, ok := vars["environmentUUID"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	req := domain.FeatureConfigRequest{
+		EnvironmentID: envID,
+	}
+	return req, nil
+}
+
+// decodeGetFeatureConfigsByIdentifierRequest decodes GET /client/env/{environmentUUID}/feature-configs/{identifier} requests
+// into a domain.FeatureConfigsByIdentifierRequest that can be passed to the ProxyService
+func decodeGetFeatureConfigsByIdentifierRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	envID, ok := vars["environmentUUID"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	identifier := vars["identifier"]
+	req := domain.FeatureConfigByIdentifierRequest{
+		EnvironmentID: envID,
+		Identifier:    identifier,
+	}
+	return req, nil
+}
+
+// decodeGetTargetSegmentsRequest decodes GET /client/env/{environmentUUID}/target-segments requests
+// into a domain.TargetSegmentsRequest that can be passed to the ProxyService
+func decodeGetTargetSegmentsRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	envID, ok := vars["environmentUUID"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	req := domain.TargetSegmentsRequest{
+		EnvironmentID: envID,
+	}
+	return req, nil
+}
+
+// decodeGetTargetSegmentsByIdentifierRequest decodes GET /client/env/{environmentUUID}/target-segments/{identifier}
+// requests into a domain.TargetSegmentsByIdentifierRequest that can be passed to the ProxyService
+func decodeGetTargetSegmentsByIdentifierRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	envID, ok := vars["environmentUUID"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	identifier := vars["identifier"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	req := domain.TargetSegmentsByIdentifierRequest{
+		EnvironmentID: envID,
+		Identifier:    identifier,
+	}
+	return req, nil
+}
+
+// decodeGetEvaluationsRequest decodes GET /client/env/{environmentUUID}/target/{target}/evaluations
+// requests into a domain.EvaluationsRequest that can be passed to the ProxyService
+func decodeGetEvaluationsRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+
+	envID, ok := vars["environmentUUID"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	target, ok := vars["target"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	req := domain.EvaluationsRequest{
+		EnvironmentID:    envID,
+		TargetIdentifier: target,
+	}
+	return req, nil
+}
+
+// decodeGetEvaluationsByFeatureRequest decodes GET /client/env/{environmentUUID}/target/{target}/evaluations/{feature}
+// requests into a domain.EvaluationsByFeatureRequest that can be passed to the ProxyService
+func decodeGetEvaluationsByFeatureRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+
+	envID, ok := vars["environmentUUID"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	target, ok := vars["target"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	feature, ok := vars["feature"]
+	if !ok {
+		return nil, errBadRouting
+	}
+
+	req := domain.EvaluationsByFeatureRequest{
+		EnvironmentID:     envID,
+		TargetIdentifier:  target,
+		FeatureIdentifier: feature,
+	}
+	return req, nil
+}
+
+// decodeGetStreamRequest decodes GET /stream requests into a domain.StreamRequest that
+// can be passed to the ProxyService
+func decodeGetStreamRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	apiKey := r.Header.Get("API-Key")
+
+	req := domain.StreamRequest{
+		APIKey: apiKey,
+	}
+
+	if req.APIKey == "" {
+		return nil, fmt.Errorf("%w: API-Key can't be empty", errBadRequest)
+	}
+	return req, nil
+}

--- a/transport/endpoints.go
+++ b/transport/endpoints.go
@@ -1,0 +1,145 @@
+package transport
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/harness/ff-proxy/domain"
+)
+
+// streamEndpoint is the endpoint definition for an endpoint that provides streaming
+// functionality
+type streamEndpoint func(ctx context.Context, req interface{}, stream interface{}) error
+
+// Endpoints collects all of the endpoints that make up a ProxyService
+type Endpoints struct {
+	PostAuthenticate              endpoint.Endpoint
+	GetFeatureConfigs             endpoint.Endpoint
+	GetFeatureConfigsByIdentifier endpoint.Endpoint
+	GetTargetSegments             endpoint.Endpoint
+	GetTargetSegmentsByIdentifier endpoint.Endpoint
+	GetEvaluations                endpoint.Endpoint
+	GetEvaluationsByFeature       endpoint.Endpoint
+	GetStream                     streamEndpoint
+}
+
+// NewEndpoints returns an initalised Endpoints where each endpoint invokes the
+// corresponding method on the passed ProxyService
+func NewEndpoints(p ProxyService) *Endpoints {
+	return &Endpoints{
+		PostAuthenticate:              makePostAuthenticateEndpoint(p),
+		GetFeatureConfigs:             makeGetFeatureConfigsEndpoint(p),
+		GetFeatureConfigsByIdentifier: makeGetFeatureConfigsByIdentifierEndpoint(p),
+		GetTargetSegments:             makeGetTargetSegmentsEndpoint(p),
+		GetTargetSegmentsByIdentifier: makeGetTargetSegmentsByIdentifierEndpoint(p),
+		GetEvaluations:                makeGetEvaluationsEndpoint(p),
+		GetEvaluationsByFeature:       makeGetEvaluationsByFeatureEndpoint(p),
+		GetStream:                     makeGetStreamEndpoint(p),
+	}
+}
+
+// makePostAuthenticateEndpoint is a function to convert a services Authenticate
+// method to an endpoint
+func makePostAuthenticateEndpoint(s ProxyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(domain.AuthRequest)
+		resp, err := s.Authenticate(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+	}
+}
+
+// makeGetFeatureConfigsEndpoint is a function to convert a services GetFeatureConfig
+// method to an endpoint
+func makeGetFeatureConfigsEndpoint(s ProxyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (repsonse interface{}, err error) {
+		req := request.(domain.FeatureConfigRequest)
+		featureConfigs, err := s.FeatureConfig(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return featureConfigs, nil
+	}
+}
+
+// makeGetFeatureConfigsByIdentifierEndpoint is a function to convert a services
+// FeatureConfigByIdentifier method to an endpoint
+func makeGetFeatureConfigsByIdentifierEndpoint(s ProxyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(domain.FeatureConfigByIdentifierRequest)
+		featureConfig, err := s.FeatureConfigByIdentifier(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return featureConfig, nil
+	}
+}
+
+// makeGetTargetSegmentsEndpoint is a function to convert a services TargetSegments
+// method to an endpoint
+func makeGetTargetSegmentsEndpoint(s ProxyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(domain.TargetSegmentsRequest)
+		segments, err := s.TargetSegments(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return segments, nil
+	}
+}
+
+// makeGetTargetSegmentsByIdentifierEndpoint is a function to convert a services
+// TargetSegmentsByIdentifier method to an endpoint
+func makeGetTargetSegmentsByIdentifierEndpoint(s ProxyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(domain.TargetSegmentsByIdentifierRequest)
+		segment, err := s.TargetSegmentsByIdentifier(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return segment, nil
+	}
+}
+
+// makeGetEvaluationsEndpoint is a function to convert a services Evaluations
+// method to an endpoint
+func makeGetEvaluationsEndpoint(s ProxyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(domain.EvaluationsRequest)
+		evaluation, err := s.Evaluations(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return evaluation, nil
+	}
+}
+
+// makeGetEvaluationsByFeatureEndpoint is a function to convert a services
+// EvaluationsByFeature method to an endpoint
+func makeGetEvaluationsByFeatureEndpoint(s ProxyService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(domain.EvaluationsByFeatureRequest)
+		evaluations, err := s.EvaluationsByFeature(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return evaluations, nil
+	}
+}
+
+// makeGetStreamEndpoint is a function to convert a services Stream method
+// to an endpoint
+func makeGetStreamEndpoint(s ProxyService) streamEndpoint {
+	return func(ctx context.Context, request interface{}, stream interface{}) (err error) {
+		req := request.(domain.StreamRequest)
+		wstream := stream.(domain.Stream)
+
+		err = s.Stream(ctx, req, wstream)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+}

--- a/transport/http_server.go
+++ b/transport/http_server.go
@@ -1,0 +1,162 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/harness/ff-proxy/log"
+
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+)
+
+// HTTPServer is an http server that handles http requests
+type HTTPServer struct {
+	router *mux.Router
+	server *http.Server
+	log    log.Logger
+}
+
+// NewHTTPServer registers the passed endpoints against routes and returns an
+// HTTPServer that's ready to use
+func NewHTTPServer(host string, port int, e *Endpoints, l log.Logger) *HTTPServer {
+	l = log.With(l, "component", "HTTPServer")
+
+	router := mux.NewRouter()
+	server := &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", host, port),
+		Handler:           cors(router),
+		ReadTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       1 * time.Minute,
+	}
+
+	h := &HTTPServer{
+		router: router,
+		server: server,
+		log:    l,
+	}
+	h.registerEndpoints(e)
+	return h
+}
+
+//ServeHTTP makes HTTPServer implement the http.Handler interface
+func (h *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.router.ServeHTTP(w, r)
+}
+
+// Serve listens on the HTTPServers addr and handles requests
+func (h *HTTPServer) Serve() error {
+	h.log.Info("msg", "starting http server", "addr", h.server.Addr)
+	return h.server.ListenAndServe()
+}
+
+// Shutdown gracefully shutsdown the server
+func (h *HTTPServer) Shutdown(ctx context.Context) error {
+	h.log.Info("msg", "shutting down http server...", "addr", h.server.Addr)
+	return h.server.Shutdown(ctx)
+}
+
+// Use applies the passed MiddewareFuncs to all endpoints on the HTTPServer
+func (h *HTTPServer) Use(mw ...mux.MiddlewareFunc) {
+	h.router.Use(mw...)
+}
+
+func (h *HTTPServer) registerEndpoints(e *Endpoints) {
+	options := []httptransport.ServerOption{
+		httptransport.ServerErrorHandler(errorHandler{logger: h.log}),
+		httptransport.ServerErrorEncoder(encodeError),
+		httptransport.ServerBefore(httptransport.PopulateRequestContext),
+	}
+
+	streamOptions := []StreamHandlerOption{
+		StreamHandlerErrorHandler(errorHandler{logger: h.log}),
+		StreamHandlerErrorEncoder(encodeError),
+		StreamHandlerBefore(httptransport.PopulateRequestContext),
+	}
+
+	h.router.Methods(http.MethodPost).Path("/client/auth").Handler(httptransport.NewServer(
+		e.PostAuthenticate,
+		decodeAuthRequest,
+		encodeResponse,
+		options...,
+	))
+
+	h.router.Methods(http.MethodGet).Path("/client/env/{environmentUUID}/feature-configs").Handler(httptransport.NewServer(
+		e.GetFeatureConfigs,
+		decodeGetFeatureConfigsRequest,
+		encodeResponse,
+		options...,
+	))
+
+	h.router.Methods(http.MethodGet).Path("/client/env/{environmentUUID}/feature-configs/{identifier}").Handler(httptransport.NewServer(
+		e.GetFeatureConfigsByIdentifier,
+		decodeGetFeatureConfigsByIdentifierRequest,
+		encodeResponse,
+		options...,
+	))
+
+	h.router.Methods(http.MethodGet).Path("/client/env/{environmentUUID}/target-segments").Handler(httptransport.NewServer(
+		e.GetTargetSegments,
+		decodeGetTargetSegmentsRequest,
+		encodeResponse,
+		options...,
+	))
+
+	h.router.Methods(http.MethodGet).Path("/client/env/{environmentUUID}/target-segments/{identifier}").Handler(httptransport.NewServer(
+		e.GetTargetSegmentsByIdentifier,
+		decodeGetTargetSegmentsByIdentifierRequest,
+		encodeResponse,
+		options...,
+	))
+
+	h.router.Methods(http.MethodGet).Path("/client/env/{environmentUUID}/target/{target}/evaluations").Handler(httptransport.NewServer(
+		e.GetEvaluations,
+		decodeGetEvaluationsRequest,
+		encodeResponse,
+		options...,
+	))
+
+	h.router.Methods(http.MethodGet).Path("/client/env/{environmentUUID}/target/{target}/evaluations/{feature}").Handler(httptransport.NewServer(
+		e.GetEvaluationsByFeature,
+		decodeGetEvaluationsByFeatureRequest,
+		encodeResponse,
+		options...,
+	))
+
+	h.router.Methods(http.MethodGet).Path("/stream").Handler(NewStreamHandler(
+		e.GetStream,
+		decodeGetStreamRequest,
+		encodeStreamResponse,
+		streamOptions...,
+	))
+}
+
+func cors(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Access-Control-Allow-Origin", "*")
+		w.Header().Add("Access-Control-Allow-Methods", "GET,OPTIONS")
+		w.Header().Add("Access-Control-Allow-Headers", "Content-Type,Authorization,Accept,Origin,API-Key")
+
+		if r.Method == http.MethodOptions {
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// errorHandler handles logging transport errors
+type errorHandler struct {
+	logger log.Logger
+}
+
+// Handle makes errorHandler implement the httptransport.ErrorHandler interface
+func (e errorHandler) Handle(ctx context.Context, err error) {
+	method := ctx.Value(httptransport.ContextKeyRequestMethod)
+	path := ctx.Value(httptransport.ContextKeyRequestPath)
+	e.logger.Error("method", method, "path", path, "err", err)
+}

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -1,0 +1,144 @@
+package transport
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/harness/ff-proxy/cache"
+	"github.com/harness/ff-proxy/domain"
+	"github.com/harness/ff-proxy/log"
+	proxyservice "github.com/harness/ff-proxy/proxy-service"
+	"github.com/harness/ff-proxy/repository"
+	"github.com/stretchr/testify/assert"
+)
+
+// For now this test just hits each endpoint and checks that it gets the correct
+// status code in the response which is http.StatusNotImplemented for now.
+// It might make sense when this grows to have a test function for each endpoint
+// that contains valid & invalid request scenarios and their expected responses
+// e.g. Something like this for each endpoint
+// TestAuthEndpoint(t testing.T) {
+//    // Test auth request with empty ApiKey in body - expect 401
+//    // Test auth request with an empty body - expect 401
+//    // Test auth request with a valid ApiKey in body - expect 200 and some token
+//}
+func TestServerEndpoints(t *testing.T) {
+
+	// Create in mem cache and repos
+	cache := cache.NewMemCache()
+	featureRepo, err := repository.NewFeatureConfigRepo(cache, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetRepo, err := repository.NewTargetRepo(cache, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logger := log.NewNoOpLogger()
+
+	// Setup service and http servers
+	proxyService := proxyservice.NewProxyService(featureRepo, targetRepo, logger)
+	endpoints := NewEndpoints(proxyService)
+	server := NewHTTPServer("localhost", 7000, endpoints, logger)
+	testServer := httptest.NewServer(server)
+	defer testServer.Close()
+
+	testCases := map[string]struct {
+		method             string
+		url                string
+		payload            interface{}
+		headers            http.Header
+		expectedStatusCode int
+	}{
+		"Given I make a valid request to /auth/client": {
+			method: http.MethodPost,
+			url:    fmt.Sprintf("%s/client/auth", testServer.URL),
+			payload: domain.AuthRequest{
+				APIKey: "123",
+			},
+			expectedStatusCode: http.StatusNotImplemented,
+		},
+		"Given I make a valid request to /client/env/{environmentUUID}/feature-configs": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/1234/feature-configs", testServer.URL),
+			expectedStatusCode: http.StatusNotImplemented,
+		},
+		"Given I make a valid request to /client/env/{environmentUUID}/feature-configs/{identifier}": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/1234/feature-configs/harnessappdemodarkmode", testServer.URL),
+			expectedStatusCode: http.StatusNotImplemented,
+		},
+		"Given I make a valid request to /client/env/{environmentUUID}/target-segments": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/1234/target-segments", testServer.URL),
+			expectedStatusCode: http.StatusNotImplemented,
+		},
+		"Given I make a valid request to /client/env/{environmentUUID}/target-segments/{identifier}": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/1234/target-segments/james}", testServer.URL),
+			expectedStatusCode: http.StatusNotImplemented,
+		},
+		"Given I make a valid request to /client/env/{environmentUUID}/target/{target}/evaluations": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/1234/target/james/evaluations", testServer.URL),
+			expectedStatusCode: http.StatusNotImplemented,
+		},
+		"Given I make a valid request to /client/env/{environmentUUID}/target/{target}/evaluations/{feature}": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/1234/target/james/evaluations/harnessappdemodarkmode", testServer.URL),
+			expectedStatusCode: http.StatusNotImplemented,
+		},
+		"Given I make a valid request to /stream": {
+			method: http.MethodGet,
+			url:    fmt.Sprintf("%s/stream", testServer.URL),
+			headers: http.Header{
+				"API-Key": []string{"123"},
+			},
+			expectedStatusCode: http.StatusNotImplemented,
+		},
+	}
+
+	for desc, tc := range testCases {
+		tc := tc
+		t.Run(desc, func(t *testing.T) {
+			var req *http.Request
+
+			switch tc.method {
+			case http.MethodPost:
+				b, err := json.Marshal(tc.payload)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				req, err = http.NewRequest(http.MethodPost, tc.url, bytes.NewBuffer(b))
+				if err != nil {
+					t.Fatal(err)
+				}
+			case http.MethodGet:
+				req, err = http.NewRequest(http.MethodGet, tc.url, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if tc.headers != nil {
+				req.Header = tc.headers
+			}
+
+			resp, err := testServer.Client().Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.expectedStatusCode, resp.StatusCode)
+
+			// Validate response body once it's implemented
+		})
+	}
+}

--- a/transport/stream_handler.go
+++ b/transport/stream_handler.go
@@ -1,0 +1,91 @@
+package transport
+
+import (
+	"net/http"
+
+	"github.com/go-kit/kit/transport"
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/go-kit/log"
+	"github.com/harness/ff-proxy/domain"
+)
+
+// StreamHandlerOption sets an optional parameter for a StreamHandler
+type StreamHandlerOption func(s *StreamHandler)
+
+// StreamHandlerBefore sets RequestFuncs in the StreamHandler that are executed before
+// the request is decoded
+func StreamHandlerBefore(before ...httptransport.RequestFunc) StreamHandlerOption {
+	return func(s *StreamHandler) {
+		s.before = append(s.before, before...)
+	}
+}
+
+// StreamHandlerErrorEncoder sets the ErrorEncoder used by the StreamHandler
+func StreamHandlerErrorEncoder(ee httptransport.ErrorEncoder) StreamHandlerOption {
+	return func(s *StreamHandler) {
+		s.errorEncoder = ee
+	}
+}
+
+// StreamHandlerErrorHandler sets the ErrorHandler used by the StreamHandler
+func StreamHandlerErrorHandler(ee transport.ErrorHandler) StreamHandlerOption {
+	return func(s *StreamHandler) {
+		s.errorHandler = ee
+	}
+}
+
+// StreamHandler is the handler used for handling streaming requests
+type StreamHandler struct {
+	endpoint     streamEndpoint
+	dec          httptransport.DecodeRequestFunc
+	enc          httptransport.EncodeResponseFunc
+	before       []httptransport.RequestFunc
+	errorEncoder httptransport.ErrorEncoder
+	errorHandler transport.ErrorHandler
+}
+
+// NewStreamHandler creates and returns a StreamHandler
+func NewStreamHandler(e streamEndpoint, dec httptransport.DecodeRequestFunc, enc httptransport.EncodeResponseFunc, opts ...StreamHandlerOption) StreamHandler {
+	s := StreamHandler{
+		endpoint:     e,
+		dec:          dec,
+		enc:          enc,
+		errorEncoder: httptransport.DefaultErrorEncoder,
+		errorHandler: transport.NewLogErrorHandler(log.NewNopLogger()),
+	}
+
+	for _, opt := range opts {
+		opt(&s)
+	}
+	return s
+}
+
+// ServeHTTP makes stream handler implement http.Handler
+func (s StreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	for _, fn := range s.before {
+		ctx = fn(ctx, r)
+	}
+
+	req, err := s.dec(ctx, r)
+	if err != nil {
+		s.errorHandler.Handle(ctx, err)
+		s.errorEncoder(ctx, err, w)
+		return
+	}
+
+	stream := domain.NewStream(w)
+	err = s.endpoint(ctx, req, stream)
+	if err != nil {
+		s.errorHandler.Handle(ctx, err)
+		s.errorEncoder(ctx, err, w)
+		return
+	}
+
+	if err := s.enc(ctx, w, stream); err != nil {
+		s.errorHandler.Handle(ctx, err)
+		s.errorEncoder(ctx, err, w)
+		return
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,0 +1,35 @@
+package transport
+
+import (
+	"context"
+
+	"github.com/harness/ff-proxy/domain"
+	"github.com/harness/ff-proxy/gen"
+)
+
+// ProxyService is the interface for the Proxy
+type ProxyService interface {
+	// Authenticate performs authentication
+	Authenticate(ctx context.Context, req domain.AuthRequest) (domain.AuthResponse, error)
+
+	// FeatureConfig gets all FeatureConfig for an environment
+	FeatureConfig(ctx context.Context, req domain.FeatureConfigRequest) ([]domain.FeatureConfig, error)
+
+	// FeatureConfigByIdentifier gets the feature config for a feature
+	FeatureConfigByIdentifier(ctx context.Context, req domain.FeatureConfigByIdentifierRequest) (domain.FeatureConfig, error)
+
+	// TargetSegments gets all of the TargetSegments in an environment
+	TargetSegments(ctx context.Context, req domain.TargetSegmentsRequest) ([]gen.Segment, error)
+
+	// TargetSegmentsByIdentifier get a TargetSegments from an environment by its identifier
+	TargetSegmentsByIdentifier(ctx context.Context, req domain.TargetSegmentsByIdentifierRequest) (gen.Segment, error)
+
+	// Evaluations gets all of the evaluations in an environment for a target
+	Evaluations(ctx context.Context, req domain.EvaluationsRequest) ([]gen.Evaluation, error)
+
+	// Evaluations gets all of the evaluations in an environment for a target for a particular feature
+	EvaluationsByFeature(ctx context.Context, req domain.EvaluationsByFeatureRequest) (gen.Evaluation, error)
+
+	// Stream streams flag updates out to the client
+	Stream(ctx context.Context, req domain.StreamRequest, stream domain.Stream) error
+}


### PR DESCRIPTION
- Adds transport package
  - Contains the http server that handles requests/responses
  - Created specific handler to handle stream requests
  - Added endpoints
  - Added a basic test for each endpoint that makes a request and checks
    that it gets a http.StatusNotImplemented status code
- Adds proxy-service package
  - Added a skeleton proxy service that just returns NotImplemented
    errors for each endpoint for now
- Adds a basic leveled logger that gets passed in to things that need it
  e.g. Service, HTTPServer
- Creates request types in domain package
- Creates Stream type that can be used for streaming endpoints