### PR TITLE
(MAINT) Bump golang server sdk version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
-	github.com/harness/ff-golang-server-sdk v0.0.23
+	github.com/harness/ff-golang-server-sdk v0.0.24-0.20211207112015-ed0101ca4576
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/harness/ff-golang-server-sdk v0.0.23 h1:yjVIggm/Jmx1Yj8FVjkwuaxa3AedsHhBx3iCtnKr0H8=
 github.com/harness/ff-golang-server-sdk v0.0.23/go.mod h1:YsJKYmEcJuxceJKcRjfXON5z+F9VHOS5dDzTVQLb7bI=
+github.com/harness/ff-golang-server-sdk v0.0.24-0.20211207112015-ed0101ca4576 h1:iMsH80JLzkZB13QsPJzZyqr/GdtXS72EiztM5CD5qB0=
+github.com/harness/ff-golang-server-sdk v0.0.24-0.20211207112015-ed0101ca4576/go.mod h1:XPa7+w1VKXUG5udSF8RYqYdmZ47bWHn2gzk1iZTJBxM=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/api v1.10.1/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=


### PR DESCRIPTION
Bump the go sdk version to consume all the latest sdk updates needed for the proxy
- Logging improvements (quieten down metrics logs)
- Streaming bug fix
- Sending empty metrics bug fix
- Saving data to store when store disabled bug fix (causes a bunch of logs in docker deploys)

We should pin this to a released version once the next release goes out, for now we need the commit sha to consume these. 