### PR TITLE
FFM-1957 only forward auth request in online mode

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -328,7 +328,7 @@ func main() {
 
 	// Setup service and middleware
 	var service proxyservice.ProxyService
-	service = proxyservice.NewService(fcr, tr, sr, tokenSource.GenerateToken, featureEvaluator, clientService, logger)
+	service = proxyservice.NewService(fcr, tr, sr, tokenSource.GenerateToken, featureEvaluator, clientService, logger, offline)
 
 	// Configure endpoints and server
 	endpoints := transport.NewEndpoints(service)

--- a/proxy-service/service_test.go
+++ b/proxy-service/service_test.go
@@ -114,7 +114,7 @@ func setupService(cfg benchmarkConfig, b *testing.B) ProxyService {
 
 	// Client service isn't used by the methods we benchmark so we can get away
 	// with making it nil
-	return NewService(featureRepo, targetRepo, segmentRepo, authFn, NewFeatureEvaluator(), nil, log.NoOpLogger{})
+	return NewService(featureRepo, targetRepo, segmentRepo, authFn, NewFeatureEvaluator(), nil, log.NoOpLogger{}, true)
 }
 
 type benchmark struct {

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -187,10 +187,11 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 		proxyservice.NewFeatureEvaluator(),
 		setupConfig.clientService,
 		logger,
+		false,
 	)
 	endpoints := NewEndpoints(service)
 
-	server := NewHTTPServer("localhost", 7000, endpoints, logger)
+	server := NewHTTPServer(7000, endpoints, logger)
 	server.Use(middleware.NewEchoAuthMiddleware([]byte(`secret`), bypassAuth))
 	return server
 }


### PR DESCRIPTION
Previously we were always forwarding auth requests to feature flags whether we were running in online of offline mode. Now we only forward auth requests if we're running in online mode.

**Testing**

Manually tested by configuring the proxy with `.online.uat.env` and then pointed an SDK at it with a target that didn't exist and the target was created in feature flags. Then I configured the proxy with `.offline.env` and when my SDK made an auth request I no longer saw an error log saying it failed. 