### PR TITLE
(FFM-2015) Target registration fix

### DIFF
--- a/config/remote_config.go
+++ b/config/remote_config.go
@@ -441,9 +441,7 @@ func (r RemoteConfig) addTargetConfig(ctx context.Context, inputs <-chan configP
 
 // filterOnAllowedAPIKeys filters the pipeline by the AllowedKeys. If an input in
 // the pipeline only contains APIKeys that don't exist in the AllowedKeys then
-// it will not be passed further down the pipeline. If an input has two keys and
-// one of them exists in the AllowedKeys then the one that doesn't exist will be
-// removed and the input will be passed down the pipeline with just the one APIKey.
+// it will not be passed further down the pipeline.
 func (r RemoteConfig) filterOnAllowedAPIKeys(ctx context.Context, inputs <-chan configPipeline) <-chan configPipeline {
 	out := make(chan configPipeline)
 
@@ -458,10 +456,11 @@ func (r RemoteConfig) filterOnAllowedAPIKeys(ctx context.Context, inputs <-chan 
 
 			keys := []string{}
 
-			// filter found api keys - only keep ones specified in AllowedKeys
+			// filter found api keys - only keep if any specified in AllowedKeys
 			for _, key := range input.APIKeys {
 				if _, ok := input.AllowedKeys[key]; ok {
-					keys = append(keys, key)
+					keys = input.APIKeys
+					break
 				}
 			}
 

--- a/proxy-service/service.go
+++ b/proxy-service/service.go
@@ -136,7 +136,7 @@ func (s Service) Authenticate(ctx context.Context, req domain.AuthRequest) (doma
 		defer cancel()
 
 		if _, err := s.clientService.Authenticate(newCtx, req.APIKey, req.Target); err != nil {
-			s.logger.Error(ctx, "failed to forward Target registrationg via auth request to client service", "err", err)
+			s.logger.Error(ctx, "failed to forward Target registration via auth request to client service", "err", err)
 		}
 		s.logger.Debug(ctx, "successfully registered target with feature flags", "target_identifier", req.Target.Target.Identifier)
 	}()

--- a/services/admin_service.go
+++ b/services/admin_service.go
@@ -86,7 +86,7 @@ func (r AdminService) PageEnvironments(ctx context.Context, input PageEnvironmen
 
 	// If there are no environments in the response then there are either none
 	// to retrieve or we've paged over them all so we're done
-	if *resp.JSON200.Data.Environments != nil && len(*resp.JSON200.Data.Environments) == 0 {
+	if resp.JSON200.Data.Environments != nil && len(*resp.JSON200.Data.Environments) == 0 {
 		return PageEnvironmentsResult{Finished: true}, nil
 	}
 
@@ -135,7 +135,7 @@ func (r AdminService) PageProjects(ctx context.Context, input PageProjectsInput)
 
 	// If there are no projects in the response then there are either none
 	// to retrieve or we've paged over them all so we're done
-	if *resp.JSON200.Data.Projects != nil && len(*resp.JSON200.Data.Projects) == 0 {
+	if resp.JSON200.Data.Projects != nil && len(*resp.JSON200.Data.Projects) == 0 {
 		return PageProjectsResult{Finished: true}, nil
 	}
 
@@ -189,7 +189,7 @@ func (r AdminService) PageTargets(ctx context.Context, input PageTargetsInput) (
 
 	// If there are no projects in the response then there are either none
 	// to retrieve or we've paged over them all so we're done
-	if *resp.JSON200.Targets != nil && len(*resp.JSON200.Targets) == 0 {
+	if resp.JSON200.Targets != nil && len(*resp.JSON200.Targets) == 0 {
 		return PageTargetsResult{Finished: true}, nil
 	}
 


### PR DESCRIPTION
**Changes**
We didn't store all the keys for configured environments. This meant auth with client keys would fail and targets couldn't be registered upstream