### PR TITLE
(MAINT) Bump golang sdk version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.3.0
-	github.com/harness/ff-golang-server-sdk v0.0.24-0.20211217161246-fc3c2f813bee
+	github.com/harness/ff-golang-server-sdk v0.0.24-0.20211224134156-e284c4cb25b6
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -441,6 +441,8 @@ github.com/harness/ff-golang-server-sdk v0.0.24-0.20211217102743-a69b17ae360c h1
 github.com/harness/ff-golang-server-sdk v0.0.24-0.20211217102743-a69b17ae360c/go.mod h1:XPa7+w1VKXUG5udSF8RYqYdmZ47bWHn2gzk1iZTJBxM=
 github.com/harness/ff-golang-server-sdk v0.0.24-0.20211217161246-fc3c2f813bee h1:ut1mB/OrwI97O/GCLO8b4P+oWCPaXQcmH8lOqVMzMAo=
 github.com/harness/ff-golang-server-sdk v0.0.24-0.20211217161246-fc3c2f813bee/go.mod h1:XPa7+w1VKXUG5udSF8RYqYdmZ47bWHn2gzk1iZTJBxM=
+github.com/harness/ff-golang-server-sdk v0.0.24-0.20211224134156-e284c4cb25b6 h1:0+VYW62vKL+bkL0D7m8A9b2wC79JY9MWVNnxarExaLw=
+github.com/harness/ff-golang-server-sdk v0.0.24-0.20211224134156-e284c4cb25b6/go.mod h1:XPa7+w1VKXUG5udSF8RYqYdmZ47bWHn2gzk1iZTJBxM=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/api v1.10.1/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=


### PR DESCRIPTION
Bump golang sdk proxy to point at this commit - https://github.com/harness/ff-golang-server-sdk/pull/64 so it can soak test over the Christmas break. Still seeing an issue where we can end up with multiple streams connected to the same env after disconnects so this should hopefully fix the final issue here