### PR TITLE
Add basic implementation for hooking into the SDKs SSE Events

### DIFF
--- a/event_listener.go
+++ b/event_listener.go
@@ -1,0 +1,47 @@
+package ffproxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/harness/ff-golang-server-sdk/stream"
+	"github.com/harness/ff-proxy/log"
+	"github.com/wings-software/ff-server/pkg/hash"
+)
+
+// Stream is a placeholder interface that will be implemented by our InMemStream
+// and Redis Stream (FFM-2105, FFM-2102)
+type Stream interface {
+	Pub(ctx context.Context, topic string, event interface{})
+}
+
+// EventListener implements the golang sdks stream.EventStreamListener interface
+// and can be used to hook into the SDK to receive SSE Events that are sent to
+// it by the FeatureFlag server.
+type EventListener struct {
+	log    log.Logger
+	stream Stream
+	hasher hash.Hasher
+}
+
+// NewEventListener creates an EventListener
+func NewEventListener(l log.Logger, s Stream, h hash.Hasher) EventListener {
+	l = l.With("component", "EventListener")
+	return EventListener{
+		log:    l,
+		stream: s,
+		hasher: h,
+	}
+}
+
+// Pub makes EventListener implement the golang sdks stream.EventStreamListener
+// interface.
+func (e EventListener) Pub(ctx context.Context, event stream.Event) error {
+	e.log.Info("got Event from SDK", "event", fmt.Sprintf("%+v", event))
+
+	// TODO:Push event to stream implementation
+	//topic := e.hasher.Hash(event.APIKey)
+	//e.stream.Pub(ctx, topic, event.SSEEvent)
+
+	return nil
+}

--- a/event_listener_test.go
+++ b/event_listener_test.go
@@ -1,0 +1,20 @@
+package ffproxy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/harness/ff-golang-server-sdk/stream"
+	"github.com/harness/ff-proxy/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/wings-software/ff-server/pkg/hash"
+)
+
+func TestEventListener_Pub(t *testing.T) {
+	el := NewEventListener(log.NoOpLogger{}, nil, hash.NewSha256())
+	ctx := context.Background()
+	event := stream.Event{}
+
+	err := el.Pub(ctx, event)
+	assert.Nil(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.3.0
-	github.com/harness/ff-golang-server-sdk v0.0.24-0.20220111144918-95f59344bbf9
+	github.com/harness/ff-golang-server-sdk v0.0.24-0.20220119131602-fb0e102ab915
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goblin v0.0.0-20210519012713-85d372ac71e2/go.mod h1:VzmDKDJVZI3aJmnRI9VjAn9nJ8qPPsN1fqzr9dqInIo=
@@ -445,6 +446,8 @@ github.com/harness/ff-golang-server-sdk v0.0.24-0.20211224134156-e284c4cb25b6 h1
 github.com/harness/ff-golang-server-sdk v0.0.24-0.20211224134156-e284c4cb25b6/go.mod h1:XPa7+w1VKXUG5udSF8RYqYdmZ47bWHn2gzk1iZTJBxM=
 github.com/harness/ff-golang-server-sdk v0.0.24-0.20220111144918-95f59344bbf9 h1:+MDHf0LYRd9CADCVNrAq5TlduESxTvql4MsI3LaUak4=
 github.com/harness/ff-golang-server-sdk v0.0.24-0.20220111144918-95f59344bbf9/go.mod h1:g27JJDAEVUo+6eaGHElRunETSFkIGdI9XSWVM5Y61do=
+github.com/harness/ff-golang-server-sdk v0.0.24-0.20220119131602-fb0e102ab915 h1:9ddPGT/EBny+L1ykWvdZf1d/eS19iBmXhrtQqcIGgEk=
+github.com/harness/ff-golang-server-sdk v0.0.24-0.20220119131602-fb0e102ab915/go.mod h1:LRSKL1xL+RrAesnL5eq/dA/EQJ9G0F1XSxPCaapS2Vk=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/api v1.10.1/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=


### PR DESCRIPTION
- Creates a type that implements the sdks[ stream.EventStreamListener interface](https://github.com/harness/ff-golang-server-sdk/pull/69)
- For now it doesn't do anything but the plan is for this to forward SSE events to topics in some other stream which could be some in memory implementation or a redis stream. 

**Testing**
- Configured the Proxy to point to uat by setting the envs in .online.uat.env
- Toggled a flag on/off
- Saw the log in the EventListener showing the event was forwarded to it
![Screenshot 2022-01-19 at 14 46 27](https://user-images.githubusercontent.com/16992818/150155890-47bb10d5-2a23-4c03-bd8b-5b4396d5c750.png)

