### PR TITLE
FFM-2252 Performance Improvements

### DIFF
--- a/config/remote_config_test.go
+++ b/config/remote_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -437,7 +438,9 @@ func TestPollTargets(t *testing.T) {
 
 			// Only poll once for testing
 			actual := <-remoteConfig.PollTargets(ctx, ticker)
-			assert.Equal(t, tc.expectedTargets, actual)
+			if !reflect.DeepEqual(tc.expectedTargets, actual) {
+				t.Errorf("(%s) expected: %v \n got: %v", desc, tc.expectedTargets, actual)
+			}
 		})
 	}
 }

--- a/proxy-service/service.go
+++ b/proxy-service/service.go
@@ -199,7 +199,7 @@ func (s Service) FeatureConfig(ctx context.Context, req domain.FeatureConfigRequ
 	}
 
 	// fetch segments
-	segments, err := s.segmentRepo.Get(ctx, segmentKey)
+	segments, err := s.segmentRepo.GetAsMap(ctx, segmentKey)
 	if err != nil {
 		if !errors.Is(err, domain.ErrCacheNotFound) {
 			return []domain.FeatureConfig{}, fmt.Errorf("%w: %s", ErrInternal, err)
@@ -212,7 +212,7 @@ func (s Service) FeatureConfig(ctx context.Context, req domain.FeatureConfigRequ
 	for _, flag := range flags {
 		configs = append(configs, domain.FeatureConfig{
 			FeatureFlag: flag,
-			Segments:    segmentArrayToMap(segments),
+			Segments:    segments,
 		})
 	}
 
@@ -236,7 +236,7 @@ func (s Service) FeatureConfigByIdentifier(ctx context.Context, req domain.Featu
 	}
 
 	// fetch segments
-	segments, err := s.segmentRepo.Get(ctx, segmentKey)
+	segments, err := s.segmentRepo.GetAsMap(ctx, segmentKey)
 	if err != nil {
 		if !errors.Is(err, domain.ErrCacheNotFound) {
 			return domain.FeatureConfig{}, fmt.Errorf("%w: %s", ErrInternal, err)
@@ -248,7 +248,7 @@ func (s Service) FeatureConfigByIdentifier(ctx context.Context, req domain.Featu
 	// build FeatureConfig
 	return domain.FeatureConfig{
 		FeatureFlag: flag,
-		Segments:    segmentArrayToMap(segments),
+		Segments:    segments,
 	}, nil
 }
 
@@ -307,7 +307,7 @@ func (s Service) Evaluations(ctx context.Context, req domain.EvaluationsRequest)
 	}
 
 	// fetch segments
-	segments, err := s.segmentRepo.Get(ctx, segmentKey)
+	segments, err := s.segmentRepo.GetAsMap(ctx, segmentKey)
 	if err != nil {
 		if !errors.Is(err, domain.ErrCacheNotFound) {
 			return nil, fmt.Errorf("%w: %s", ErrInternal, err)
@@ -319,7 +319,7 @@ func (s Service) Evaluations(ctx context.Context, req domain.EvaluationsRequest)
 	for _, flag := range flags {
 		configs = append(configs, domain.FeatureConfig{
 			FeatureFlag: flag,
-			Segments:    segmentArrayToMap(segments),
+			Segments:    segments,
 		})
 	}
 
@@ -358,7 +358,7 @@ func (s Service) EvaluationsByFeature(ctx context.Context, req domain.Evaluation
 	}
 
 	// fetch segment
-	segments, err := s.segmentRepo.Get(ctx, segmentKey)
+	segments, err := s.segmentRepo.GetAsMap(ctx, segmentKey)
 	if err != nil {
 		if errors.Is(err, domain.ErrCacheNotFound) {
 			return clientgen.Evaluation{}, fmt.Errorf("%w: %s", ErrNotFound, err)
@@ -378,7 +378,7 @@ func (s Service) EvaluationsByFeature(ctx context.Context, req domain.Evaluation
 	// build FeatureConfig
 	config := domain.FeatureConfig{
 		FeatureFlag: flag,
-		Segments:    segmentArrayToMap(segments),
+		Segments:    segments,
 	}
 
 	evaluations, err := s.evaluator.Evaluate(target, config)
@@ -450,12 +450,4 @@ func boolToHealthString(healthy bool) string {
 		return "unhealthy"
 	}
 	return "healthy"
-}
-
-func segmentArrayToMap(segments []domain.Segment) map[string]domain.Segment {
-	segmentMap := map[string]domain.Segment{}
-	for _, segment := range segments {
-		segmentMap[segment.Identifier] = segment
-	}
-	return segmentMap
 }

--- a/repository/feature_flag_repo.go
+++ b/repository/feature_flag_repo.go
@@ -3,8 +3,9 @@ package repository
 import (
 	"context"
 	"fmt"
-	"github.com/harness/ff-proxy/cache"
 	"time"
+
+	"github.com/harness/ff-proxy/cache"
 
 	"github.com/harness/ff-proxy/domain"
 )
@@ -57,13 +58,17 @@ func (f FeatureFlagRepo) Get(ctx context.Context, key domain.FeatureFlagKey) ([]
 		return []domain.FeatureFlag{}, err
 	}
 
-	featureFlags := []domain.FeatureFlag{}
+	featureFlags := make([]domain.FeatureFlag, len(results))
+
+	idx := 0
 	for _, b := range results {
 		featureFlag := &domain.FeatureFlag{}
 		if err := featureFlag.UnmarshalBinary(b); err != nil {
 			return []domain.FeatureFlag{}, err
 		}
-		featureFlags = append(featureFlags, *featureFlag)
+
+		featureFlags[idx] = *featureFlag
+		idx++
 	}
 	return featureFlags, nil
 }

--- a/repository/segment_repo.go
+++ b/repository/segment_repo.go
@@ -3,8 +3,9 @@ package repository
 import (
 	"context"
 	"fmt"
-	"github.com/harness/ff-proxy/cache"
 	"time"
+
+	"github.com/harness/ff-proxy/cache"
 
 	"github.com/harness/ff-proxy/domain"
 )
@@ -50,20 +51,42 @@ func (t SegmentRepo) Add(ctx context.Context, key domain.SegmentKey, values ...d
 	return nil
 }
 
-// Get gets all of the Segments for a given key
 func (t SegmentRepo) Get(ctx context.Context, key domain.SegmentKey) ([]domain.Segment, error) {
 	results, err := t.cache.GetAll(ctx, string(key))
 	if err != nil {
 		return []domain.Segment{}, err
 	}
 
-	segments := []domain.Segment{}
+	segments := make([]domain.Segment, len(results))
+
+	idx := 0
 	for _, b := range results {
 		segment := &domain.Segment{}
 		if err := segment.UnmarshalBinary(b); err != nil {
 			return []domain.Segment{}, err
 		}
-		segments = append(segments, *segment)
+		segments[idx] = *segment
+		idx++
+	}
+
+	return segments, nil
+}
+
+// GetAsMap gets all of the Segments for a given key and returns them in a map
+func (t SegmentRepo) GetAsMap(ctx context.Context, key domain.SegmentKey) (map[string]domain.Segment, error) {
+	results, err := t.cache.GetAll(ctx, string(key))
+	if err != nil {
+		return map[string]domain.Segment{}, err
+	}
+
+	segments := make(map[string]domain.Segment, len(results))
+
+	for _, b := range results {
+		segment := &domain.Segment{}
+		if err := segment.UnmarshalBinary(b); err != nil {
+			return map[string]domain.Segment{}, err
+		}
+		segments[segment.Identifier] = *segment
 	}
 
 	return segments, nil

--- a/repository/segment_repo_test.go
+++ b/repository/segment_repo_test.go
@@ -183,3 +183,96 @@ func TestSegmentRepo_GetByIdentifer(t *testing.T) {
 		})
 	}
 }
+
+func TestSegmentRepoGet(t *testing.T) {
+	key123 := domain.NewSegmentKey("123")
+
+	emptyConfig := map[domain.SegmentKey][]domain.Segment{}
+	populatedConfig := map[domain.SegmentKey][]domain.Segment{
+		key123: {segmentFoo, segmentBar},
+	}
+
+	testCases := map[string]struct {
+		cache      cache.MemCache
+		repoConfig map[domain.SegmentKey][]domain.Segment
+		shouldErr  bool
+		expected   []domain.Segment
+	}{
+		"Given I call Get with an empty SegmentRepo": {
+			cache:      cache.NewMemCache(),
+			repoConfig: emptyConfig,
+			shouldErr:  true,
+			expected:   []domain.Segment{},
+		},
+		"Given I call Get with a populated SegmentRepo": {
+			cache:      cache.NewMemCache(),
+			repoConfig: populatedConfig,
+			shouldErr:  false,
+			expected:   []domain.Segment{segmentFoo, segmentBar},
+		},
+	}
+	for desc, tc := range testCases {
+		tc := tc
+		t.Run(desc, func(t *testing.T) {
+			repo, err := NewSegmentRepo(tc.cache, tc.repoConfig)
+			if err != nil {
+				t.Fatalf("(%s): error = %v, shouldErr = %v", desc, err, tc.shouldErr)
+			}
+
+			actual, err := repo.Get(context.Background(), key123)
+			if (err != nil) != tc.shouldErr {
+				t.Errorf("(%s): error = %v, shouldErr = %v", desc, err, tc.shouldErr)
+			}
+
+			assert.ElementsMatch(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestSegmentRepoGetAsMap(t *testing.T) {
+	key123 := domain.NewSegmentKey("123")
+
+	emptyConfig := map[domain.SegmentKey][]domain.Segment{}
+	populatedConfig := map[domain.SegmentKey][]domain.Segment{
+		key123: {segmentFoo, segmentBar},
+	}
+
+	testCases := map[string]struct {
+		cache      cache.MemCache
+		repoConfig map[domain.SegmentKey][]domain.Segment
+		shouldErr  bool
+		expected   map[string]domain.Segment
+	}{
+		"Given I call Get with an empty SegmentRepo": {
+			cache:      cache.NewMemCache(),
+			repoConfig: emptyConfig,
+			shouldErr:  true,
+			expected:   map[string]domain.Segment{},
+		},
+		"Given I call Get with a populated SegmentRepo": {
+			cache:      cache.NewMemCache(),
+			repoConfig: populatedConfig,
+			shouldErr:  false,
+			expected: map[string]domain.Segment{
+				segmentFoo.Identifier: segmentFoo,
+				segmentBar.Identifier: segmentBar,
+			},
+		},
+	}
+	for desc, tc := range testCases {
+		tc := tc
+		t.Run(desc, func(t *testing.T) {
+			repo, err := NewSegmentRepo(tc.cache, tc.repoConfig)
+			if err != nil {
+				t.Fatalf("(%s): error = %v, shouldErr = %v", desc, err, tc.shouldErr)
+			}
+
+			actual, err := repo.GetAsMap(context.Background(), key123)
+			if (err != nil) != tc.shouldErr {
+				t.Errorf("(%s): error = %v, shouldErr = %v", desc, err, tc.shouldErr)
+			}
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/repository/target_repo.go
+++ b/repository/target_repo.go
@@ -59,13 +59,16 @@ func (t TargetRepo) Get(ctx context.Context, key domain.TargetKey) ([]domain.Tar
 		return []domain.Target{}, err
 	}
 
-	targets := []domain.Target{}
+	targets := make([]domain.Target, len(results))
+
+	idx := 0
 	for _, b := range results {
 		target := &domain.Target{}
 		if err := target.UnmarshalBinary(b); err != nil {
 			return []domain.Target{}, err
 		}
-		targets = append(targets, *target)
+		targets[idx] = *target
+		idx++
 	}
 
 	return targets, nil
@@ -99,7 +102,7 @@ func (t TargetRepo) DeltaAdd(ctx context.Context, key domain.TargetKey, targets 
 		}
 	}
 
-	existingTargets := map[string]domain.Target{}
+	existingTargets := make(map[string]domain.Target, len(results))
 	for _, b := range results {
 		target := &domain.Target{}
 		if err := target.UnmarshalBinary(b); err != nil {
@@ -108,7 +111,7 @@ func (t TargetRepo) DeltaAdd(ctx context.Context, key domain.TargetKey, targets 
 		existingTargets[target.Identifier] = *target
 	}
 
-	newTargets := map[string]domain.Target{}
+	newTargets := make(map[string]domain.Target, len(results))
 	for _, target := range targets {
 		newTargets[target.Identifier] = target
 	}


### PR DESCRIPTION
After looking at the CPU and memory profiles for the Proxy service this `segmentArrayToMap` function was flagged as something that was using a lot of resources. I also noticed that the performance in the FeatureConfigs and Evaluations endpoints degraded significantly as we increased the number of FeatureFlags or Segments. 

It looks like the main issue was we were calling the segmentArrayToMap for each feature flag that we were returning https://github.com/harness/ff-proxy/blob/main/proxy-service/service.go#L212 so the first change I made was to move this call to outside the loop over the feature flags.

The other change I made was there are a few places where we're fetching the Segments from the repo and have to loop over the returned array to create a map. So I added a function to the segment repo to just return the Segments as a map so we don't have to do this extra loop.   

**Testing**

- Added unit tests in
- Existing E2E tests still pass so there shouldn't be any regressions