### PR TITLE
(FFM-2488) Validate api keys env var

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -259,7 +259,7 @@ func main() {
 			orgIdentifierEnv:     orgIdentifier,
 			adminServiceTokenEnv: adminServiceToken,
 			authSecretEnv:        authSecret,
-			apiKeysEnv:           apiKeysFlag,
+			apiKeysEnv:           apiKeys,
 		}
 	}
 	validateFlags(requiredFlags)
@@ -613,6 +613,10 @@ func validateFlags(flags map[string]interface{}) {
 			}
 		case []string:
 			if len(v.([]string)) == 0 {
+				unset = append(unset, k)
+			}
+		case keys:
+			if len(v.(keys)) == 0 {
 				unset = append(unset, k)
 			}
 		}


### PR DESCRIPTION
**Issue**
We weren't checking the api keys type in our validate flags function. We also were passing the flag name rather than value.

**Fix**
Add the extra type check to validateFlags function