### PR TITLE
FFM-2684 Make target name same as identifier if it's not provided by the client

### DIFF
--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -123,6 +123,12 @@ func decodeAuthRequest(c echo.Context) (interface{}, error) {
 	if req.APIKey == "" {
 		return nil, fmt.Errorf("%w: apiKey cannot be empty", errBadRequest)
 	}
+
+	// Mimic what the client service does and set identifier value as the
+	// name if it hasn't been provided.
+	if req.Target.Name == "" {
+		req.Target.Name = req.Target.Identifier
+	}
 	return req, nil
 }
 


### PR DESCRIPTION
**What**
TLDR: Fixes bug where your target wouldn't be forwarded from the Proxy to Feature Flags if you didn't provide a Name and Identifier.

If you connected a client SDK to the Proxy and only gave your Target an Identifier and not a Name then the target wasn't being forwarded from the Proxy to Feature Flags, getting created on the backend and then appearing in the UI properly. However if you pointed the same SDK config directly at Feature Flags then your target was being created and appeared in the UI.

The reason why it worked with feature flags was the Client service sets the Identifier as the Name value [here](https://github.com/wings-software/ff-server/blob/master/internal/interfaces/rest/v1/client.go#L72) if it's not provided in the payload. However in the Proxy if the Name wasn't provided we were sending the Name value as an empty string to the Client service which then caused the auth request fail preventing the target from being created.

So what I've done is make the Proxy mimic the client service and use the Identifier value as the Name if the name isn't provided.

**Testing**

Previously if you made this curl request to the Proxy you would see this error log 
```
 curl http://localhost:7000/client/auth -d '{"apiKey":"27a1daf8-7969-4d11-a429-83a0b7320862","target":{"identifier":"james"}}' 
 
 // Proxy logs
 proxy_1  | {"level":"error","ts":"2022-03-31T14:14:48Z","caller":"log/log.go:114","msg":"failed to forward Target registration via auth request to client service","component":"ProxyService","method":"Authenticate","err":"got non 200 response, status: 403, body: Invalid Key","reqID":"39f5184e-1912-414b-a179-8876cf6af034"}
```

Now making that curl request my target is created in Feature Flags and I can see it in the UI