### PR TITLE
FFM-3188 Cleanup proxy error logs

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -329,7 +329,7 @@ func main() {
 		logger.Info("retrieved offline config")
 	} else {
 		logger.Info("retrieving config from ff-server...")
-		remoteConfig = config.NewRemoteConfig(
+		remoteConfig, err := config.NewRemoteConfig(
 			ctx,
 			accountIdentifier,
 			orgIdentifier,
@@ -339,10 +339,15 @@ func main() {
 			config.WithLogger(logger),
 			config.WithConcurrency(20),
 		)
+		if err != nil {
+			logger.Error("error(s) encountered fetching config from FeatureFlags, startup will continue but the Proxy may be missing required config", "errors", err)
+		} else {
+			logger.Info("successfully retrieved config from FeatureFlags")
+
+		}
 
 		authConfig = remoteConfig.AuthConfig()
 		targetConfig = remoteConfig.TargetConfig()
-		logger.Info("successfully retrieved config from ff-server")
 
 		envIDToProjectEnvironmentInfo := remoteConfig.ProjectEnvironmentInfo()
 


### PR DESCRIPTION
*What*

Changes the error handling in the way we fetch config from the ff-server
so that any errors encountered are bubbled all the way up to the caller
where they can be logged out/dealt with

*Why*

Currently the proxy will log that it has succesfully retrieved config
from the ff-server even if an error was encountered or it fails to
retreive any config from ff-server. Now it will log out any errors
encountered fetching the remote config and continue starting up.

*Testing*

Tested locally by making the Proxy start up while my local feature flags
server was down and rather than logging out `successfully retrieved
config` it logs out that an error occured trying to retrieve the config.

I also tested it with my feature flags service running but introduced
some deliberate pauses to cause timeouts.