### PR TITLE
(FFM-3526) Fix target polling nil pointer

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -329,7 +329,7 @@ func main() {
 		logger.Info("retrieved offline config")
 	} else {
 		logger.Info("retrieving config from ff-server...")
-		remoteConfig, err := config.NewRemoteConfig(
+		remoteConfig, err = config.NewRemoteConfig(
 			ctx,
 			accountIdentifier,
 			orgIdentifier,


### PR DESCRIPTION
**Issue**
The target polling function [here](https://github.com/harness/ff-proxy/blob/main/config/remote_config.go#L138) was crashing with a nil pointer error because the logger was nil

This happened because when setting remoteConfig we shadowed the variable instead of setting the predefined remoteConfig variable, so when it was used further down for the poller the struct was all nils
