### PR TITLE
(FFM-3867) Unmaintained dgrijalva/jwt-go repo dependency

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fanout/go-gripcontrol"
+	"github.com/conormurray95/go-gripcontrol"
 	"github.com/hashicorp/go-retryablehttp"
 
 	_ "net/http/pprof" //#nosec

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/harness/ff-proxy
 go 1.17
 
 require (
+	github.com/conormurray95/go-gripcontrol v0.0.0-20221004124357-41403afcaecc
 	github.com/deepmap/oapi-codegen v1.6.0
-	github.com/fanout/go-gripcontrol v0.0.0-20181114050548-adc1002dfd32
 	github.com/go-kit/kit v0.12.0
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/golang-jwt/jwt v3.2.2+incompatible
@@ -22,10 +22,9 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/conormurray95/go-pubcontrol v0.0.0-20221004123744-4d052349ceb5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/fanout/go-pubcontrol v0.0.0-20181114050323-6700863ff8fe // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/getkin/kin-openapi v0.53.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,10 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/conormurray95/go-gripcontrol v0.0.0-20221004124357-41403afcaecc h1:arscgrUrXljhOrbN9s6U6IrvknMoEVW1UhfIT3l0rvc=
+github.com/conormurray95/go-gripcontrol v0.0.0-20221004124357-41403afcaecc/go.mod h1:O38TB92vwjG63iYiZNa7Ox1yUkrPDRRiZ6RVNTv3cFU=
+github.com/conormurray95/go-pubcontrol v0.0.0-20221004123744-4d052349ceb5 h1:krYnetTYQwHFjQT0wd5KJncVvOVKC0Ijzvo20e3yiOU=
+github.com/conormurray95/go-pubcontrol v0.0.0-20221004123744-4d052349ceb5/go.mod h1:YufG2XL1U0NMQSvIhlBuDq0n7Mhg9pZ8YWkJxysFFpY=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -91,7 +95,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deepmap/oapi-codegen v1.6.0 h1:w/d1ntwh91XI0b/8ja7+u5SvA4IFfM0UNNLmiDR1gg0=
 github.com/deepmap/oapi-codegen v1.6.0/go.mod h1:ryDa9AgbELGeB+YEXE1dR53yAjHwFvE9iAUlWl9Al3M=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
@@ -107,10 +110,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fanout/go-gripcontrol v0.0.0-20181114050548-adc1002dfd32 h1:EjjyfA60tq/r67iLiRfEPpte+TIRS34MrOBs7Sli4z0=
-github.com/fanout/go-gripcontrol v0.0.0-20181114050548-adc1002dfd32/go.mod h1:P/WDSh6TzXrmWJt5R1Pfbb4bPUGV/vYHM4MgV2VMBaU=
-github.com/fanout/go-pubcontrol v0.0.0-20181114050323-6700863ff8fe h1:PpGB2P6TBa2Ql9WlNprWcCBAe//gwQ6DCXfUPFChwIM=
-github.com/fanout/go-pubcontrol v0.0.0-20181114050323-6700863ff8fe/go.mod h1:7E12GoiO4rKf3D2aN6yi/4i+OdDaaTV0meewu6SBLDQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -15,7 +15,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/fanout/go-gripcontrol"
+	"github.com/conormurray95/go-gripcontrol"
 	"github.com/go-redis/redis/v8"
 	"github.com/harness/ff-golang-server-sdk/stream"
 	ffproxy "github.com/harness/ff-proxy"


### PR DESCRIPTION
**Issue**
Even after removing our direct dependencies to github.com/dgrijalva/jwt-go here it's still listed as an indirect dependency due to the `fanout/go-gripcontrol` and `fanout/go-pubcontrol` dependencies. 
I've forked these repos and raised pr's with the recommended migration path for this archived repo. If they do review and merge these prs we can just rev the dependencies here and have this indirect dependancy removed.

**PRs**
fanout/go-gripcontrol - https://github.com/fanout/go-gripcontrol/pull/3 
fanout/go-pubcontrol - https://github.com/fanout/go-pubcontrol/pull/5 

**Workaround**
These repos haven't had any activity in a long time so we might not get a response to these prs. In this event we can instead point at my forks here or fork these as official Harness repos using this pr as a guide. 
Leaving this pr in a draft for now until we see if we get a response. 