### PR TITLE
(FFM-4719) Prevent nil pointer converting rules

### DIFF
--- a/domain/domainToEvaluation.go
+++ b/domain/domainToEvaluation.go
@@ -74,9 +74,17 @@ func convertGenPrerequisite(p clientgen.Prerequisite) *evaluation.Prerequisite {
 
 //convert converts variation map to evaluation object
 func convertGenVariationMap(v clientgen.VariationMap) *evaluation.VariationMap {
+	var segments []string
+	var targets []clientgen.TargetMap
+	if v.TargetSegments != nil {
+		segments = *v.TargetSegments
+	}
+	if v.Targets != nil {
+		targets = *v.Targets
+	}
 	return &evaluation.VariationMap{
-		TargetSegments: *v.TargetSegments,
-		Targets:        convertTargetToIdentifier(*v.Targets),
+		TargetSegments: segments,
+		Targets:        convertTargetToIdentifier(targets),
 		Variation:      v.Variation,
 	}
 }


### PR DESCRIPTION
**Issue**
If a flag existed with variationMap rules in which a target rule existed but no segment rule existed we would get a nil pointer error dereferencing the TargetSegments object.

**Fix**
Check that the objects are not nil before we try and dereference them
I'm also opening a ticket to deprecate this converter code, we should be able to expose the Evaluator object from the go sdk and use it directly so we can use the one unified rest.FeatureConfig model for everything going forward