### PR TITLE
(FFM-5131) Configurable docker container port

### DIFF
--- a/config/pushpin/pushpin.conf
+++ b/config/pushpin/pushpin.conf
@@ -19,7 +19,7 @@ stats_connection_ttl=120
 services=condure,zurl,pushpin-proxy,pushpin-handler
 
 # plain HTTP port that mongrel2 should listen on
-http_port=7999
+http_port=7000
 
 # list of HTTPS ports that mongrel2 should listen on (you must have certs set)
 https_ports=443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - ${CONFIG_VOLUME:-./config:/config}
     ports:
-      - "7000:7000"
+      - 7000:${PORT:-7000}
 
   redis:
     image: "redis:latest"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,6 @@ if [ -w /etc/pushpin/pushpin.conf ]; then
 		-e 's/push_in_http_addr=.*/push_in_http_addr=0.0.0.0/' \
 		-e 's/push_in_sub_specs=.*/push_in_sub_spec=tcp:\/\/\*:5562/' \
 		-e 's/command_spec=.*/command_spec=tcp:\/\/\*:5563/' \
-		-e 's/^http_port=.*/http_port=7999/' \
 		/etc/pushpin/pushpin.conf
 else
 	echo "docker-entrypoint.sh: unable to write to /etc/pushpin/pushpin.conf, readonly"
@@ -31,16 +30,17 @@ if [ -v target ]; then
 	echo "* ${target},over_http" > /etc/pushpin/routes
 fi
 
-# Update routes file to use $PORT if set
-if [ -w /etc/pushpin/routes ]; then
+# Update pushpin.conf file to use $PORT for http_port
+if [ -w /etc/pushpin/pushpin.conf ]; then
   if [ -n "${PORT}" ]; then
-    echo "Setting internal relay proxy port to ${PORT}"
+    echo "Listening for requests on port ${PORT}"
     sed -i \
-		-e "s/8000/${PORT}/g" \
-		/etc/pushpin/routes
+		-e "s/http_port=7000/http_port=${PORT}/" \
+		/etc/pushpin/pushpin.conf
+		export PORT=
   fi
 else
-	echo "docker-entrypoint.sh: unable to write to /etc/pushpin/routes, readonly"
+	echo "docker-entrypoint.sh: unable to write to /etc/pushpin/pushpin.conf, readonly"
 fi
 
 exec "$@"

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 { ./app/ff-proxy; } &
-{ pushpin --port localhost:7000; } &
+{ pushpin; } &
 wait -n
 pkill -P $$


### PR DESCRIPTION
**Changes**
When setting the `PORT` env var for a docker container this should refer to the port of pushpin as this is the url that downstream sdks actually hit.
For this we update the `http_port` section of pushpin.conf to reflect the chosen port then reset that env var so it doesn't run the relay proxy itself on that port. 

**Testing**
Tested this by running a docker-compose with multiple relay proxies in parallel on different ports and could connect to all successfully. 