### PR TITLE
(FFM-5170) Cleanup exposed ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,18 +54,6 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["pushpin", "--merge-output"]
 
-# Expose ports.
-# - 7999: HTTP port to forward on to the app
-# - 5560: ZMQ PULL for receiving messages
-# - 5561: HTTP port for receiving messages and commands
-# - 5562: ZMQ SUB for receiving messages
-# - 5563: ZMQ REP for receiving commands
-EXPOSE 7999
-EXPOSE 5560
-EXPOSE 5561
-EXPOSE 5562
-EXPOSE 5563
-
 
 ############################
 # STEP 3 add relay proxy build to pushpin image
@@ -86,5 +74,6 @@ RUN chown -R 65534:65534 /app/ff-proxy /log /pushpin /usr/lib/pushpin /etc/pushp
 # Setting this to 65534 which hould be the nodbody user
 USER 65534
 
+# Expose default port pushpin listens on
 EXPOSE 7000
 CMD ["./start.sh"]


### PR DESCRIPTION
**Changes**
These ports are exposed by the pushpin section of the Dockerfile but they're not needed by consumers of the relay proxy so we can clean these up.

**Impact**
`EXPOSE` commands in a Dockerfile are really only there for documentation, they don't have any impact on which container ports are available once it runs. Having these hang around just means people will wonder why they're there and what they're used for so best to only expose our default running port for the proxy itself and have it be a bit cleaner when you run `docker ps`

**Old**
<img width="1509" alt="Screenshot 2022-11-02 at 17 08 01" src="https://user-images.githubusercontent.com/42169772/199555405-dbb77367-5f2a-4011-b6d2-517511660912.png">

**New**
<img width="1308" alt="Screenshot 2022-11-02 at 17 12 12" src="https://user-images.githubusercontent.com/42169772/199556178-ad1e592e-ff57-4661-8a4f-58807ae9cde4.png">

