### PR TITLE
(MAINT) Update gocov-html dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ $(GOBIN)/gocov:
 # Install gocov-html to generate a code coverage html file
 $(GOBIN)/gocov-html:
 	@echo "🔘 Installing gocov-html ... (`date '+%H:%M:%S'`)"
-	@go install github.com/matm/gocov-html@latest
+	@go install github.com/matm/gocov-html/cmd/gocov-html@latest
 
 # Install gosec for security scans
 $(GOBIN)/gosec:


### PR DESCRIPTION
gocov-html released for the first time in 6 years and updated the package name which broke our test coverage reports, updating to use the new package name 