### PR TITLE
(FFM-5279) Prevent proxies deleting each others config

### DIFF
--- a/repository/auth_repo.go
+++ b/repository/auth_repo.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/harness/ff-proxy/cache"
@@ -24,9 +25,9 @@ func NewAuthRepo(c cache.Cache, config map[domain.AuthAPIKey]string) (AuthRepo, 
 		return ar, nil
 	}
 
-	// cleanup old unused keys before we set the new ones
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	ar.cache.RemoveAll(ctx, AuthKey)
+	// cleanup old unused keys for specified envs before we set the new ones
+	ar.clearCachedKeys(ctx, config)
 
 	if err := ar.Add(ctx, apiEnvMapToAuthConfig(config)...); err != nil {
 		cancel()
@@ -35,6 +36,35 @@ func NewAuthRepo(c cache.Cache, config map[domain.AuthAPIKey]string) (AuthRepo, 
 	cancel()
 
 	return ar, nil
+}
+
+// clearCachedKeys clears any old existing keys for the specified environments we want to configure
+// the reason we do this instead of RemoveAll is a user may have one proxy running against env a
+// and another proxy running against env b, both connected to the same redis cache
+// we only want to clear old keys related to the envs this individual proxy is configuring and not
+// wipe anyone else's data
+func (a AuthRepo) clearCachedKeys(ctx context.Context, newConfig map[domain.AuthAPIKey]string) {
+	// get all auth keys
+	currentConfig, ok := a.GetAll(ctx)
+	if !ok {
+		// no keys exist so we can safely return
+		return
+	}
+
+	// what envs are being set in new config
+	envsToAdd := map[string]struct{}{}
+	for _, env := range newConfig {
+		envsToAdd[env] = struct{}{}
+	}
+
+	// remove all existing keys for affected envs
+	for key, env := range currentConfig {
+		// if env exists in envsToAdd map delete the key
+		_, ok := envsToAdd[env]
+		if ok {
+			a.cache.Remove(ctx, AuthKey, string(key))
+		}
+	}
 }
 
 // Add adds environment api key hash pairs to the cache
@@ -61,6 +91,24 @@ func (a AuthRepo) Get(ctx context.Context, key domain.AuthAPIKey) (string, bool)
 	}
 
 	return string(environment), true
+}
+
+// GetAll gets all values from auth repo
+func (a AuthRepo) GetAll(ctx context.Context) (map[domain.AuthAPIKey]string, bool) {
+
+	results, err := a.cache.GetAll(ctx, AuthKey)
+	if err != nil {
+		return map[domain.AuthAPIKey]string{}, false
+	}
+
+	keys := map[domain.AuthAPIKey]string{}
+	for key, b := range results {
+		var env = strings.Trim(string(b), "\"")
+
+		keys[domain.AuthAPIKey(key)] = env
+	}
+
+	return keys, true
 }
 
 func apiEnvMapToAuthConfig(config map[domain.AuthAPIKey]string) []domain.AuthConfig {

--- a/repository/auth_repo_test.go
+++ b/repository/auth_repo_test.go
@@ -61,3 +61,155 @@ func TestAuthRepo_Get(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthRepo_GetAll(t *testing.T) {
+	populated := map[domain.AuthAPIKey]string{
+		domain.AuthAPIKey("apikey-foo"): "env-foo",
+		domain.AuthAPIKey("apikey-bar"): "env-bar",
+	}
+
+	unpopulated := map[domain.AuthAPIKey]string{}
+
+	extraKeys := map[domain.AuthAPIKey]string{
+		domain.AuthAPIKey("apikey-extra"): "env-extra",
+	}
+
+	type expected struct {
+		keys    map[domain.AuthAPIKey]string
+		boolVal bool
+	}
+
+	testCases := map[string]struct {
+		cache    cache.Cache
+		data     map[domain.AuthAPIKey]string
+		fn       func(repo AuthRepo)
+		key      string
+		expected expected
+	}{
+		"Given I have an empty AuthRepo": {
+			cache:    cache.NewMemCache(),
+			data:     unpopulated,
+			expected: expected{keys: map[domain.AuthAPIKey]string{}, boolVal: false},
+		},
+		"Given I have a populated AuthRepo": {
+			cache:    cache.NewMemCache(),
+			data:     populated,
+			expected: expected{keys: populated, boolVal: true},
+		},
+		"Given I add to the  AuthRepo": {
+			cache: cache.NewMemCache(),
+			data:  populated,
+			fn: func(repo AuthRepo) {
+				for key, env := range extraKeys {
+					repo.Add(context.Background(), domain.AuthConfig{
+						APIKey:        key,
+						EnvironmentID: domain.EnvironmentID(env),
+					})
+				}
+
+			},
+			expected: expected{keys: mergeAuthMaps(populated, extraKeys), boolVal: true},
+		},
+	}
+	for desc, tc := range testCases {
+		tc := tc
+		t.Run(desc, func(t *testing.T) {
+
+			repo, err := NewAuthRepo(tc.cache, tc.data)
+			if err != nil {
+				t.Fatalf("(%s): error = %v", desc, err)
+			}
+			if tc.fn != nil {
+				tc.fn(repo)
+			}
+			actual, ok := repo.GetAll(context.Background())
+
+			assert.Equal(t, tc.expected.boolVal, ok)
+			assert.Equal(t, tc.expected.keys, actual)
+		})
+	}
+}
+
+func TestAuthRepo_Setup(t *testing.T) {
+	// we start with two keys for the foo environment
+	fooKeys := map[domain.AuthAPIKey]string{
+		domain.AuthAPIKey("apikey-foo"):  "env-foo",
+		domain.AuthAPIKey("apikey-foo2"): "env-foo",
+	}
+
+	// we test adding new auth data for a different env to make sure we don't clear data from other envs
+	barKeys := map[domain.AuthAPIKey]string{
+		domain.AuthAPIKey("apikey-bar"): "env-bar",
+	}
+
+	// we also test adding fresh data for foo env to make sure we clear old keys
+	newFooKeys := map[domain.AuthAPIKey]string{
+		domain.AuthAPIKey("apikey-foo"): "env-foo",
+	}
+
+	type expected struct {
+		keys map[domain.AuthAPIKey]string
+	}
+
+	testCases := map[string]struct {
+		initialData map[domain.AuthAPIKey]string
+		extraData   map[domain.AuthAPIKey]string
+		cache       cache.Cache
+		data        map[domain.AuthAPIKey]string
+		key         string
+		expected    expected
+	}{
+		"Given I add initial data to empty cache": {
+			cache:       cache.NewMemCache(),
+			initialData: fooKeys,
+
+			expected: expected{keys: fooKeys},
+		},
+		"Given I add extra env keys to populated cache": {
+			cache:       cache.NewMemCache(),
+			initialData: fooKeys,
+			extraData:   barKeys,
+			expected:    expected{keys: mergeAuthMaps(fooKeys, barKeys)},
+		},
+		"Given I alter env keys for populated cache": {
+			cache:       cache.NewMemCache(),
+			initialData: fooKeys,
+			extraData:   newFooKeys,
+			expected:    expected{keys: newFooKeys},
+		},
+	}
+	for desc, tc := range testCases {
+		tc := tc
+		t.Run(desc, func(t *testing.T) {
+
+			// populate initial data
+			_, err := NewAuthRepo(tc.cache, tc.initialData)
+			if err != nil {
+				t.Fatalf("(%s): error = %v", desc, err)
+			}
+
+			// populate extra data
+			repo, err := NewAuthRepo(tc.cache, tc.extraData)
+			if err != nil {
+				t.Fatalf("(%s): error = %v", desc, err)
+			}
+
+			actual, _ := repo.GetAll(context.Background())
+
+			assert.Equal(t, tc.expected.keys, actual)
+		})
+	}
+}
+
+// merge any number of auth maps into one
+// used to produce expected test results easier
+func mergeAuthMaps(maps ...map[domain.AuthAPIKey]string) map[domain.AuthAPIKey]string {
+	newMap := map[domain.AuthAPIKey]string{}
+	for _, m := range maps {
+		for k, v := range m {
+			newMap[k] = v
+		}
+	}
+
+	return newMap
+}


### PR DESCRIPTION
**Issue**
When horizontal scaling multiple proxies connecting to a single redis cache we could run into an issue where the second proxy to start wipes the auth data of the first proxy from the cache, this was because we used a `RemoveAll` call which was fine when we only supported single instances.

**New behaviour**
On startup check which envs a proxy is configuring and only delete keys related to that env. This means:

- We won't delete data for environments other proxy instances are serving
- We'll still clean up old stale keys on startup for environments, deleting nothing would be a security issue