### PR TITLE
(FFM-5530) Disable stream endpoint if flagStreamEnabled false

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,10 +66,10 @@ Adjust the port the relay proxy runs on.
 ### Connection mode between Relay Proxy and Harness SaaS
 Some corporate networks may be highly restrictive on allowing sse connections. If you find that the Relay Proxy starts successfully but fails to receive any updates you may want to use these settings to force the Relay Proxy to poll for changes instead of streaming them.
 
-| Environment Variable | Flag                 | Description                                                                                                                                                                                                                          | Type    | Default |
-|----------------------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|---------|
-| FLAG_STREAM_ENABLED  | flag-stream-enabled  | Should the proxy connect to Harness in streaming mode to get flag changes. Set to false if your network absorbs sse events.  | boolean | true    |
-| FLAG_POLL_INTERVAL   | flag-poll-interval   | How often in minutes the proxy should poll for flag updates (if stream not connected)                                                                                                                                                | int     | 1       |
+| Environment Variable | Flag                 | Description                                                                                                                 | Type    | Default |
+|----------------------|----------------------|-----------------------------------------------------------------------------------------------------------------------------|---------|---------|
+| FLAG_STREAM_ENABLED  | flag-stream-enabled  | Should the proxy connect to Harness in streaming mode to get flag changes. Set to false if your network absorbs sse events. | boolean | true    |
+| FLAG_POLL_INTERVAL   | flag-poll-interval   | How often in seconds the proxy should poll for flag updates (if stream not connected)                                       | int     | 1       |
 
 ### Adjust timings
 Adjust how often certain actions are performed.

--- a/proxy-service/service.go
+++ b/proxy-service/service.go
@@ -14,7 +14,7 @@ import (
 	"github.com/harness/ff-proxy/repository"
 )
 
-//ProxyService is the interface for the ProxyService
+// ProxyService is the interface for the ProxyService
 type ProxyService interface {
 	// Authenticate performs authentication
 	Authenticate(ctx context.Context, req domain.AuthRequest) (domain.AuthResponse, error)
@@ -415,7 +415,7 @@ func (s Service) EvaluationsByFeature(ctx context.Context, req domain.Evaluation
 func (s Service) Stream(ctx context.Context, req domain.StreamRequest) (domain.StreamResponse, error) {
 	s.logger = s.logger.With("method", "Stream")
 	if !s.streamingEnabled {
-		return domain.StreamResponse{}, fmt.Errorf("%w: streaming will only work if the Proxy is running with pushpin", ErrNotImplemented)
+		return domain.StreamResponse{}, fmt.Errorf("%w: streaming endpoint disabled", ErrNotImplemented)
 	}
 
 	hashedAPIKey := s.hasher.Hash(req.APIKey)


### PR DESCRIPTION
**Issue**
When a user sets the `flagStreamEnabled` config param to false we don’t receive stream events from ff-server. This means we don’t receive any to pass downwards to sdks connected to ff-proxy.
 
**Solution**
To keep everything in order we should disable the stream endpoint when a user configures this option to force downstream sdks to poll the proxy for changes

**Other changes**
Change `flagPollInterval` default to 60. This changed from minutes to seconds in a recent golang sdk release so we currently default to 1 second polling