### PR TITLE
[FFM-5916]: Add curl to proxy to support healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ENV PUSHPIN_VERSION 1.33.1-1~bionic1
 # Install Pushpin
 RUN \
   apt-get update && \
-  apt-get install -y pushpin=$PUSHPIN_VERSION
+  apt-get install -y pushpin=$PUSHPIN_VERSION curl
 
 # Cleanup
 RUN \


### PR DESCRIPTION
This includes curl inside the image, which can be useful for testing, but is commonly used in healthchecks on AWS fargate and Docker images.