### PR TITLE
(FFM-5129) HTTPS support

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -673,7 +673,6 @@ func streamHealthCheck() error {
 	var multiErr error
 
 	for i := 0; i < 2; i++ {
-		// TODO does this need to be changed when we enable https on pushpin?
 		resp, err := http.Get(fmt.Sprintf("http://localhost:5561"))
 		if err != nil || resp == nil {
 			multiErr = multierror.Append(fmt.Errorf("gpc request failed streaming will be disabled: %s", err), multiErr)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       - TARGET_POLL_DURATION=${TARGET_POLL_DURATION}
       - GENERATE_OFFLINE_CONFIG=${GENERATE_OFFLINE_CONFIG}
       - PORT=${PORT}
+      - TLS_ENABLED=${TLS_ENABLED}
+      - TLS_CERT=${TLS_CERT}
+      - TLS_KEY=${TLS_KEY}
     build:
       context: ./
       dockerfile: ./Dockerfile

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ Adjust how often certain actions are performed.
 | METRIC_POST_DURATION | metric-post-duration | How often in seconds the proxy posts metrics to Harness. Set to 0 to disable.               | int  | 60      |
 | HEARTBEAT_INTERVAL   | heartbeat-interval   | How often in seconds the proxy polls pings it's health function                             | int  | 60      |
 
-### TLS
+### TLS (beta)
 | Environment Variable | Flag        | Description                                                                 | Type   | Default |
 |----------------------|-------------|-----------------------------------------------------------------------------|--------|---------|
 | TLS_ENABLED          | tls-enabled | If true the proxy will use the tlsCert and tlsKey to run with https enabled | bool   | false   |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,13 @@ Adjust how often certain actions are performed.
 | METRIC_POST_DURATION | metric-post-duration | How often in seconds the proxy posts metrics to Harness. Set to 0 to disable.               | int  | 60      |
 | HEARTBEAT_INTERVAL   | heartbeat-interval   | How often in seconds the proxy polls pings it's health function                             | int  | 60      |
 
+### TLS
+| Environment Variable | Flag        | Description                                                                 | Type   | Default |
+|----------------------|-------------|-----------------------------------------------------------------------------|--------|---------|
+| TLS_ENABLED          | tls-enabled | If true the proxy will use the tlsCert and tlsKey to run with https enabled | bool   | false   |
+| TLS_CERT             | tls-cert    | Path to tls cert file. Required if tls enabled is true.                     | string |         |
+| TLS_KEY              | tls-key     | Path to tls key file. Required if tls enabled is true.                      | string |         |
+
 ### Harness URLs
 You may need to adjust these if you pass all your traffic through a filter or proxy rather than sending the requests directly. 
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,7 +1,7 @@
 # Enabling TLS
 There are two ways to configure the Relay Proxy to accept HTTPS requests.
 
-### Native TLS
+### Native TLS (Beta)
 You can configure the Relay Proxy to start with HTTPS enabled. This can be configured using the TLS config options. See [configuration](./configuration.md) for details. 
 
 This does not provide every fine-grained configuration option available to secure servers. If you require more control the best option is to use a program made for this purpose, and follow the "External TLS" option below.

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,7 +1,12 @@
 # Enabling TLS
+There are two ways to configure the Relay Proxy to accept HTTPS requests.
 
-The Relay Proxy does not currently natively support running with TLS enabled (coming soon).
+### Native TLS
+You can configure the Relay Proxy to start with HTTPS enabled. This can be configured using the TLS config options. See [configuration](./configuration.md) for details. 
 
+This does not provide every fine-grained configuration option available to secure servers. If you require more control the best option is to use a program made for this purpose, and follow the "External TLS" option below.
+
+### External TLS
 The recommended way to connect to the Relay Proxy using TLS is to place a reverse proxy such as nginx in front of the Relay Proxy. Then all connected sdks should make requests to the reverse proxy url instead of hitting the Relay Proxy directly.
 
 ![TLS Setup](images/TLS.png?raw=true)

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -244,7 +244,7 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 	})
 	endpoints := NewEndpoints(service)
 
-	server := NewHTTPServer(8000, endpoints, logger)
+	server := NewHTTPServer(8000, endpoints, logger, false, "", "")
 	server.Use(middleware.NewEchoAuthMiddleware([]byte(`secret`), bypassAuth))
 	return server
 }


### PR DESCRIPTION
**Changes**
Add native https support
This involves:
- Running the proxy in https mode
- Running pushpin in https mode

This feature has been marked beta for now until the ticket for adding automated tests for https mode have been added

**Testing**
Testing running in https as a container
Tested built exe in https mode 