### PR TITLE
(FFM-6136) Add redis tls connection support

### DIFF
--- a/cache/redis_client.go
+++ b/cache/redis_client.go
@@ -110,7 +110,7 @@ func (r *RedisCache) Remove(ctx context.Context, key string, field string) {
 func (r *RedisCache) HealthCheck(ctx context.Context) error {
 	res := r.client.Ping(ctx)
 	if res.Err() != nil {
-		return fmt.Errorf("redis failed to respond")
+		return fmt.Errorf("redis failed to respond err: %s", res.Err())
 	}
 	return nil
 }

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -339,14 +339,32 @@ func main() {
 	// if we're just generating the offline config we should only use in memory mode for now
 	// when we move to a pattern of allowing periodic config dumps to disk we can remove this requirement
 	if redisAddress != "" && !generateOfflineConfig {
-		client := redis.NewClient(&redis.Options{
-			Addr:     redisAddress,
-			Password: redisPassword,
-			DB:       redisDB,
-		})
+		// if address does not start with redis:// or rediss:// then default to redis://
+		// if the connection string starts with rediss:// it means we'll connect with TLS enabled
+		redisConnectionString := redisAddress
+		if !strings.HasPrefix(redisAddress, "redis://") && !strings.HasPrefix(redisAddress, "rediss://") {
+			redisConnectionString = fmt.Sprintf("redis://%s", redisAddress)
+		}
+		parsed, err := redis.ParseURL(redisConnectionString)
+		if err != nil {
+			logger.Error("failed to parse redis address url", "connection string", redisConnectionString, "err", err)
+			os.Exit(1)
+		}
+		// TODO - going forward we can open up support for more of these query param connection string options e.g. max_retries etc
+		// we would first need to test the impact that these would have if unset vs current defaults
+		opts := redis.UniversalOptions{}
+		opts.DB = parsed.DB
+		opts.Addrs = []string{parsed.Addr}
+		opts.Username = parsed.Username
+		opts.Password = parsed.Password
+		opts.TLSConfig = parsed.TLSConfig
+		if redisPassword != "" {
+			opts.Password = redisPassword
+		}
+		client := redis.NewUniversalClient(&opts)
 		logger.Info("connecting to redis", "address", redisAddress)
 		sdkCache = cache.NewRedisCache(client)
-		err := sdkCache.HealthCheck(ctx)
+		err = sdkCache.HealthCheck(ctx)
 		if err != nil {
 			logger.Error("failed to connect to redis", "err", err)
 			os.Exit(1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,9 +35,11 @@ Config required to connect to redis. Note only `REDIS_ADDRESS` is required to co
 
 | Environment Variable | Flag           | Description                                                        | Type   | Default |
 |----------------------|----------------|--------------------------------------------------------------------|--------|---------|
-| REDIS_ADDRESS        | redis-address  | Redis host:port address.                                           | string |         |
+| REDIS_ADDRESS        | redis-address  | Redis host:port address. See below for info on connecting via TLS  | string |         |
 | REDIS_PASSWORD       | redis-db       | (Optional) Database to be selected after connecting to the server. | string |         |
 | REDIS_DB             | redis-password | (Optional) Redis password.                                         | int    | 0       |
+
+**Connecting to Redis via TLS:** To connect to a redis instance which has TLS enabled you should prepend `rediss://` to the beginning of your REDIS_ADDRESS url e.g. `rediss://localhost:6379` 
 
 ### Debug
 Enable debug logging.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -15,9 +15,13 @@ The response will look something like this:
 
 `{"cache":"healthy","env-0000-0000-0000-0000-0000":"healthy", "env-0000-0000-0000-0000-0002":"healthy"}`
 
+If you've configured a custom port using the PORT environment variable your healthcheck should point at that port instead e.g. for port 10000 it would be set to:
+
+`curl https://localhost:10000/health`
+
 If using a Redis cache the cache healthcheck will verify that we could successfully ping the Redis client.
 
-You will have a health entry for each environment you've configured the Relay Proxy with. This will display if your streaming connection for these environments is healthy. You can find which friendly environment identifier this UUID maps to by checking your proxy startup logs. 
+You will have a health entry for each environment you've configured the Relay Proxy with. This will display if your streaming connection for these environments is healthy. You can find which friendly environment identifier this UUID maps to by checking your proxy startup logs.
 
 
 ### Sample CURL Requests

--- a/docs/redis_cache.md
+++ b/docs/redis_cache.md
@@ -5,6 +5,14 @@ You can optionally configure the Relay Proxy to store flag data in redis. See [c
 The Relay Proxy does not currently support clustered Redis or Redis Sentinel.
 
 
+
+## FAQs
+### Can the Relay Proxy be connected to an Elasticache redis instance?
+Yes. Relay Proxy can connect to Elasticache redis instances as long as cluster mode is disabled. 
+
+### Can I connect to Redis instances which have TLS enabled?
+Yes. To connect to a redis instance which has TLS enabled you just need to prepend the REDIS_ADDRESS location with `rediss://` e.g. `rediss://localhost:6379`.
+
 ### What happens if network connection is lost?
 If connection is lost to Harness servers the Relay Proxy will continue to serve the cached values to connected sdks.
 


### PR DESCRIPTION
**Issue**
Relay Proxy didn't support connecting to redis with tls enabled e.g. running an elasticache instance with "Encryption in transit" enabled. 

**Solution**
Support redis connection strings. These allow config to be added as one long connection string rather than adding support for a whole host of redis config options as individual environment variables. 
The connection string format can be found [here](https://github.com/go-redis/redis/blob/1278a8094fc3aed20f12ef6f0aa37f9e06a0bdb3/options.go#L219) 
Right now we only use a few of these options but can widen support for them going forward e.g. allowing query params like`REDIS_ADDRESS=localhost:6379?max_retries=3` to edit the max retry config and similar for other options. This hasn't been done right now because of the testing involved and possible impacts on default config values.

**Changes to users**
For existing users nothing will change, if you pass a REDIS_ADDRESS of localhost:6379 we will change it to be redis://localhost:6379 and make it a valid connection string.
If a user specifically wants to enable TLS they can pass the REDIS_ADDRESS like so `rediss://localhost:6379` which will enable TLS for the connection.

**Other changes**
Surfaced up any errors from the redis healthcheck to help users debug connection issues to redis

**Todo**

- [x] Add documentation in https://github.com/harness/ff-proxy/blob/main/docs/redis_cache.md for configuring tls and custom options
- [x] Test a Relay Proxy connecting to an Elasticache instance with a redis password set, encryption at rest and encryption in transport all enabled
- [x] Fix pr checks - this seems to be related to an ongoing issue with github itself - https://www.githubstatus.com/history and should resolve itself by tomorrow

**Demo**
Connecting to an elasticache redis instance which has encryption at rest and encryption in transport enabled along with a redis db password:

https://user-images.githubusercontent.com/42169772/207649389-d32559ea-7cc5-4918-b217-90fa7fe7345e.mov

