### PR TITLE
(FFM-6184) Fix incorrect url config docs

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -597,7 +597,7 @@ func main() {
 							clusterIdentifier = client.GetClusterIdentifier()
 							break
 						}
-						logger.Info("sending metrics")
+						logger.Debug("sending metrics")
 						metricService.SendMetrics(ctx, clusterIdentifier)
 					}
 				}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,11 +94,11 @@ You may need to adjust these if you pass all your traffic through a filter or pr
 
 | Environment Variable | Flag           | Description                                 | Type   | Default                              |
 |----------------------|----------------|---------------------------------------------|--------|--------------------------------------|
-| ADMIN_SERVICE        | admin-service  | URL of the ff admin service                 | string | https://harness.io/gateway/cf        |
-| CLIENT_SERVICE       | client-service | URL of the ff client service                | string | https://config.ff.harness.io/        |
+| ADMIN_SERVICE        | admin-service  | URL of the ff admin service                 | string | https://app.harness.io/gateway/cf    |
+| CLIENT_SERVICE       | client-service | URL of the ff client service                | string | https://config.ff.harness.io/api/1.0 |
 | METRIC_SERVICE       | metric-service | URL of the ff metric service                | string | https://events.ff.harness.io/api/1.0 |
-| SDK_BASE_URL         | sdk-base-url   | URL for the embedded SDK to connect to      | string | https://config.ff.harness.io/        |
-| SDK_EVENTS_URL       | sdk-events-url | URL for the embedded SDK to send metrics to | string | https://events.ff.harness.io/        |
+| SDK_BASE_URL         | sdk-base-url   | URL for the embedded SDK to connect to      | string | https://config.ff.harness.io/api/1.0 |
+| SDK_EVENTS_URL       | sdk-events-url | URL for the embedded SDK to send metrics to | string | https://events.ff.harness.io/api/1.0 |
 
 ### Auth
 | Environment Variable | Flag        | Description                                                                  | Type    | Default |


### PR DESCRIPTION
**Changes**
The documented defaults for ADMIN_SERVICE, CLIENT_SERVICE, SDK_BASE_URL and SDK_EVENTS_URL were incorrect in the proxy docs, updating these to our real defaults.
Also changing the "sending metrics" log message to be a debug log in the spirit of remaining silent log wise if nothing is going wrong. 

