### PR TITLE
(FFM-6169) Allows heartbeat to be configured off

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,7 +80,7 @@ Adjust how often certain actions are performed.
 |----------------------|----------------------|---------------------------------------------------------------------------------------------|------|---------|
 | TARGET_POLL_DURATION | target-poll-duration | How often in seconds the proxy polls feature flags for Target changes. Set to 0 to disable. | int  | 60      |
 | METRIC_POST_DURATION | metric-post-duration | How often in seconds the proxy posts metrics to Harness. Set to 0 to disable.               | int  | 60      |
-| HEARTBEAT_INTERVAL   | heartbeat-interval   | How often in seconds the proxy polls pings it's health function                             | int  | 60      |
+| HEARTBEAT_INTERVAL   | heartbeat-interval   | How often in seconds the proxy polls pings it's health function. Set to 0 to disable.       | int  | 60      |
 
 ### TLS
 | Environment Variable | Flag        | Description                                                                 | Type   | Default |

--- a/tests/e2e/testhelpers/setup/main.go
+++ b/tests/e2e/testhelpers/setup/main.go
@@ -38,7 +38,8 @@ ADMIN_SERVICE_TOKEN=%s
 API_KEYS=%s
 TLS_ENABLED=true
 TLS_CERT=certs/cert.crt
-TLS_KEY=certs/cert.key`
+TLS_KEY=certs/cert.key
+HEARTBEAT_INTERVAL=0`
 
 var onlineProxyRedisTemplate = `ACCOUNT_IDENTIFIER=%s
 ORG_IDENTIFIER=%s


### PR DESCRIPTION
**Change**
All of our other intervals have a pattern of being allowed to be set to 0 to disable entirely which can be useful. 
A lot of customers deploying to cloud providers will have their own checks hitting the /health endpoint on a regular interval anyway so we should allow this to be configured off to avoid extra api calls and clutter in the logs. 