### PR TITLE
(FFM-6483) Wider linux kernel support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,17 +27,21 @@ FROM ubuntu:20.04 as pushpin
 RUN \
   apt-get update && \
   apt-get install -y apt-transport-https software-properties-common && \
-  echo deb https://fanout.jfrog.io/artifactory/debian fanout-bionic main \
+  echo deb https://fanout.jfrog.io/artifactory/debian fanout-focal main \
     | tee /etc/apt/sources.list.d/fanout.list && \
   apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys \
     EA01C1E777F95324
 
-ENV PUSHPIN_VERSION 1.33.1-1~bionic1
+ENV PUSHPIN_VERSION 1.35.0-1~focal1
 
 # Install Pushpin
 RUN \
   apt-get update && \
-  apt-get install -y pushpin=$PUSHPIN_VERSION curl
+  apt-get install -y pushpin=$PUSHPIN_VERSION curl binutils
+
+# Required for the image to work on Centos7 with 3.10 kernel
+RUN \
+    strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
 
 # Cleanup
 RUN \


### PR DESCRIPTION
**Issue**
When running an ubuntu 20.04 image on a centos7 machine with linux kernel 3.10 we run into this fairly common linux kernel issue of `error while loading shared libraries: libQt5Core.so.5: cannot open shared object file: No such file or directory`. This comes when launching our pushpin dependency. 

This errors on kernel versions 3.10 because that kernel is incompatible with libQt5Core.so.5 which is only compatible with kernels 3.17 and above. These `.note.ABI` tags trigger compatibility checks by the linker when loaded. Stripping this tag out only disables the check by the dynamic linker for the kernel version to be at least as high and has no other effects. See [this discussion](https://github.com/microsoft/WSL/issues/3023) and the many pr's that reference it. This and a multitude of forums/articles/github issues all had this same suggested workaround to remove these tags and prevent the kernel refusing to start over incompatibilities in parts of OS libraries we don't need or use.

**Other changes**
Also bumped our pushpin version and we now pull the focal version instead of the bionic one to be consistent, though both work fine. 

**Note**
The only thing I'm unclear on and investigating is why this is an issue with ubuntu:20.04 but wasn't with ubuntu:18.04 for us, it's more for curiosity because the proposed solution I have here seems to be the standard workaround on every repo I've seen encounter it. It appears the answer is that some of these OS level dependencies changed between these ubuntu OS versions and that's why it's now being pulled into the dynamic linker when running on ubuntu:20.04 when it wasn't on ubuntu:18.04 and triggering this issue. 

**Testing**
Tested that this new image runs successfully on centos7 machines with a linux 3.10 kernel as well as on regular aws linux2 AMI