### PR TITLE
(FFM-6784) Point docs to developer hub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ make image
 ```
 
 ## Run the proxy
-You can run the proxy by executing the binary or running the docker image and configure it by passing various flag values listed in the docs [here](https://docs.harness.io/article/rae6uk12hk-deploy-relay-proxy#configure_the_relay_proxy). They can also be found in [main.go](https://github.com/harness/ff-proxy/blob/main/cmd/ff-proxy/main.go)
+You can run the proxy by executing the binary or running the docker image and configure it by passing various flag values listed in the docs [here](https://developer.harness.io/docs/feature-flags/ff-using-flags/relay-proxy/#configuration-variables). They can also be found in [main.go](https://github.com/harness/ff-proxy/blob/main/cmd/ff-proxy/main.go)
 
 ```
 ./ff-proxy -admin-service-token $SERVICE_TOKEN -auth-secret $AUTH_TOKEN -account-identifier $ACCOUNT_IDENTIFIER -org-identifier $ORG_IDENTIFIER -api-keys $API_KEYS

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 The Relay Proxy is a lightweight Go application that runs within your infrastructure and handles all streaming connections to the Harness platform. It fetches all of your flag, target, and target group data on startup, caches it, fetches any updates over time, and serves it to your connected downstream SDKs.
 
 ## Getting Started
-To learn more about deploying the relay proxy see [Deploy the Relay Proxy](https://docs.harness.io/article/rae6uk12hk-deploy-relay-proxy).
+To learn more about deploying the relay proxy see [Deploy the Relay Proxy](https://developer.harness.io/docs/feature-flags/ff-using-flags/relay-proxy/deploy-relay-proxy/).
 
 ## Why use the Relay Proxy?
-To read more about use cases and advantages of the Relay Proxy see the [Why use the Relay Proxy?](https://docs.harness.io/article/q0kvq8nd2o-relay-proxy#why_use_the_relay_proxy).
+To read more about use cases and advantages of the Relay Proxy see the [Why use the Relay Proxy?](https://developer.harness.io/docs/feature-flags/ff-using-flags/relay-proxy/#why-use-the-relay-proxy).
 
 You can also read more about the use cases, architecture and more in [our blog post](https://harness.io/blog/in-depth-feature-flags-relay-proxy).
 

--- a/file_decoder.go
+++ b/file_decoder.go
@@ -65,6 +65,7 @@ func NewFileDecoder(fileSystem fs.FS, file string) (*FileDecoder, error) {
 
 // Decode decodes the contents of the file into v and closes it
 func (f *FileDecoder) Decode(v interface{}) error {
+	//#nosec G307
 	defer f.file.Close()
 	return f.dec.Decode(v)
 }

--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -104,6 +104,7 @@ func codeFrom(err error) int {
 // that can be passed to the service. It returns a wrapped bad request error if
 // the request body is empty or if the apiKey is empty
 func decodeAuthRequest(c echo.Context) (interface{}, error) {
+	//#nosec G307
 	defer c.Request().Body.Close()
 
 	req := domain.AuthRequest{}
@@ -248,6 +249,7 @@ func decodeGetStreamRequest(c echo.Context) (interface{}, error) {
 
 // decodeMetricsRequest decodes POST /metrics/{environment} requests into domain.Metrics
 func decodeMetricsRequest(c echo.Context) (interface{}, error) {
+	//#nosec G307
 	defer c.Request().Body.Close()
 
 	b, err := io.ReadAll(c.Request().Body)


### PR DESCRIPTION
**Changes**
Change docs links to point to developer hub instead of docs.harness.io
gosec released an update which is causing the linter step to fail, ignoring the new file closer warnings for now and raising a ticket to address this. 