### PR TITLE
(FFM-7189) Allow extra headers

### DIFF
--- a/transport/http_server.go
+++ b/transport/http_server.go
@@ -151,7 +151,7 @@ func cors(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Access-Control-Allow-Origin", "*")
 		w.Header().Add("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
-		w.Header().Add("Access-Control-Allow-Headers", "Content-Type,Authorization,Accept,Origin,API-Key")
+		w.Header().Add("Access-Control-Allow-Headers", "Content-Type,Authorization,Accept,Origin,API-Key,Harness-SDK-Info,Harness-AccountID,Harness-EnvironmentID")
 
 		if r.Method == http.MethodOptions {
 			return


### PR DESCRIPTION
**Issue**
The latest javascript sdk was getting CORS errors when used with the relay proxy because of some new headers it sends that weren't in the `Access-Control-Allow-Headers` response header. 

**Fix**
Add these new headers. The latest javascript sdks now work with the relay proxy without any changes again. 

**Note**
I've added a ticket to allow users to specify additional allowed headers that will be done as a follow up to this to allow for users who send their own custom headers in relay proxy requests. https://harness.atlassian.net/browse/FFM-7239 