### PR TITLE
(FFM-7329) Mask sdk keys in logs

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -83,6 +83,14 @@ func (i *keys) Set(value string) error {
 	return nil
 }
 
+func (i *keys) PrintMasked() string {
+	var maskedKeys []string
+	for _, key := range *i {
+		maskedKeys = append(maskedKeys, token.MaskRight(key))
+	}
+	return strings.Join(maskedKeys, ",")
+}
+
 var (
 	debug                 bool
 	bypassAuth            bool
@@ -249,7 +257,7 @@ func initFF(ctx context.Context, cache gosdkCache.Cache, baseURL, eventURL, envI
 	retryClient.RetryMax = 5
 	retryClient.Logger = l.With("component", "RetryClient", "environment", envID)
 
-	l = l.With("component", "SDK", "apiKey", sdkKey, "environmentID", envID, "environment_identifier", envIdent, "project_identifier", projectIdent)
+	l = l.With("component", "SDK", "apiKey", token.MaskRight(sdkKey), "environmentID", envID, "environment_identifier", envIdent, "project_identifier", projectIdent)
 	structuredLogger, ok := l.(log.StructuredLogger)
 	if !ok {
 		l.Error("unexpected logger", "expected", "log.StructuredLogger", "got", fmt.Sprintf("%T", structuredLogger))
@@ -321,7 +329,7 @@ func main() {
 		cancel()
 	}()
 
-	logger.Info("service config", "pprof", pprofEnabled, "debug", debug, "bypass-auth", bypassAuth, "offline", offline, "port", port, "admin-service", adminService, "account-identifier", accountIdentifier, "org-identifier", orgIdentifier, "sdk-base-url", sdkBaseURL, "sdk-events-url", sdkEventsURL, "redis-addr", redisAddress, "redis-db", redisDB, "api-keys", fmt.Sprintf("%v", apiKeys), "target-poll-duration", fmt.Sprintf("%ds", targetPollDuration), "heartbeat-interval", fmt.Sprintf("%ds", heartbeatInterval), "flag-stream-enabled", flagStreamEnabled, "flag-poll-interval", fmt.Sprintf("%dm", flagPollInterval), "config-dir", configDir, "tls-enabled", tlsEnabled, "tls-cert", tlsCert, "tls-key", tlsKey)
+	logger.Info("service config", "pprof", pprofEnabled, "debug", debug, "bypass-auth", bypassAuth, "offline", offline, "port", port, "admin-service", adminService, "account-identifier", accountIdentifier, "org-identifier", orgIdentifier, "sdk-base-url", sdkBaseURL, "sdk-events-url", sdkEventsURL, "redis-addr", redisAddress, "redis-db", redisDB, "api-keys", apiKeys.PrintMasked(), "target-poll-duration", fmt.Sprintf("%ds", targetPollDuration), "heartbeat-interval", fmt.Sprintf("%ds", heartbeatInterval), "flag-stream-enabled", flagStreamEnabled, "flag-poll-interval", fmt.Sprintf("%dm", flagPollInterval), "config-dir", configDir, "tls-enabled", tlsEnabled, "tls-cert", tlsCert, "tls-key", tlsKey)
 
 	adminService, err := services.NewAdminService(logger, adminService, adminServiceToken)
 	if err != nil {

--- a/token/hide_key.go
+++ b/token/hide_key.go
@@ -1,0 +1,9 @@
+package token
+
+func MaskRight(s string) string {
+	rs := []rune(s)
+	for i := len(rs) - 1; i > 3; i-- {
+		rs[i] = '*'
+	}
+	return string(rs)
+}

--- a/token/hide_key_test.go
+++ b/token/hide_key_test.go
@@ -1,0 +1,38 @@
+package token
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_MaskRight(t *testing.T) {
+	testCases := map[string]struct {
+		input    string
+		expected string
+	}{
+		"Test key gets all characters after first 4 masked": {
+			input:    "abcdef12-1234-5678-abcd-012345678901",
+			expected: "abcd********************************",
+		},
+		"Test exactly 4 characters": {
+			input:    "abcd",
+			expected: "abcd",
+		},
+		"Test less than 4 characters": {
+			input:    "ab",
+			expected: "ab",
+		},
+		"Test empty string": {
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for desc, tc := range testCases {
+		t.Run(desc, func(t *testing.T) {
+			actual := MaskRight(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
**Issue**
Our read only SDK Keys were being logged on startup and as part of the context logging in the embedded go sdk's we launch per key. 

**Fix**
Mask these keys before logging them (first 4 letters cleartext and the remainder as *). This means we can still identify which keys have been used in the proxy for debugging purposes however it doesn't log out then entire key which can be a security concern.