### PR TITLE
(FFM-7417) Restrict envs if all keys auth

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -389,6 +389,7 @@ func main() {
 		targetConfig  map[domain.TargetKey][]domain.Target
 		segmentConfig map[domain.SegmentKey][]domain.Segment
 		authConfig    map[domain.AuthAPIKey]string
+		approvedEnvs  map[string]struct{}
 	)
 
 	var remoteConfig config.RemoteConfig
@@ -454,6 +455,19 @@ func main() {
 		authConfig = remoteConfig.AuthConfig()
 		targetConfig = remoteConfig.TargetConfig()
 		envInfo := remoteConfig.EnvInfo()
+
+		// If all provided api keys auth'd successfully then restrict this proxy instance to only serve requests from those envs.
+		// The reason we're still lenient here is that if a network issue causes an api key not to auth we still want to
+		// fallback to serving cached data where possible. This logic can be extended/improved in future for other use cases
+		// but this will lockdown requests a bit better while still giving us high availability for now. This could be coupled
+		// with a new config option to exit if any keys fail for users who want to restrict fully to whats provided in the startup config
+		if len(envInfo) == len(apiKeys) {
+			approvedEnvs = map[string]struct{}{}
+			for env, _ := range envInfo {
+				approvedEnvs[env] = struct{}{}
+			}
+			logger.Info("serving requests for configured environments", "environments", approvedEnvs)
+		}
 		logger.Info(fmt.Sprintf("successfully fetched config for %d environment(s)", len(envInfo)))
 		// start an sdk instance for each valid api key
 		for _, env := range envInfo {
@@ -481,7 +495,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	authRepo, err := repository.NewAuthRepo(sdkCache, authConfig)
+	authRepo, err := repository.NewAuthRepo(sdkCache, authConfig, approvedEnvs)
 	if err != nil {
 		logger.Error("failed to create auth config repo", "err", err)
 		os.Exit(1)

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -389,7 +389,7 @@ func main() {
 		targetConfig  map[domain.TargetKey][]domain.Target
 		segmentConfig map[domain.SegmentKey][]domain.Segment
 		authConfig    map[domain.AuthAPIKey]string
-		approvedEnvs  map[string]struct{}
+		approvedEnvs  = map[string]struct{}{}
 	)
 
 	var remoteConfig config.RemoteConfig
@@ -462,7 +462,6 @@ func main() {
 		// but this will lockdown requests a bit better while still giving us high availability for now. This could be coupled
 		// with a new config option to exit if any keys fail for users who want to restrict fully to whats provided in the startup config
 		if len(envInfo) == len(apiKeys) {
-			approvedEnvs = map[string]struct{}{}
 			for env, _ := range envInfo {
 				approvedEnvs[env] = struct{}{}
 			}

--- a/token/token_source_test.go
+++ b/token/token_source_test.go
@@ -25,7 +25,7 @@ func TestTokenSource_GenerateToken(t *testing.T) {
 
 	authRepo, _ := repository.NewAuthRepo(cache.NewMemCache(), map[domain.AuthAPIKey]string{
 		domain.AuthAPIKey(hashedKey): envID,
-	})
+	}, nil)
 	tokenSource := NewTokenSource(log.NoOpLogger{}, authRepo, hash.NewSha256(), secret)
 
 	testCases := map[string]struct {

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -189,7 +189,7 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 	}
 
 	if setupConfig.authRepo == nil {
-		ar, err := repository.NewAuthRepo(setupConfig.cache, config.AuthConfig())
+		ar, err := repository.NewAuthRepo(setupConfig.cache, config.AuthConfig(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1290,7 +1290,7 @@ func TestHTTPServer_StreamIntegration(t *testing.T) {
 		domain.AuthAPIKey(apiKey1Hash): envID,
 		domain.AuthAPIKey(apiKey2Hash): envID,
 		domain.AuthAPIKey(apiKey3Hash): envID,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**Issue**
When starting the proxy connected to redis we serve requests for any data in the cache, even if api keys for those environments weren't specified in the config.

**Fix**
If all api keys auth on startup then restrict the authRepo to only authenticate requests pointed at those environments.

**Notes**
If an api key doesn't authenticate for some reason we'll fallback to the old behaviour of attempting to service requests for all environments because we can't be completely sure which environment the api key was for. This allows us to continue to provide high availability, serving requests if the proxy can't connect with SaaS for some reason. 

These restrictions can be extended going forward if required e.g. provide a config option to exit on startup if any provided keys fail to auth.
