### PR TITLE
(FFM-7488) Serve requests for uncached targets

### DIFF
--- a/tests/e2e/evaluation_test.go
+++ b/tests/e2e/evaluation_test.go
@@ -81,13 +81,14 @@ func TestEvaluationsByFeature(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		"Target that doesnt exist returns 404": {
+		"Target that doesnt exist returns results": {
 			args: args{
 				FlagName:   "string-flag1",
 				TargetName: "doesntexist",
 			},
 			want: result{
-				StatusCode: 404,
+				StatusCode: 200,
+				Value:      "red",
 			},
 			wantErr: true,
 		},
@@ -136,13 +137,14 @@ func TestEvaluations(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		"Target that doesnt exist returns 404": {
+		"Target that doesnt exist returns results": {
 			args: args{
 				APIKey:     GetServerAPIKey(),
 				TargetName: "doesntexist",
 			},
 			want: result{
-				StatusCode: 404,
+				StatusCode: 200,
+				Results:    expectedEvaluations,
 			},
 			wantErr: true,
 		},

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -523,6 +523,11 @@ func TestHTTPServer_GetTargetSegmentsByIdentifier(t *testing.T) {
 			url:                fmt.Sprintf("%s/client/env/1234/target-segments/bar", testServer.URL),
 			expectedStatusCode: http.StatusNotFound,
 		},
+		"Given I make GET request for an environment that doesn't exist": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/noexist/target-segments/james", testServer.URL),
+			expectedStatusCode: http.StatusNotFound,
+		},
 		"Given I make GET request for an environment and identifier that exist": {
 			method:               http.MethodGet,
 			url:                  fmt.Sprintf("%s/client/env/1234/target-segments/flagsTeam", testServer.URL),
@@ -601,15 +606,20 @@ func TestHTTPServer_GetEvaluations(t *testing.T) {
 			url:                fmt.Sprintf("%s/client/env/1234/target/james/evaluations", testServer.URL),
 			expectedStatusCode: http.StatusMethodNotAllowed,
 		},
+		// we return an empty array for this right now because we can't tell the difference between
+		// an environment not existing at all and there just being no flags in it
 		"Given I make GET request for an environment that doesn't exist": {
-			method:             http.MethodGet,
-			url:                fmt.Sprintf("%s/client/env/abcd/target/james/evaluations", testServer.URL),
-			expectedStatusCode: http.StatusNotFound,
+			method: http.MethodGet,
+			url:    fmt.Sprintf("%s/client/env/abcd/target/james/evaluations", testServer.URL),
+			expectedResponseBody: []byte(`[]
+`),
+			expectedStatusCode: http.StatusOK,
 		},
 		"Given I make GET request for target that doesn't exist": {
-			method:             http.MethodGet,
-			url:                fmt.Sprintf("%s/client/env/1234/target/bar/evaluations", testServer.URL),
-			expectedStatusCode: http.StatusNotFound,
+			method:               http.MethodGet,
+			url:                  fmt.Sprintf("%s/client/env/1234/target/bar/evaluations", testServer.URL),
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: targetFooEvaluations,
 		},
 		// TODO - commented out due to an issue with the new go sdk evaluator in evaluating certain attribute based rules on flags
 		// these rules are now deprecated and can't be created from the UI but we should upgrade once the go sdk fixes this issue
@@ -698,14 +708,17 @@ func TestHTTPServer_GetEvaluationsByFeature(t *testing.T) {
 			expectedStatusCode: http.StatusMethodNotAllowed,
 		},
 		"Given I make GET request for an environment that doesn't exist": {
-			method:             http.MethodGet,
-			url:                fmt.Sprintf("%s/client/env/abcd/target/james/evaluations/harnessappdemodarkmode", testServer.URL),
+			method: http.MethodGet,
+			url:    fmt.Sprintf("%s/client/env/abcd/target/james/evaluations/harnessappdemodarkmode", testServer.URL),
+			expectedResponseBody: []byte(`{"error":"not found"}
+`),
 			expectedStatusCode: http.StatusNotFound,
 		},
 		"Given I make GET request for target that doesn't exist": {
-			method:             http.MethodGet,
-			url:                fmt.Sprintf("%s/client/env/1234/target/bar/evaluations/harnessappdemodarkmode", testServer.URL),
-			expectedStatusCode: http.StatusNotFound,
+			method:               http.MethodGet,
+			url:                  fmt.Sprintf("%s/client/env/1234/target/bar/evaluations/harnessappdemodarkmode", testServer.URL),
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: darkModeEvaluationTrue,
 		},
 		// TODO - commented out due to an issue with the new go sdk evaluator in evaluating certain attribute based rules on flags
 		// these rules are now deprecated and can't be created from the UI but we should upgrade once the go sdk fixes this issue


### PR DESCRIPTION
**Current behaviour**
If a client request is sent to /client/env/${ENV}/target/${TARGET}/evaluations and the target doesn't exist currently we return a 404 and don't service the request. 
However if we want to configure the proxy as a backup that kicks in if SaaS isn't available this can cause issues for already connected clients attempting to fetch new flag evaluations when changes are made or when the sdk polls for updated values. 

**New behaviour**
If a client request comes in for evaluations for a target that doesn't exist we log a warning and service the requests as best we can by creating a dummy target with the identifier from the request. 

**Note**
Ultimately this can still cause some issues e.g. if a specific target attribute is critical for an evaluation, however this would need to be fixed at the sdk level by always sending the full target going forward which is being looked at for future improvements anyway. If this behaviour is problematic and some people would rather always get a 404 in this case we could make it configurable in future however for 99% of cases this improvement is better than having rejected requests. 