### PR TITLE
FFM-7751 Increase timeouts for populating redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN \
   echo deb https://fanout.jfrog.io/artifactory/debian fanout-focal main \
     | tee /etc/apt/sources.list.d/fanout.list && \
   apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys \
-    EA01C1E777F95324
+    7D0343148157C3DF
 
 ENV PUSHPIN_VERSION 1.35.0-1~focal1
 

--- a/repository/auth_repo.go
+++ b/repository/auth_repo.go
@@ -26,7 +26,7 @@ func NewAuthRepo(c cache.Cache, config map[domain.AuthAPIKey]string, approvedEnv
 		return ar, nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 	// cleanup old unused keys for specified envs before we set the new ones
 	ar.clearCachedKeys(ctx, config)
 


### PR DESCRIPTION
**What**

- Increases the timeouts when we initialise a repo and populate the redis cache with data
- Changes the key used for verifying pushpin install

**Why**

- The initial timeouts we had could be too aggressive when we're trying to load environments into redis that contain a large number of flags, target, segments etc
- The CI builds seemed to have started to fail when building the docker images with the below error. I had a look at the pushpin install docs and found the key mentioned in the logs so gave it a go and they started working again. Seems like they've maybe swapped keys at some point. 

```
INFO[0148] Running: [/bin/sh -c apt-get update &amp;&amp;   apt-get install -y pushpin=$PUSHPIN_VERSION curl binutils] 
Hit:1 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
Get:3 https://fanout.jfrog.io/artifactory/debian fanout-focal InRelease [2145 B]
Hit:4 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Err:3 https://fanout.jfrog.io/artifactory/debian fanout-focal InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7D0343148157C3DF
```