### PR TITLE
(FFM-7824) Fix go 1.18 vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.18 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harness/ff-proxy
 
-go 1.18
+go 1.20
 
 require (
 	github.com/avast/retry-go v3.0.0+incompatible


### PR DESCRIPTION
**Issue**
Go 1.18 has a critical vulnerability

**Fix**
Move to go 1.20 to remediate this

**Testing**
PR STO scan confirms the issue has been remediated
![Screenshot 2023-05-12 at 11 26 44](https://github.com/harness/ff-proxy/assets/42169772/c2c3ac44-9a38-4140-9a3b-3305fb7fadfb)
