### PR TITLE
FFM-7702 Clean up cache metrics registration

### DIFF
--- a/cache/metrics_test.go
+++ b/cache/metrics_test.go
@@ -252,7 +252,7 @@ func TestCacheMetrics_GetAll(t *testing.T) {
 		readCount    *mockCounter
 		expected     result
 	}{
-		"Given I call GetAll and the decorated cache errors": {
+		"Given I call GetAll and the decorated cache errors with a domain.ErrCacheNotFound error": {
 			args: args{
 				key:       "foo",
 				cacheData: map[string]map[string][]byte{},
@@ -264,7 +264,7 @@ func TestCacheMetrics_GetAll(t *testing.T) {
 
 			expected: result{
 				observations: 1,
-				labels:       []string{"foo", "GetAll", "true"},
+				labels:       []string{"foo", "GetAll", "false"},
 			},
 		},
 		"Given I call GetAll and the decorated cache doesn't error": {


### PR DESCRIPTION
**What**

- Cleans up the prometheus registration for the cache
- Puts a check in so we don't register CacheNotFound errors as errors in prometheus metrics. I think the error label in the prometheus should be reserved for internal/unexpected errors, we already track the status code in the http handlers so can see when requests have been made for a resource that doesn't exist

**Why**

I was a bit sloppy when initailly registering some of the metrics for the cache and spotted they weren't coming throuhg during my load testing.

**Testing**

Tested these changes out locally