### PR TITLE
FFM-8024 Kill SDK streams if proxy disconnects from SaaS stream

### DIFF
--- a/domain/sdk_client_map.go
+++ b/domain/sdk_client_map.go
@@ -1,0 +1,48 @@
+package domain
+
+import (
+	"sync"
+
+	harness "github.com/harness/ff-golang-server-sdk/client"
+)
+
+// SDKClientMap is a map of environmentIDs to sdks
+type SDKClientMap struct {
+	*sync.RWMutex
+	m map[string]*harness.CfClient
+}
+
+// NewSDKClientMap creates an SDKClientMap
+func NewSDKClientMap() *SDKClientMap {
+	return &SDKClientMap{
+		RWMutex: &sync.RWMutex{},
+		m:       map[string]*harness.CfClient{},
+	}
+}
+
+// Set sets a key and value in the map
+func (s *SDKClientMap) Set(key string, value *harness.CfClient) {
+	s.Lock()
+	defer s.Unlock()
+	s.m[key] = value
+}
+
+// Copy returns a copy of the map
+func (s *SDKClientMap) Copy() map[string]*harness.CfClient {
+	s.RLock()
+	defer s.RUnlock()
+	return s.m
+}
+
+// StreamConnected checks if the sdk for the given key has a healthy stream connection.
+// If an SDK doesn't exist for the key it will return false
+func (s *SDKClientMap) StreamConnected(key string) bool {
+	s.Lock()
+	defer s.Unlock()
+
+	sdk, ok := s.m[key]
+	if !ok {
+		return false
+	}
+	return sdk.IsStreamConnected()
+}

--- a/domain/sdk_client_map_test.go
+++ b/domain/sdk_client_map_test.go
@@ -1,0 +1,55 @@
+package domain
+
+import (
+	"testing"
+
+	harness "github.com/harness/ff-golang-server-sdk/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSDKClientMap(t *testing.T) {
+	actual := NewSDKClientMap()
+	assert.NotNil(t, actual)
+	assert.NotNil(t, actual.RWMutex)
+	assert.NotNil(t, actual.m)
+}
+
+func TestSDKClientMap_Set(t *testing.T) {
+	cm := NewSDKClientMap()
+
+	cfClient := &harness.CfClient{}
+
+	cm.Set("foo", cfClient)
+
+	actual, ok := cm.m["foo"]
+	assert.True(t, ok)
+
+	assert.Equal(t, *cfClient, *actual)
+}
+
+func TestSDKClientMap_Copy(t *testing.T) {
+	cm := NewSDKClientMap()
+
+	cfClient := &harness.CfClient{}
+	cm.Set("foo", cfClient)
+
+	expected := map[string]*harness.CfClient{
+		"foo": cfClient,
+	}
+
+	actual := cm.Copy()
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestSDKClientMap_StreamConnected(t *testing.T) {
+	cm := NewSDKClientMap()
+
+	cfClient := &harness.CfClient{}
+	cm.Set("foo", cfClient)
+
+	const expected = false
+	actual := cm.StreamConnected("foo")
+
+	assert.Equal(t, expected, actual)
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/google/uuid v1.3.0
-	github.com/harness/ff-golang-server-sdk v0.1.5
+	github.com/harness/ff-golang-server-sdk v0.1.9-0.20230602135407-fcab18845da4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,12 @@ github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57Q
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/harness/ff-golang-server-sdk v0.1.5 h1:oBExNBrZoZgkBeRPNdrx2Ig21ZgYlwI5ygXTARrWWLg=
 github.com/harness/ff-golang-server-sdk v0.1.5/go.mod h1:wVdWTn+0nPjHf25cvyJ03UnSFKTId2JGUdVIliD/VnU=
+github.com/harness/ff-golang-server-sdk v0.1.9-0.20230526121559-0ad8f0c8e96e h1:9hEIlGCXg9Ln/+H9ymiQzdxI7aM/b3EsICCsStwE6zA=
+github.com/harness/ff-golang-server-sdk v0.1.9-0.20230526121559-0ad8f0c8e96e/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
+github.com/harness/ff-golang-server-sdk v0.1.9-0.20230531120043-bc397ace1417 h1:adFmbb37WZ9tLpaJv69XKqEUhvbqCFdc43pjLQoMPSM=
+github.com/harness/ff-golang-server-sdk v0.1.9-0.20230531120043-bc397ace1417/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
+github.com/harness/ff-golang-server-sdk v0.1.9-0.20230602135407-fcab18845da4 h1:XUsvuVhqri52ZkTZJU2QRybYN14yFdVyomFq0E2W98c=
+github.com/harness/ff-golang-server-sdk v0.1.9-0.20230602135407-fcab18845da4/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/transport/http_server.go
+++ b/transport/http_server.go
@@ -93,7 +93,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints, reg prometheusRegister) {
 	h.router.GET("/health", NewUnaryHandler(
 		e.Health,
 		decodeHealthRequest,
-		encodeHealthResponse,
+		encodeResponse,
 		encodeEchoError,
 	))
 


### PR DESCRIPTION
**What**

- Updates the version of the go sdk we're using to one that has changes we need to implement this
- When the Proxy  receives a /stream request it checks if the internal SDK is connected to a SaaS stream
- Updates the stream worker so that if we receive a StreamDisconnect error from the SDK we close the stream between Proxy and SDK
- Moved the SDKClient from main to its own package and gave it public methods so we could inject it into the ProxyService
- We no longer mark the proxy as unhealthy if an internal sdk stream disconnects from SaaS

**Why**

There was an edge case where the Proxy could disconnect from SaaS stream and pull in updates via polling while it waited to reestablish the stream connection. Any changes pulled in via polling would be missed by SDKs listening for events on the Proxy stream because there are no SSE events associated with a poll.

This change now means that if the Proxy -> SaaS stream goes down the SDK -> Proxy stream is killed and we force the SDK to poll for changes and only let it stream for changes when the Proxy -> SaaS stream is back up

**Testing**

Was able to test this out with a local feature flags, Proxy & SDK. When I killed my Feature Flags -> Proxy stream my local sdk went into polling mode. When my Featrue Flags -> Proxy stream was healthy then my SDK began streaming