### PR TITLE
Use jsoniter over encoding/json

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,10 +1,10 @@
 package domain
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/harness/ff-golang-server-sdk/rest"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/golang-jwt/jwt/v4"
 	admingen "github.com/harness/ff-proxy/gen/admin"
@@ -31,12 +31,12 @@ type FeatureConfig struct {
 // marshaling but if we want to optimise storage space we could use something
 // more efficient
 func (f *FeatureFlag) MarshalBinary() ([]byte, error) {
-	return json.Marshal(f)
+	return jsoniter.Marshal(f)
 }
 
 // UnmarshalBinary unmarshals bytes to a FeatureFlag
 func (f *FeatureFlag) UnmarshalBinary(b []byte) error {
-	return json.Unmarshal(b, f)
+	return jsoniter.Unmarshal(b, f)
 }
 
 // TargetKey is the key that maps to a Target
@@ -55,12 +55,12 @@ type Target struct {
 // MarshalBinary marshals a Target to bytes. Currently it uses json marshaling
 // but if we want to optimise storage space we could use something more efficient
 func (t *Target) MarshalBinary() ([]byte, error) {
-	return json.Marshal(t)
+	return jsoniter.Marshal(t)
 }
 
 // UnmarshalBinary unmarshals bytes to a Target
 func (t *Target) UnmarshalBinary(b []byte) error {
-	return json.Unmarshal(b, t)
+	return jsoniter.Unmarshal(b, t)
 }
 
 // SegmentKey is the key that maps to a Segment
@@ -77,12 +77,12 @@ type Segment rest.Segment
 // MarshalBinary marshals a Segment to bytes. Currently it uses json marshaling
 // but if we want to optimise storage space we could use something more efficient
 func (s *Segment) MarshalBinary() ([]byte, error) {
-	return json.Marshal(s)
+	return jsoniter.Marshal(s)
 }
 
 // UnmarshalBinary unmarshals bytes to a Segment
 func (s *Segment) UnmarshalBinary(b []byte) error {
-	return json.Unmarshal(b, s)
+	return jsoniter.Unmarshal(b, s)
 }
 
 // AuthAPIKey is the APIKey type used for authentication lookups
@@ -128,10 +128,10 @@ type AuthConfig struct {
 // MarshalBinary marshals an EnvironmentID to bytes. Currently it uses json marshaling
 // but if we want to optimise storage space we could use something more efficient
 func (a *EnvironmentID) MarshalBinary() ([]byte, error) {
-	return json.Marshal(a)
+	return jsoniter.Marshal(a)
 }
 
 // UnmarshalBinary unmarshals bytes to an EnvironmentID
 func (a *EnvironmentID) UnmarshalBinary(b []byte) error {
-	return json.Unmarshal(b, a)
+	return jsoniter.Unmarshal(b, a)
 }

--- a/proxy-service/service.go
+++ b/proxy-service/service.go
@@ -2,13 +2,13 @@ package proxyservice
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
 	admingen "github.com/harness/ff-proxy/gen/admin"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/harness/ff-golang-server-sdk/evaluation"
 	"github.com/harness/ff-golang-server-sdk/logger"
@@ -412,7 +412,7 @@ func boolToHealthString(healthy bool) string {
 func toString(variation rest.Variation, kind string) string {
 	value := fmt.Sprintf("%v", variation.Value)
 	if kind == "json" {
-		data, err := json.Marshal(variation.Value)
+		data, err := jsoniter.Marshal(variation.Value)
 		if err != nil {
 			value = "{}"
 		} else {

--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -2,7 +2,6 @@ package transport
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/harness/ff-proxy/domain"
 	proxyservice "github.com/harness/ff-proxy/proxy-service"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/labstack/echo/v4"
 )
 
@@ -23,14 +23,14 @@ var (
 // for endpoints that require one.
 func encodeResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	return json.NewEncoder(w).Encode(response)
+	return jsoniter.NewEncoder(w).Encode(response)
 }
 
 // encodeHealthResponse encodes a healthcheck response with status code
 func encodeHealthResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(getHealthStatusCode(response))
-	return json.NewEncoder(w).Encode(response)
+	return jsoniter.NewEncoder(w).Encode(response)
 }
 
 func encodeStreamResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
@@ -67,7 +67,7 @@ func encodeError(ctx context.Context, err error, w http.ResponseWriter) {
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(codeFrom(err))
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	jsoniter.NewEncoder(w).Encode(map[string]interface{}{
 		"error": err.Error(),
 	})
 }
@@ -117,7 +117,7 @@ func decodeAuthRequest(c echo.Context) (interface{}, error) {
 		return nil, fmt.Errorf("%w: request body cannot be empty", errBadRequest)
 	}
 
-	if err := json.Unmarshal(b, &req); err != nil {
+	if err := jsoniter.Unmarshal(b, &req); err != nil {
 		return nil, err
 	}
 
@@ -258,7 +258,7 @@ func decodeMetricsRequest(c echo.Context) (interface{}, error) {
 	}
 
 	req := domain.MetricsRequest{}
-	if err := json.Unmarshal(b, &req); err != nil {
+	if err := jsoniter.Unmarshal(b, &req); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**What**

- Replaces `encoding/json` with `jsoniter`

**Why**

- From benchmarking we've done jsoniter is up to 2x faster and uses less CPU