### PR TITLE
FFM-8625 Add key value & Memoize cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,1 @@
+package cache

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,1 +1,0 @@
-package cache

--- a/cache/key_value_cache.go
+++ b/cache/key_value_cache.go
@@ -1,0 +1,170 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-redis/cache/v8"
+	"github.com/go-redis/redis/v8"
+)
+
+var (
+	// ErrNotFound is the error returned when a record isn't found
+	ErrNotFound = errors.New("NotFound")
+)
+
+// Options defines optional parameters for configuring a KeyValCache
+type Options func(k *KeyValCache)
+
+// WithMarshalFunc lets you set how data is marshaled into the cache
+func WithMarshalFunc(marshalFunc cache.MarshalFunc) Options {
+	return func(k *KeyValCache) {
+		k.marshalFn = marshalFunc
+	}
+}
+
+// WithUnmarshalFunc lets you set how data is unmarshaled from the cache
+func WithUnmarshalFunc(unmarshalFunc cache.UnmarshalFunc) Options {
+	return func(k *KeyValCache) {
+		k.unmarshalFn = unmarshalFunc
+	}
+}
+
+// WithTTL sets the TTL for keys in the cache
+func WithTTL(ttl time.Duration) Options {
+	return func(k *KeyValCache) {
+		k.ttl = ttl
+	}
+}
+
+// WithLocalCache lets you configure the LocalCache e.g.
+// NewKeyValCache("localhost:6379", WithLocalCache(cache.NewTinyLFU(5000, 1 * time.Hour))
+func WithLocalCache(lc cache.LocalCache) Options {
+	return func(k *KeyValCache) {
+		k.localCache = lc
+	}
+}
+
+// KeyValCache is a cache that stores KeyValue pairs
+type KeyValCache struct {
+	cache       *cache.Cache
+	marshalFn   cache.MarshalFunc
+	unmarshalFn cache.UnmarshalFunc
+	ttl         time.Duration
+	localCache  cache.LocalCache
+	redisClient redis.UniversalClient
+}
+
+// NewKeyValCache instantiates and returns a KeyValCache
+func NewKeyValCache(rc redis.UniversalClient, opts ...Options) *KeyValCache {
+	k := &KeyValCache{
+		// Set sane defaults, these can be overridden using the Option funcs
+		ttl:        1 * time.Hour,
+		localCache: nil,
+	}
+	for _, opt := range opts {
+		opt(k)
+	}
+
+	k.cache = cache.New(&cache.Options{
+		Redis:      rc,
+		LocalCache: k.localCache,
+		Marshal:    k.marshalFn,
+		Unmarshal:  k.unmarshalFn,
+	})
+	k.redisClient = rc
+
+	return k
+}
+
+// Set sets a key in the cache
+func (k *KeyValCache) Set(ctx context.Context, key string, value interface{}) error {
+	err := k.cache.Set(&cache.Item{
+		Ctx:            ctx,
+		Key:            key,
+		Value:          value,
+		TTL:            k.ttl,
+		Do:             nil,
+		SkipLocalCache: true,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: KeyValCache.Set failed for key: %q", err, key)
+	}
+	return nil
+}
+
+// Get gets a value from the cache specified by the key
+func (k *KeyValCache) Get(ctx context.Context, key string, value interface{}) error {
+	err := k.cache.Get(ctx, key, value)
+	if err != nil {
+		if err == cache.ErrCacheMiss {
+			return fmt.Errorf("%w: KeyValCache.Get key %s doesn't exist in cache: %s", ErrNotFound, key, err)
+		}
+		return fmt.Errorf("%w: KeyValCache.Get failed for key: %q", err, key)
+	}
+	return nil
+}
+
+// GetOnce gets the value from the cache, if the item does not exist in the cache it executes the doFn, caches the result
+// and returns the value. Only one doFn execution is in-flight for a given key at a time so if a duplicate comes in the
+// caller waits for the original request to complete and gets the result from the cache
+func (k *KeyValCache) GetOnce(ctx context.Context, key string, value interface{}, doFn CacheDoFn) error {
+	err := k.cache.Once(&cache.Item{
+		Ctx:            ctx,
+		Key:            key,
+		Value:          value,
+		Do:             doFn,
+		SkipLocalCache: true,
+	})
+	if err != nil {
+		if err == cache.ErrCacheMiss {
+			return fmt.Errorf("%w: key %s doesn't exist in cache: %s", ErrNotFound, key, err)
+		}
+		return fmt.Errorf("%w: KeyValCache.GetOnce failed for key %q", err, key)
+	}
+	return nil
+}
+
+// Delete can be used to forcefully remove a key from the cache before it's TTL has expired
+func (k *KeyValCache) Delete(ctx context.Context, key string) error {
+	if err := k.cache.Delete(ctx, key); err != nil {
+		return fmt.Errorf("%w: KeyValCache.Delete failed for key: %s", err, key)
+	}
+	return nil
+}
+
+// Keys returns a list of keys that match the pattern
+func (k *KeyValCache) Keys(ctx context.Context, key string) ([]string, error) {
+	cmd := k.redisClient.Keys(ctx, key)
+	if cmd.Err() != nil {
+		return nil, fmt.Errorf("%w: KeyValCache.Keys failed for key pattern %q", cmd.Err(), key)
+	}
+	return cmd.Result()
+}
+
+// GetLatest returns the latest of keys that match the pattern
+// TODO Investigate using ZSET and ZRevRangeByScore for this
+func (k *KeyValCache) GetLatest(ctx context.Context, key string) (string, error) {
+	keys, err := k.redisClient.Keys(ctx, fmt.Sprintf("%s:*", key)).Result()
+	if err != nil {
+		return "", fmt.Errorf("%w: KeyValCache.GetLatest failed for key pattern %q", err, key)
+	}
+
+	if len(keys) == 0 {
+		return "", fmt.Errorf("KeyValCache.GetLatest no keys found for key pattern: %q", key)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		iVersion, _ := strconv.Atoi(strings.Split(keys[i], ":")[1])
+		jVersion, _ := strconv.Atoi(strings.Split(keys[j], ":")[1])
+		return iVersion > jVersion
+	})
+
+	latestVersionKey := keys[0]
+	return k.redisClient.Get(ctx, latestVersionKey).Result()
+}

--- a/cache/key_value_cache_test.go
+++ b/cache/key_value_cache_test.go
@@ -1,0 +1,243 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/cache/v8"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyValCache_Set(t *testing.T) {
+	ctx := context.Background()
+	k := setupTestKeyValCache()
+
+	testCases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{
+			name:  "Set a valid key-value pair",
+			key:   "testKey",
+			value: "testValue",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := k.Set(ctx, tc.key, tc.value)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestKeyValCache_Get(t *testing.T) {
+	ctx := context.Background()
+	k := setupTestKeyValCache()
+
+	key := "testKey"
+	value := "testValue"
+
+	_ = k.Set(ctx, key, value)
+
+	testCases := []struct {
+		name      string
+		key       string
+		wantValue string
+		wantErr   error
+	}{
+		{
+			name:      "Get an existing key",
+			key:       key,
+			wantValue: value,
+			wantErr:   nil,
+		},
+		{
+			name:      "Get a non-existing key",
+			key:       "nonexistentKey",
+			wantValue: "",
+			wantErr:   ErrNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result string
+			err := k.Get(ctx, tc.key, &result)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr))
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantValue, result)
+			}
+		})
+	}
+}
+
+func TestKeyValCache_Delete(t *testing.T) {
+	ctx := context.Background()
+	k := setupTestKeyValCache()
+
+	key := "testKey"
+	value := "testValue"
+
+	_ = k.Set(ctx, key, value)
+
+	testCases := []struct {
+		name    string
+		key     string
+		wantErr error
+	}{
+		{
+			name:    "Delete an existing key",
+			key:     key,
+			wantErr: nil,
+		},
+		{
+			name:    "Delete a non-existing key",
+			key:     "nonexistentKey",
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := k.Delete(ctx, tc.key)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestKeyValCache_Keys(t *testing.T) {
+	ctx := context.Background()
+	k := setupTestKeyValCache()
+
+	keys := []string{"key1", "key2", "key3"}
+
+	for _, key := range keys {
+		_ = k.Set(ctx, key, "value")
+	}
+
+	testCases := []struct {
+		name     string
+		pattern  string
+		wantKeys []string
+		wantErr  error
+	}{
+		{
+			name:     "Get all keys",
+			pattern:  "*",
+			wantKeys: keys,
+			wantErr:  nil,
+		},
+		{
+			name:     "Get keys with a specific pattern",
+			pattern:  "key[12]",
+			wantKeys: []string{"key1", "key2"},
+			wantErr:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := k.Keys(ctx, tc.pattern)
+
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, tc.wantErr))
+			} else {
+				require.NoError(t, err)
+				assert.ElementsMatch(t, tc.wantKeys, result)
+			}
+		})
+	}
+}
+
+func TestKeyValCache_GetLatest(t *testing.T) {
+	ctx := context.Background()
+	k := setupTestKeyValCache()
+
+	versions := []string{"1", "2", "3", "4", "5"}
+
+	testCases := []struct {
+		name      string
+		key       string
+		wantValue string
+		wantErr   error
+		hasKeys   bool
+	}{
+		{
+			name:      "Get latest version",
+			key:       "mykey",
+			wantValue: "value:5",
+			wantErr:   nil,
+			hasKeys:   true,
+		},
+		{
+			name:      "Errors on no keys",
+			key:       "nopattern",
+			wantValue: "",
+			wantErr:   errors.New("KeyValCache.GetLatest no keys found for key pattern: \"nopattern\""),
+			hasKeys:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.hasKeys {
+				for _, version := range versions {
+					_ = k.Set(ctx, fmt.Sprintf("mykey:%s", version), fmt.Sprintf("value:%s", version))
+				}
+			}
+			result, err := k.GetLatest(ctx, tc.key)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, tc.wantErr.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.wantValue, result)
+			}
+		})
+	}
+}
+
+func setupTestKeyValCache() *KeyValCache {
+	mr, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	redisClient := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+
+	k := &KeyValCache{
+		ttl:        1 * time.Hour,
+		localCache: nil,
+	}
+
+	k.cache = cache.New(&cache.Options{
+		Redis:      redisClient,
+		LocalCache: k.localCache,
+		Marshal:    k.marshalFn,
+		Unmarshal:  k.unmarshalFn,
+	})
+	k.redisClient = redisClient
+
+	return k
+}

--- a/cache/memoize_cache.go
+++ b/cache/memoize_cache.go
@@ -1,0 +1,179 @@
+package cache
+
+import (
+	"crypto/md5"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	jsoniter "github.com/json-iterator/go"
+	gocache "github.com/patrickmn/go-cache"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type memoizeMetrics interface {
+	// cacheMissInc increments a counter whenever the raw bytes don't exist in the memoize cache
+	cacheMissInc()
+
+	// cacheHitInc increments a counter whenever we've found the raw bytes in the memoize cache
+	cacheHitInc()
+
+	// cacheMarshalInc increments a counter each time we marshal an object and store it in the memoize cache
+	cacheMarshalInc()
+
+	// cacheHitWithUnmarshalInc increments a counter whenever we've found the raw bytes in the memoize cache but have
+	// still had to perform an unmarshal. This shouldn't happen but this counter will let us know if it is occuring
+	cacheHitWithUnmarshalInc()
+}
+
+type internalCache interface {
+	Get(key string) (interface{}, bool)
+	Set(key string, v interface{}, d time.Duration)
+}
+
+type memoizeCache struct {
+	Cache
+	metrics memoizeMetrics
+}
+
+// NewMemoizeCache creates a memoize cache
+func NewMemoizeCache(rc redis.UniversalClient, defaultExpiration, cleanupInterval time.Duration, metrics memoizeMetrics) Cache {
+	mc := memoizeCache{}
+	//c := gocache.New(defaultExpiration, cleanupInterval)
+
+	if metrics == nil {
+		metrics = noOpMetrics{}
+	}
+	mc.metrics = metrics
+
+	mc.Cache = NewRedisCache(rc)
+
+	return mc
+}
+
+func (m memoizeCache) makeMarshalFunc(ffCache internalCache) func(interface{}) ([]byte, error) {
+	return func(i interface{}) ([]byte, error) {
+		data, err := jsoniter.Marshal(i)
+		if err != nil {
+			//log.Error("msg", "unable to marshall feature evaluations", "err", err)
+			return nil, err
+		}
+
+		hasher := md5.New()
+		hasher.Write(data)
+		hash := hasher.Sum(nil)
+		ffCache.Set(string(hash), i, gocache.DefaultExpiration)
+		m.metrics.cacheMarshalInc()
+		return data, nil
+	}
+}
+
+func (m memoizeCache) makeUnmarshalFunc(ffCache internalCache) func([]byte, interface{}) error {
+	return func(bytes []byte, i interface{}) error {
+		hasher := md5.New()
+		hasher.Write(bytes)
+		hash := hasher.Sum(nil)
+		if resp, ok := ffCache.Get(string(hash)); ok {
+			val := reflect.ValueOf(i)
+			if val.Kind() != reflect.Ptr {
+				m.metrics.cacheHitWithUnmarshalInc()
+				return jsoniter.Unmarshal(bytes, &i)
+			}
+
+			// We got a hit for the bytes in our memoize cache so can return them
+			// and don't have to perform any unmarshaling.
+			m.metrics.cacheHitInc()
+			respValue := reflect.ValueOf(resp)
+			if respValue.Kind() == reflect.Ptr {
+				val.Elem().Set(respValue.Elem())
+			} else {
+				val.Elem().Set(respValue)
+			}
+
+			return nil
+		}
+
+		// The raw bytes weren't in the memoize cache so we increment our cache
+		// readMiss counters and have to perform a full unmarshal
+		m.metrics.cacheMissInc()
+		err := jsoniter.Unmarshal(bytes, &i)
+		if err != nil {
+			return err
+		}
+
+		// Because we didn't find these bytes in our local cache.
+		// save them for next time.
+		ffCache.Set(string(hash), i, gocache.DefaultExpiration)
+		return nil
+	}
+}
+
+// MemoizeMetrics implements the memoizeMetrics interface
+type MemoizeMetrics struct {
+	cacheMarshal     prometheus.Counter
+	hitWithUnmarshal prometheus.Counter
+
+	miss prometheus.Counter
+	hit  prometheus.Counter
+}
+
+// NewMemoizeMetrics creates a MemoizeMetrics struct that records prometheus metrics that tracks activity in the
+// memoize cache
+func NewMemoizeMetrics(label string, reg *prometheus.Registry) MemoizeMetrics {
+	m := MemoizeMetrics{
+		miss: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: fmt.Sprintf("ff_%s_memoize_cache_miss", label),
+			Help: "Tracks the number of misses we get performing lookups in our memoize cache. When we get a readMiss we have to perform a full unmarshal",
+		}),
+		hit: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: fmt.Sprintf("ff_%s_memoize_cache_hit", label),
+			Help: "Tracks the number of hits we get performing lookups in our memoize cache. When we get a hit we can return raw bytes and avoid performing any unmarshaling",
+		}),
+
+		cacheMarshal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: fmt.Sprintf("ff_%s_memoize_cache_write_marshal", label),
+			Help: "Tracks the number of times the memoize cache marshals an object to bytes. This happens every time we set a value in the cache",
+		}),
+
+		hitWithUnmarshal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: fmt.Sprintf("ff_%s_memoize_cache_hit_with_unmarshal", label),
+			Help: "Tracks the number of hits we get performing lookups in our memoize cache but we've still had to perform a full unmarshal",
+		}),
+	}
+
+	reg.MustRegister(
+		m.cacheMarshal,
+		m.hitWithUnmarshal,
+		m.miss,
+		m.hit,
+	)
+
+	return m
+}
+
+func (m MemoizeMetrics) cacheMarshalInc() {
+	m.cacheMarshal.Inc()
+}
+
+func (m MemoizeMetrics) cacheMissInc() {
+	m.miss.Inc()
+}
+
+func (m MemoizeMetrics) cacheHitWithUnmarshalInc() {
+	m.hitWithUnmarshal.Inc()
+}
+
+func (m MemoizeMetrics) cacheHitInc() {
+	m.hit.Inc()
+}
+
+type noOpMetrics struct{}
+
+func (n noOpMetrics) cacheMarshalInc() {}
+
+func (n noOpMetrics) cacheMissInc() {}
+
+func (n noOpMetrics) cacheHitWithUnmarshalInc() {}
+
+func (n noOpMetrics) cacheHitInc() {}

--- a/cache/memoize_cache_test.go
+++ b/cache/memoize_cache_test.go
@@ -1,0 +1,172 @@
+package cache
+
+//type mockInternalCache struct {
+//	data map[string]interface{}
+//}
+//
+//func (m *mockInternalCache) Get(key string) (interface{}, bool) {
+//	v, ok := m.data[key]
+//	return v, ok
+//}
+//
+//func (m *mockInternalCache) Set(key string, v interface{}, d time.Duration) {
+//	m.data[key] = v
+//}
+//
+//type mockMetrics struct {
+//	cacheMarshal        int
+//	cacheUnmarshal      int
+//	localCacheUnmarshal int
+//	localCacheHit       int
+//}
+//
+//func (m *mockMetrics) cacheMarshalInc() {
+//	m.cacheMarshal++
+//}
+//
+//func (m *mockMetrics) cacheMissInc() {
+//	m.cacheUnmarshal++
+//}
+//
+//func (m *mockMetrics) cacheHitWithUnmarshalInc() {
+//	m.localCacheUnmarshal++
+//}
+//
+//func (m *mockMetrics) cacheHitInc() {
+//	m.localCacheHit++
+//}
+//
+//func TestNewMemoizeMetrics(t *testing.T) {
+//	// Just testing it doesn't panic when we call MustRegister
+//	_ = NewMemoizeMetrics("", prometheus.NewRegistry())
+//}
+//
+//func TestMemoizeCache_makeMarshalFunc(t *testing.T) {
+//	mockMetrics := &mockMetrics{}
+//
+//	c := NewMemoizeCache(nil, 1*time.Minute, 1*time.Minute, 1*time.Minute, mockMetrics)
+//
+//	mc, ok := c.(memoizeCache)
+//	assert.True(t, ok)
+//
+//	marshal := mc.makeMarshalFunc(cache.New(1*time.Minute, 1*time.Minute))
+//
+//	m := map[string]string{
+//		"hello": "world",
+//	}
+//
+//	b, err := marshal(m)
+//	assert.Nil(t, err)
+//
+//	assert.Equal(t, b, mustMarshal(m))
+//	assert.Equal(t, 1, mockMetrics.cacheMarshal)
+//}
+//
+//func TestMemoizeCache_makeUnmarshalFunc(t *testing.T) {
+//	type mocks struct {
+//		metrics       *mockMetrics
+//		internalCache *mockInternalCache
+//	}
+//
+//	type cacheData struct {
+//		value map[string]string
+//	}
+//
+//	type results struct {
+//		cacheUnmarshal      int
+//		localCacheUnmarshal int
+//		localCacheHit       int
+//	}
+//
+//	testCases := map[string]struct {
+//		mocks     mocks
+//		cacheData cacheData
+//		shouldErr bool
+//
+//		thing    interface{}
+//		expected results
+//	}{
+//		"Given my internal cache has the thing": {
+//			mocks: mocks{
+//				metrics:       &mockMetrics{},
+//				internalCache: &mockInternalCache{data: make(map[string]interface{})},
+//			},
+//			cacheData: cacheData{
+//				value: map[string]string{
+//					"hello": "world",
+//				},
+//			},
+//			shouldErr: false,
+//
+//			thing: map[string]string{
+//				"hello": "world",
+//			},
+//
+//			expected: results{
+//				cacheUnmarshal:      0,
+//				localCacheUnmarshal: 0,
+//				localCacheHit:       1,
+//			},
+//		},
+//		"Given I have an empty internal cache": {
+//			mocks: mocks{
+//				metrics:       &mockMetrics{},
+//				internalCache: &mockInternalCache{data: make(map[string]interface{})},
+//			},
+//			cacheData: cacheData{},
+//			shouldErr: false,
+//
+//			thing: map[string]string{"thing": "foo"},
+//
+//			expected: results{
+//				cacheUnmarshal:      1,
+//				localCacheUnmarshal: 0,
+//				localCacheHit:       0,
+//			},
+//		},
+//	}
+//
+//	for desc, tc := range testCases {
+//		desc := desc
+//		tc := tc
+//
+//		t.Run(desc, func(t *testing.T) {
+//			c := memoizeCache{
+//				Cache2:  SetupTestKeyValCache(),
+//				metrics: tc.mocks.metrics,
+//			}
+//
+//			if tc.cacheData.value != nil {
+//				// Prime the cache
+//				mFn := c.makeMarshalFunc(tc.mocks.internalCache)
+//				_, err := mFn(tc.cacheData.value)
+//				assert.Nil(t, err)
+//
+//			}
+//
+//			unmarshal := c.makeUnmarshalFunc(tc.mocks.internalCache)
+//
+//			actual := map[string]string{}
+//			err := unmarshal(mustMarshal(tc.thing), &actual)
+//			assert.Nil(t, err)
+//
+//			assert.Equal(t, tc.expected.localCacheUnmarshal, tc.mocks.metrics.localCacheUnmarshal)
+//			assert.Equal(t, tc.expected.localCacheHit, tc.mocks.metrics.localCacheHit)
+//			assert.Equal(t, tc.expected.cacheUnmarshal, tc.mocks.metrics.cacheUnmarshal)
+//		})
+//	}
+//}
+//
+//func hash(b []byte) []byte {
+//	hasher := md5.New()
+//	hasher.Write(b)
+//	return hasher.Sum(nil)
+//}
+//
+//func mustMarshal(v interface{}) []byte {
+//	b, err := jsoniter.Marshal(v)
+//	if err != nil {
+//		panic(err)
+//	}
+//	return b
+//}

--- a/cache/memoize_cache_test.go
+++ b/cache/memoize_cache_test.go
@@ -1,172 +1,182 @@
 package cache
 
-//type mockInternalCache struct {
-//	data map[string]interface{}
-//}
-//
-//func (m *mockInternalCache) Get(key string) (interface{}, bool) {
-//	v, ok := m.data[key]
-//	return v, ok
-//}
-//
-//func (m *mockInternalCache) Set(key string, v interface{}, d time.Duration) {
-//	m.data[key] = v
-//}
-//
-//type mockMetrics struct {
-//	cacheMarshal        int
-//	cacheUnmarshal      int
-//	localCacheUnmarshal int
-//	localCacheHit       int
-//}
-//
-//func (m *mockMetrics) cacheMarshalInc() {
-//	m.cacheMarshal++
-//}
-//
-//func (m *mockMetrics) cacheMissInc() {
-//	m.cacheUnmarshal++
-//}
-//
-//func (m *mockMetrics) cacheHitWithUnmarshalInc() {
-//	m.localCacheUnmarshal++
-//}
-//
-//func (m *mockMetrics) cacheHitInc() {
-//	m.localCacheHit++
-//}
-//
-//func TestNewMemoizeMetrics(t *testing.T) {
-//	// Just testing it doesn't panic when we call MustRegister
-//	_ = NewMemoizeMetrics("", prometheus.NewRegistry())
-//}
-//
-//func TestMemoizeCache_makeMarshalFunc(t *testing.T) {
-//	mockMetrics := &mockMetrics{}
-//
-//	c := NewMemoizeCache(nil, 1*time.Minute, 1*time.Minute, 1*time.Minute, mockMetrics)
-//
-//	mc, ok := c.(memoizeCache)
-//	assert.True(t, ok)
-//
-//	marshal := mc.makeMarshalFunc(cache.New(1*time.Minute, 1*time.Minute))
-//
-//	m := map[string]string{
-//		"hello": "world",
-//	}
-//
-//	b, err := marshal(m)
-//	assert.Nil(t, err)
-//
-//	assert.Equal(t, b, mustMarshal(m))
-//	assert.Equal(t, 1, mockMetrics.cacheMarshal)
-//}
-//
-//func TestMemoizeCache_makeUnmarshalFunc(t *testing.T) {
-//	type mocks struct {
-//		metrics       *mockMetrics
-//		internalCache *mockInternalCache
-//	}
-//
-//	type cacheData struct {
-//		value map[string]string
-//	}
-//
-//	type results struct {
-//		cacheUnmarshal      int
-//		localCacheUnmarshal int
-//		localCacheHit       int
-//	}
-//
-//	testCases := map[string]struct {
-//		mocks     mocks
-//		cacheData cacheData
-//		shouldErr bool
-//
-//		thing    interface{}
-//		expected results
-//	}{
-//		"Given my internal cache has the thing": {
-//			mocks: mocks{
-//				metrics:       &mockMetrics{},
-//				internalCache: &mockInternalCache{data: make(map[string]interface{})},
-//			},
-//			cacheData: cacheData{
-//				value: map[string]string{
-//					"hello": "world",
-//				},
-//			},
-//			shouldErr: false,
-//
-//			thing: map[string]string{
-//				"hello": "world",
-//			},
-//
-//			expected: results{
-//				cacheUnmarshal:      0,
-//				localCacheUnmarshal: 0,
-//				localCacheHit:       1,
-//			},
-//		},
-//		"Given I have an empty internal cache": {
-//			mocks: mocks{
-//				metrics:       &mockMetrics{},
-//				internalCache: &mockInternalCache{data: make(map[string]interface{})},
-//			},
-//			cacheData: cacheData{},
-//			shouldErr: false,
-//
-//			thing: map[string]string{"thing": "foo"},
-//
-//			expected: results{
-//				cacheUnmarshal:      1,
-//				localCacheUnmarshal: 0,
-//				localCacheHit:       0,
-//			},
-//		},
-//	}
-//
-//	for desc, tc := range testCases {
-//		desc := desc
-//		tc := tc
-//
-//		t.Run(desc, func(t *testing.T) {
-//			c := memoizeCache{
-//				Cache2:  SetupTestKeyValCache(),
-//				metrics: tc.mocks.metrics,
-//			}
-//
-//			if tc.cacheData.value != nil {
-//				// Prime the cache
-//				mFn := c.makeMarshalFunc(tc.mocks.internalCache)
-//				_, err := mFn(tc.cacheData.value)
-//				assert.Nil(t, err)
-//
-//			}
-//
-//			unmarshal := c.makeUnmarshalFunc(tc.mocks.internalCache)
-//
-//			actual := map[string]string{}
-//			err := unmarshal(mustMarshal(tc.thing), &actual)
-//			assert.Nil(t, err)
-//
-//			assert.Equal(t, tc.expected.localCacheUnmarshal, tc.mocks.metrics.localCacheUnmarshal)
-//			assert.Equal(t, tc.expected.localCacheHit, tc.mocks.metrics.localCacheHit)
-//			assert.Equal(t, tc.expected.cacheUnmarshal, tc.mocks.metrics.cacheUnmarshal)
-//		})
-//	}
-//}
-//
-//func hash(b []byte) []byte {
-//	hasher := md5.New()
-//	hasher.Write(b)
-//	return hasher.Sum(nil)
-//}
-//
-//func mustMarshal(v interface{}) []byte {
-//	b, err := jsoniter.Marshal(v)
-//	if err != nil {
-//		panic(err)
-//	}
-//	return b
-//}
+import (
+	"crypto/md5"
+	"testing"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockInternalCache struct {
+	data map[string]interface{}
+}
+
+func (m *mockInternalCache) Get(key string) (interface{}, bool) {
+	v, ok := m.data[key]
+	return v, ok
+}
+
+func (m *mockInternalCache) Set(key string, v interface{}, d time.Duration) {
+	m.data[key] = v
+}
+
+type mockMetrics struct {
+	cacheMarshal        int
+	cacheUnmarshal      int
+	localCacheUnmarshal int
+	localCacheHit       int
+}
+
+func (m *mockMetrics) cacheMarshalInc() {
+	m.cacheMarshal++
+}
+
+func (m *mockMetrics) cacheMissInc() {
+	m.cacheUnmarshal++
+}
+
+func (m *mockMetrics) cacheHitWithUnmarshalInc() {
+	m.localCacheUnmarshal++
+}
+
+func (m *mockMetrics) cacheHitInc() {
+	m.localCacheHit++
+}
+
+func TestNewMemoizeMetrics(t *testing.T) {
+	// Just testing it doesn't panic when we call MustRegister
+	_ = NewMemoizeMetrics("", prometheus.NewRegistry())
+}
+
+func TestMemoizeCache_makeMarshalFunc(t *testing.T) {
+	mockMetrics := &mockMetrics{}
+
+	c := NewMemoizeCache(nil, 1*time.Minute, 1*time.Minute, 1*time.Minute, mockMetrics)
+
+	mc, ok := c.(memoizeCache)
+	assert.True(t, ok)
+
+	marshal := mc.makeMarshalFunc(cache.New(1*time.Minute, 1*time.Minute))
+
+	m := map[string]string{
+		"hello": "world",
+	}
+
+	b, err := marshal(m)
+	assert.Nil(t, err)
+
+	assert.Equal(t, b, mustMarshal(m))
+	assert.Equal(t, 1, mockMetrics.cacheMarshal)
+}
+
+func TestMemoizeCache_makeUnmarshalFunc(t *testing.T) {
+	type mocks struct {
+		metrics       *mockMetrics
+		internalCache *mockInternalCache
+	}
+
+	type cacheData struct {
+		value map[string]string
+	}
+
+	type results struct {
+		cacheUnmarshal      int
+		localCacheUnmarshal int
+		localCacheHit       int
+	}
+
+	testCases := map[string]struct {
+		mocks     mocks
+		cacheData cacheData
+		shouldErr bool
+
+		thing    interface{}
+		expected results
+	}{
+		"Given my internal cache has the thing": {
+			mocks: mocks{
+				metrics:       &mockMetrics{},
+				internalCache: &mockInternalCache{data: make(map[string]interface{})},
+			},
+			cacheData: cacheData{
+				value: map[string]string{
+					"hello": "world",
+				},
+			},
+			shouldErr: false,
+
+			thing: map[string]string{
+				"hello": "world",
+			},
+
+			expected: results{
+				cacheUnmarshal:      0,
+				localCacheUnmarshal: 0,
+				localCacheHit:       1,
+			},
+		},
+		"Given I have an empty internal cache": {
+			mocks: mocks{
+				metrics:       &mockMetrics{},
+				internalCache: &mockInternalCache{data: make(map[string]interface{})},
+			},
+			cacheData: cacheData{},
+			shouldErr: false,
+
+			thing: map[string]string{"thing": "foo"},
+
+			expected: results{
+				cacheUnmarshal:      1,
+				localCacheUnmarshal: 0,
+				localCacheHit:       0,
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			c := memoizeCache{
+				Cache2:  SetupTestKeyValCache(),
+				metrics: tc.mocks.metrics,
+			}
+
+			if tc.cacheData.value != nil {
+				// Prime the cache
+				mFn := c.makeMarshalFunc(tc.mocks.internalCache)
+				_, err := mFn(tc.cacheData.value)
+				assert.Nil(t, err)
+
+			}
+
+			unmarshal := c.makeUnmarshalFunc(tc.mocks.internalCache)
+
+			actual := map[string]string{}
+			err := unmarshal(mustMarshal(tc.thing), &actual)
+			assert.Nil(t, err)
+
+			assert.Equal(t, tc.expected.localCacheUnmarshal, tc.mocks.metrics.localCacheUnmarshal)
+			assert.Equal(t, tc.expected.localCacheHit, tc.mocks.metrics.localCacheHit)
+			assert.Equal(t, tc.expected.cacheUnmarshal, tc.mocks.metrics.cacheUnmarshal)
+		})
+	}
+}
+
+func hash(b []byte) []byte {
+	hasher := md5.New()
+	hasher.Write(b)
+	return hasher.Sum(nil)
+}
+
+func mustMarshal(v interface{}) []byte {
+	b, err := jsoniter.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}


### PR DESCRIPTION
**What**

- Adds the key value and memoize cache types to the Proxy but doesn't make any changes to use them yet. There's quite a lot to do for this and I don't want the PRs to get too big so trying to do stuff in small chunks.

**Why**

- Switching the proxy to use these cache's over its current cache implementation will give us a boost in performance