### PR TITLE
FFM-8719 Log out raw metrics requests

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -567,6 +567,7 @@ func main() {
 		middleware.NewEchoLoggingMiddleware(),
 		middleware.NewEchoAuthMiddleware([]byte(authSecret), bypassAuth),
 		middleware.NewPrometheusMiddleware(promReg),
+		middleware.NewMetricsLoggingMiddleware(logger),
 	)
 
 	go func() {

--- a/log/log.go
+++ b/log/log.go
@@ -3,10 +3,13 @@ package log
 import (
 	"context"
 
-	"github.com/harness/ff-proxy/middleware"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+type contextKey string
+
+const RequestIDKey contextKey = "requestID"
 
 // Logger defines a logger with multiple logging levels. When using the logger
 // calls to its methods should include a brief message describing what happened
@@ -221,11 +224,17 @@ func (s StructuredLogger) With(keyvals ...interface{}) Logger {
 // returns them as a slice of strings
 func ExtractRequestValuesFromContext(ctx context.Context) []interface{} {
 	values := []interface{}{}
-	reqID := middleware.GetRequestID(ctx)
+	reqID := GetRequestID(ctx)
 	if reqID != "" {
 		values = append(values, "reqID")
 		values = append(values, reqID)
 	}
 
 	return values
+}
+
+// GetRequestID extracts the requestID value from the context if it exists.
+func GetRequestID(ctx context.Context) string {
+	requestID, _ := ctx.Value(RequestIDKey).(string)
+	return requestID
 }

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -249,6 +249,7 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 		middleware.NewEchoLoggingMiddleware(),
 		middleware.NewEchoAuthMiddleware([]byte(`secret`), bypassAuth),
 		middleware.NewPrometheusMiddleware(prometheus.NewRegistry()),
+		middleware.NewMetricsLoggingMiddleware(logger),
 	)
 	return server
 }


### PR DESCRIPTION
**What**

- Adds a middleware that logs out raw metrics payloads to help debug an issue being experienced by a customer
- There was a circular dependency issue with the log and middleware package which happened when I created the `NewMetricsLoggingMiddleware` function which is why I've moved the `RequestIDKey` type to the `log` package
- Just before the proxy sends metrics requests on to SaaS we now log the raw request body

**Testing**

- Running locally I can see the new log coming out
- Added this middleware to our tests and existing tests for our endpoints still pass
- Running locally with my debugger I can see the log coming out and the body is still being unmarshaled to the struct in the handler which means that we're resetting the request body properly in the middleware.
- When I point my local proxy at my production SaaS project I can see the raw request that the proxy forwards to SaaS being logged and I can see my metrics being updated in my SaaS project