### PR TITLE
(FFM-8377) Bump go sdk to quiet error logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/google/uuid v1.3.0
-	github.com/harness/ff-golang-server-sdk v0.1.9-0.20230710142157-da4e63abed92
+	github.com/harness/ff-golang-server-sdk v0.1.10
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/joho/godotenv v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/harness/ff-golang-server-sdk v0.1.9-0.20230710114508-e1366ad51bc5 h1:
 github.com/harness/ff-golang-server-sdk v0.1.9-0.20230710114508-e1366ad51bc5/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
 github.com/harness/ff-golang-server-sdk v0.1.9-0.20230710142157-da4e63abed92 h1:bJWaOJ62Mm8sOS0v9TCrE3kB0mQTEubs497nq7BuDAc=
 github.com/harness/ff-golang-server-sdk v0.1.9-0.20230710142157-da4e63abed92/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
+github.com/harness/ff-golang-server-sdk v0.1.10 h1:MAextRMcZOdA7HOMGGOJNF2gdXB+2s0tT2vA/6NU4v4=
+github.com/harness/ff-golang-server-sdk v0.1.10/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=


### PR DESCRIPTION
Bump go sdk to 0.1.10 to pull in the error logging improvements