### PR TITLE
FFM-9095 Logging clean up

### DIFF
--- a/cache/wrapper.go
+++ b/cache/wrapper.go
@@ -74,7 +74,7 @@ func (wrapper *Wrapper) getTime() time.Time {
 
 // Set sets a new value for a key
 func (wrapper *Wrapper) Set(key interface{}, value interface{}) (evicted bool) {
-	wrapper.logger = wrapper.logger.With("method", "Set", "key", key, "value", value)
+	wrapper.logger = wrapper.logger.With("method", "Set", "key", key)
 
 	// on first set delete old data
 	wrapper.m.Lock()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,12 +41,12 @@ Config required to connect to redis. Note only `REDIS_ADDRESS` is required to co
 
 **Connecting to Redis via TLS:** To connect to a redis instance which has TLS enabled you should prepend `rediss://` to the beginning of your REDIS_ADDRESS url e.g. `rediss://localhost:6379` 
 
-### Debug
-Enable debug logging.
+### Logging
+Control log level
 
 | Environment Variable | Flag  | Description            | Type    | Default |
 |----------------------|-------|------------------------|---------|---------|
-| DEBUG                | debug | Enables debug logging. | boolean | false   |
+| LOG_LEVEL                | log-level | Controls the log level. Valid inputs are `INFO`, `DEBUG` & `ERROR`. | string | `INFO`   |
 
 ### Offline mode
 These are the config options applicable for running in offline mode

--- a/services/admin_service_test.go
+++ b/services/admin_service_test.go
@@ -122,7 +122,7 @@ func TestAdminService_PageTargets(t *testing.T) {
 	for desc, tc := range testCases {
 		tc := tc
 		t.Run(desc, func(t *testing.T) {
-			logger, _ := log.NewStructuredLogger(true)
+			logger, _ := log.NewStructuredLogger("DEBUG")
 			adminService, _ := NewAdminService(logger, "localhost:8000", "svc-token")
 			adminService.client = tc.mockService
 
@@ -232,7 +232,7 @@ func TestAdminService_GetAPIKeys(t *testing.T) {
 	for desc, tc := range testCases {
 		tc := tc
 		t.Run(desc, func(t *testing.T) {
-			logger, _ := log.NewStructuredLogger(true)
+			logger, _ := log.NewStructuredLogger("DEBUG")
 			adminService, _ := NewAdminService(logger, "localhost:8000", "svc-token")
 			adminService.client = tc.mockService
 

--- a/services/client_service_test.go
+++ b/services/client_service_test.go
@@ -76,7 +76,7 @@ func TestClientService_Authenticate(t *testing.T) {
 	for desc, tc := range testCases {
 		tc := tc
 		t.Run(desc, func(t *testing.T) {
-			logger, _ := log.NewStructuredLogger(true)
+			logger, _ := log.NewStructuredLogger("DEBUG")
 			clientService, _ := NewClientService(logger, "localhost:8000")
 			clientService.client = tc.mockService
 

--- a/services/metric_service_test.go
+++ b/services/metric_service_test.go
@@ -332,7 +332,7 @@ func TestMetricService_SendMetrics(t *testing.T) {
 	for desc, tc := range testCases {
 		t.Run(desc, func(t *testing.T) {
 			postMetricsCount = 0
-			logger, _ := log.NewStructuredLogger(true)
+			logger, _ := log.NewStructuredLogger("DEBUG")
 			metricsService, _ := NewMetricService(logger, defaultMetricsURL, defaultAccount, tc.tokens, true, prometheus.NewRegistry())
 			metricsService.metrics = tc.metrics
 			metricsService.client = mockService{postMetricsWithResp: tc.postMetricsWithResp}

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -296,7 +296,7 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 	server := NewHTTPServer(8000, endpoints, logger, false, "", "", prometheus.NewRegistry())
 	server.Use(
 		middleware.NewEchoRequestIDMiddleware(),
-		middleware.NewEchoLoggingMiddleware(),
+		middleware.NewEchoLoggingMiddleware(logger),
 		middleware.NewEchoAuthMiddleware([]byte(`secret`), bypassAuth),
 		middleware.NewPrometheusMiddleware(prometheus.NewRegistry()),
 	)


### PR DESCRIPTION
**What**

- Replaces `DEBUG` environment variable with `LOG_LEVEL`
- Removes a `value` field from a log statement in the cache wrapper

**Why**

- With the `DEBUG` environment variable we could only switch between logging at INFO or DEBUG level. Using `LOG_LEVEL` means we can now switch between INFO, ERROR or DEBUG
- The default logging level is `INFO` so we still output all the middleware logs by default and you have to opt in to disable debug logging. This is so we don't break functionality
for people expecting to see these logs.
- This `value` field that we were logging out dumps out all of the values in the logs e.g. if you have 10k flags it would log out 10k records which we don't want.

**Testing**

- Tested locally.