### PR TITLE
FFM-9314 Update gosdk verison

### DIFF
--- a/cache/wrapper.go
+++ b/cache/wrapper.go
@@ -459,13 +459,18 @@ func (wrapper *Wrapper) get(key cacheKey) (interface{}, error) {
 
 func (wrapper *Wrapper) getFeatureConfigs(key cacheKey) (interface{}, error) {
 	// get FeatureFlag in rest.FeatureConfig format
-	var featureConfig []rest.FeatureConfig
+	featureConfig := []domain.FeatureFlag{}
 	err := wrapper.cache.Get(context.Background(), key.name, &featureConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return featureConfig, nil
+	result := make([]rest.FeatureConfig, 0, len(featureConfig))
+	for _, fc := range featureConfig {
+		result = append(result, rest.FeatureConfig(fc))
+	}
+
+	return result, nil
 }
 
 func (wrapper *Wrapper) getFeatureConfig(key cacheKey) (interface{}, error) {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/google/uuid v1.3.0
-	github.com/harness/ff-golang-server-sdk v0.1.10
+	github.com/harness/ff-golang-server-sdk v0.1.11-0.20230913084026-25c087ad4aa3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/joho/godotenv v1.4.0
@@ -93,3 +93,5 @@ require (
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/harness/ff-golang-server-sdk v0.1.11-0.20230912140050-d73c1a9a004d => ../ff-golang-server-sdk

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,14 @@ github.com/harness/ff-golang-server-sdk v0.1.9-0.20230710142157-da4e63abed92 h1:
 github.com/harness/ff-golang-server-sdk v0.1.9-0.20230710142157-da4e63abed92/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
 github.com/harness/ff-golang-server-sdk v0.1.10 h1:MAextRMcZOdA7HOMGGOJNF2gdXB+2s0tT2vA/6NU4v4=
 github.com/harness/ff-golang-server-sdk v0.1.10/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
+github.com/harness/ff-golang-server-sdk v0.1.11-0.20230912122014-9e744f623a34 h1:bKxS1NnLqBSzO6fT8SrxjMGM5ubHq0dNOj9TDfBKMkw=
+github.com/harness/ff-golang-server-sdk v0.1.11-0.20230912122014-9e744f623a34/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
+github.com/harness/ff-golang-server-sdk v0.1.11-0.20230912140050-d73c1a9a004d h1:lhhckk0J5Se0SBbp4Go6vq3oaOwEyANw3JFnJWlQD7g=
+github.com/harness/ff-golang-server-sdk v0.1.11-0.20230912140050-d73c1a9a004d/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
+github.com/harness/ff-golang-server-sdk v0.1.11-0.20230912150410-9edde8953b68 h1:wF+0s/NTTFqMuUr56oKhvwrY4l1cq11p4TLqOnxVEac=
+github.com/harness/ff-golang-server-sdk v0.1.11-0.20230912150410-9edde8953b68/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
+github.com/harness/ff-golang-server-sdk v0.1.11-0.20230913084026-25c087ad4aa3 h1:bmBLoKzK7GrOmJHHu3bzDsvvgoiJU0av1MuwjJnUjTI=
+github.com/harness/ff-golang-server-sdk v0.1.11-0.20230913084026-25c087ad4aa3/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=


### PR DESCRIPTION
**What**

- Updates the gosdk version
- Fixes CacheWrapper.getFeatureConfigs function. It turns out this function wasn't actually being called by the SDK code until I made the SDK changes. 

**Why**

- This version has a fix for a bug where we weren't updating the featureConfigs in the cache whenever we received an SSE event

**Testing**

- Locally
- Added unit tests to the GoSDK code that the Proxy relies on