### PR TITLE
FFM-9466 Fetch config from SaaS on startup

### DIFF
--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/harness/ff-proxy/v2/domain"
@@ -22,7 +23,8 @@ const (
 )
 
 type mockClientService struct {
-	authProxyKey func() (services.AuthenticateProxyKeyResponse, error)
+	authProxyKey    func() (services.AuthenticateProxyKeyResponse, error)
+	pageProxyConfig func() ([]domain.ProxyConfig, error)
 }
 
 func (m mockClientService) AuthenticateProxyKey(ctx context.Context, key string) (services.AuthenticateProxyKeyResponse, error) {
@@ -31,6 +33,10 @@ func (m mockClientService) AuthenticateProxyKey(ctx context.Context, key string)
 
 func (m mockClientService) Authenticate(ctx context.Context, apiKey string, target domain.Target) (string, error) {
 	return "not implemented", nil
+}
+
+func (m mockClientService) PageProxyConfig(ctx context.Context, input services.GetProxyConfigInput) ([]domain.ProxyConfig, error) {
+	return m.pageProxyConfig()
 }
 
 func TestConfig_Populate(t *testing.T) {
@@ -49,16 +55,41 @@ func TestConfig_Populate(t *testing.T) {
 	}{
 		"Given I call Populate and the clientService fails to authenticate": {
 			args: args{key: "123"},
-			mocks: mocks{clientService: mockClientService{authProxyKey: func() (services.AuthenticateProxyKeyResponse, error) {
-				return services.AuthenticateProxyKeyResponse{}, services.ErrUnauthorized
-			}}},
+			mocks: mocks{
+				clientService: mockClientService{
+					authProxyKey: func() (services.AuthenticateProxyKeyResponse, error) {
+						return services.AuthenticateProxyKeyResponse{}, services.ErrUnauthorized
+					},
+				},
+			},
 			shouldErr: true,
 		},
-		"Given I call Populate and the clientService authenticates successfully": {
+		"Given I call Populate and the client service errors fetching ProxyConfig": {
 			args: args{key: "123"},
-			mocks: mocks{clientService: mockClientService{authProxyKey: func() (services.AuthenticateProxyKeyResponse, error) {
-				return services.AuthenticateProxyKeyResponse{}, nil
-			}}},
+			mocks: mocks{
+				clientService: mockClientService{
+					authProxyKey: func() (services.AuthenticateProxyKeyResponse, error) {
+						return services.AuthenticateProxyKeyResponse{}, nil
+					},
+					pageProxyConfig: func() ([]domain.ProxyConfig, error) {
+						return []domain.ProxyConfig{}, errors.New("client service error")
+					},
+				},
+			},
+			shouldErr: true,
+		},
+		"Given I call Populate and the client service doesn't error fetching ProxyConfig": {
+			args: args{key: "123"},
+			mocks: mocks{
+				clientService: mockClientService{
+					authProxyKey: func() (services.AuthenticateProxyKeyResponse, error) {
+						return services.AuthenticateProxyKeyResponse{}, nil
+					},
+					pageProxyConfig: func() ([]domain.ProxyConfig, error) {
+						return []domain.ProxyConfig{}, nil
+					},
+				},
+			},
 			shouldErr: false,
 		},
 	}

--- a/domain/config.go
+++ b/domain/config.go
@@ -1,0 +1,41 @@
+package domain
+
+import (
+	"github.com/google/uuid"
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+)
+
+// ProxyConfig is the object that we receive from SaaS containing the config
+// for each environment associated with a ProxyKey
+type ProxyConfig struct {
+	Environments []Environments `json:"environments" json:"-"`
+}
+
+// Environments contains the environment config that the Proxy needs to store
+type Environments struct {
+	ID             uuid.UUID                 `json:"id" json:"-"`
+	ApiKeys        []string                  `json:"apiKeys"`
+	FeatureConfigs []clientgen.FeatureConfig `json:"featureConfigs"`
+	Segments       []clientgen.Segment       `json:"segments"`
+}
+
+// ToProxyConfig is a helper for converting from the generated ProxyConfig type to our domain ProxyConfig type
+func ToProxyConfig(c clientgen.ProxyConfig) ProxyConfig {
+	if *c.Environments == nil {
+		return ProxyConfig{}
+	}
+
+	environments := make([]Environments, len(*c.Environments))
+	for _, env := range *c.Environments {
+		e := Environments{
+			ID:             uuid.MustParse(*env.Id),
+			ApiKeys:        *env.ApiKeys,
+			FeatureConfigs: *env.FeatureConfigs,
+			Segments:       *env.Segments,
+		}
+
+		environments = append(environments, e)
+	}
+
+	return ProxyConfig{Environments: environments}
+}

--- a/services/client_service_test.go
+++ b/services/client_service_test.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/harness/ff-proxy/v2/log"
@@ -17,13 +19,18 @@ var errNotFound = errors.New("errNotFound")
 
 type mockService struct {
 	clientgen.ClientWithResponsesInterface
+	*sync.Mutex
+
 	authWithResp        func() error
 	postMetricsWithResp func(environment string) (*clientgen.PostMetricsResponse, error)
 
-	authProxyKey func() (*clientgen.AuthenticateProxyKeyResponse, error)
+	authProxyKey   func() (*clientgen.AuthenticateProxyKeyResponse, error)
+	getProxyConfig func(req *clientgen.GetProxyConfigParams) (*clientgen.GetProxyConfigResponse, error)
+
+	getProxyConfigCalls int
 }
 
-func (m mockService) AuthenticateWithResponse(ctx context.Context, req clientgen.AuthenticateJSONRequestBody, fns ...clientgen.RequestEditorFn) (*clientgen.AuthenticateResponse, error) {
+func (m *mockService) AuthenticateWithResponse(ctx context.Context, req clientgen.AuthenticateJSONRequestBody, fns ...clientgen.RequestEditorFn) (*clientgen.AuthenticateResponse, error) {
 	if err := m.authWithResp(); err != nil {
 		if err == errNotFound {
 			resp := clientgen.AuthenticateResponse{
@@ -41,8 +48,22 @@ func (m mockService) AuthenticateWithResponse(ctx context.Context, req clientgen
 	return &clientgen.AuthenticateResponse{JSON200: &clientgen.AuthenticationResponse{AuthToken: "hardcoded-token"}}, nil
 }
 
-func (m mockService) AuthenticateProxyKeyWithResponse(ctx context.Context, req clientgen.AuthenticateProxyKeyJSONRequestBody, fns ...clientgen.RequestEditorFn) (*clientgen.AuthenticateProxyKeyResponse, error) {
+func (m *mockService) AuthenticateProxyKeyWithResponse(ctx context.Context, req clientgen.AuthenticateProxyKeyJSONRequestBody, fns ...clientgen.RequestEditorFn) (*clientgen.AuthenticateProxyKeyResponse, error) {
 	return m.authProxyKey()
+}
+
+func (m *mockService) GetProxyConfigWithResponse(ctx context.Context, req *clientgen.GetProxyConfigParams, fns ...clientgen.RequestEditorFn) (*clientgen.GetProxyConfigResponse, error) {
+	m.Lock()
+	m.getProxyConfigCalls++
+	m.Unlock()
+
+	return m.getProxyConfig(req)
+}
+
+func (m *mockService) GetProxyConfigCalls() int {
+	m.Lock()
+	defer m.Unlock()
+	return m.getProxyConfigCalls
 }
 
 func TestClientService_Authenticate(t *testing.T) {
@@ -85,7 +106,7 @@ func TestClientService_Authenticate(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			logger, _ := log.NewStructuredLogger("DEBUG")
 			clientService, _ := NewClientService(logger, "localhost:8000")
-			clientService.client = tc.mockService
+			clientService.client = &tc.mockService
 
 			actual, err := clientService.Authenticate(context.Background(), "", domain.Target{})
 			if (err != nil) != tc.shouldErr {
@@ -169,7 +190,7 @@ func TestClientService_AuthenticateProxyKey(t *testing.T) {
 
 		t.Run(desc, func(t *testing.T) {
 
-			c := ClientService{client: tc.mocks.clientService}
+			c := ClientService{client: &tc.mocks.clientService}
 			actual, err := c.AuthenticateProxyKey(context.Background(), "123")
 			if tc.shouldErr {
 				assert.NotNil(t, err)
@@ -181,4 +202,264 @@ func TestClientService_AuthenticateProxyKey(t *testing.T) {
 			assert.Equal(t, tc.expected.response, actual)
 		})
 	}
+}
+
+func TestClientService_PageProxyConfig(t *testing.T) {
+	type args struct {
+		input GetProxyConfigInput
+	}
+
+	type mocks struct {
+		clientService *mockService
+	}
+
+	type expected struct {
+		err                 error
+		config              []domain.ProxyConfig
+		getProxyConfigCalls int
+	}
+
+	environmentsPageOne := []struct {
+		ApiKeys        *[]string                  `json:"apiKeys,omitempty"`
+		FeatureConfigs *[]clientgen.FeatureConfig `json:"featureConfigs,omitempty"`
+		Id             *string                    `json:"id,omitempty"`
+		Segments       *[]clientgen.Segment       `json:"segments,omitempty"`
+	}{
+		{
+			Id:      toPtr("515975dd-a4a6-41fe-aefb-ffc088e2b4ec"),
+			ApiKeys: toPtr([]string{"123", "456"}),
+			FeatureConfigs: toPtr([]clientgen.FeatureConfig{
+				{
+					Feature: "DarkMode",
+				},
+				{
+					Feature: "PerfEnhancement",
+				},
+			}),
+			Segments: toPtr([]clientgen.Segment{
+				{
+					Identifier: "GroupOne",
+				},
+				{
+					Identifier: "GroupTwo",
+				},
+			}),
+		},
+	}
+
+	environmentsPageTwo := []struct {
+		ApiKeys        *[]string                  `json:"apiKeys,omitempty"`
+		FeatureConfigs *[]clientgen.FeatureConfig `json:"featureConfigs,omitempty"`
+		Id             *string                    `json:"id,omitempty"`
+		Segments       *[]clientgen.Segment       `json:"segments,omitempty"`
+	}{
+		{
+			Id:      toPtr("4ce93f1b-ebb6-4477-b91a-1f985079c8d9"),
+			ApiKeys: toPtr([]string{"789"}),
+			FeatureConfigs: toPtr([]clientgen.FeatureConfig{
+				{
+					Feature: "DarkMode",
+				},
+				{
+					Feature: "PerfEnhancement",
+				},
+			}),
+			Segments: toPtr([]clientgen.Segment{
+				{
+					Identifier: "GroupOne",
+				},
+				{
+					Identifier: "GroupTwo",
+				},
+			}),
+		},
+	}
+
+	pageOne := clientgen.ProxyConfig{
+		Environments: &environmentsPageOne,
+		ItemCount:    2,
+		PageCount:    2,
+		PageIndex:    0,
+		PageSize:     1,
+		Version:      nil,
+	}
+
+	pageTwo := clientgen.ProxyConfig{
+		Environments: &environmentsPageTwo,
+		ItemCount:    2,
+		PageCount:    2,
+		PageIndex:    1,
+		PageSize:     1,
+		Version:      nil,
+	}
+
+	testCases := map[string]struct {
+		args      args
+		mocks     mocks
+		expected  expected
+		shouldErr bool
+	}{
+		"Given the ff-client-service returns an error": {
+			mocks: mocks{
+				clientService: &mockService{
+					Mutex: &sync.Mutex{},
+					getProxyConfig: func(req *clientgen.GetProxyConfigParams) (*clientgen.GetProxyConfigResponse, error) {
+						return nil, errors.New("client service error")
+					},
+				},
+			},
+			expected: expected{
+				err:                 ErrInternal,
+				config:              nil,
+				getProxyConfigCalls: 1,
+			},
+			shouldErr: true,
+		},
+		"Given the ff-client-service returns a 400": {
+			mocks: mocks{
+				clientService: &mockService{
+					Mutex: &sync.Mutex{},
+					getProxyConfig: func(req *clientgen.GetProxyConfigParams) (*clientgen.GetProxyConfigResponse, error) {
+						return &clientgen.GetProxyConfigResponse{HTTPResponse: &http.Response{StatusCode: http.StatusBadRequest}}, nil
+					},
+				},
+			},
+			expected: expected{
+				err:                 ErrBadRequest,
+				config:              nil,
+				getProxyConfigCalls: 1,
+			},
+			shouldErr: true,
+		},
+		"Given the ff-client-service returns a 401": {
+			mocks: mocks{
+				clientService: &mockService{
+					Mutex: &sync.Mutex{},
+					getProxyConfig: func(req *clientgen.GetProxyConfigParams) (*clientgen.GetProxyConfigResponse, error) {
+						return &clientgen.GetProxyConfigResponse{HTTPResponse: &http.Response{StatusCode: http.StatusUnauthorized}}, nil
+					},
+				},
+			},
+			expected: expected{
+				err:                 ErrUnauthorized,
+				config:              nil,
+				getProxyConfigCalls: 1,
+			},
+			shouldErr: true,
+		},
+		"Given the ff-client-service returns a 403": {
+			mocks: mocks{
+				clientService: &mockService{
+					Mutex: &sync.Mutex{},
+					getProxyConfig: func(req *clientgen.GetProxyConfigParams) (*clientgen.GetProxyConfigResponse, error) {
+						return &clientgen.GetProxyConfigResponse{HTTPResponse: &http.Response{StatusCode: http.StatusForbidden}}, nil
+					},
+				},
+			},
+			expected: expected{
+				err:                 ErrUnauthorized,
+				config:              nil,
+				getProxyConfigCalls: 1,
+			},
+			shouldErr: true,
+		},
+		"Given the ff-client-service returns a 404": {
+			mocks: mocks{
+				clientService: &mockService{
+					Mutex: &sync.Mutex{},
+					getProxyConfig: func(req *clientgen.GetProxyConfigParams) (*clientgen.GetProxyConfigResponse, error) {
+						return &clientgen.GetProxyConfigResponse{HTTPResponse: &http.Response{StatusCode: http.StatusNotFound}}, nil
+					},
+				},
+			},
+			expected: expected{
+				err:                 ErrNotFound,
+				config:              nil,
+				getProxyConfigCalls: 1,
+			},
+			shouldErr: true,
+		},
+		"Given the ff-client-service returns a 500": {
+			mocks: mocks{
+				clientService: &mockService{
+					Mutex: &sync.Mutex{},
+					getProxyConfig: func(req *clientgen.GetProxyConfigParams) (*clientgen.GetProxyConfigResponse, error) {
+						return &clientgen.GetProxyConfigResponse{HTTPResponse: &http.Response{StatusCode: http.StatusInternalServerError}}, nil
+					},
+				},
+			},
+			expected: expected{
+				err:                 ErrInternal,
+				config:              nil,
+				getProxyConfigCalls: 1,
+			},
+			shouldErr: true,
+		},
+		"Given the ff-client-service returns a 200 with two pages": {
+			mocks: mocks{
+				clientService: &mockService{
+					Mutex: &sync.Mutex{},
+					getProxyConfig: func(req *clientgen.GetProxyConfigParams) (*clientgen.GetProxyConfigResponse, error) {
+						var json200 *clientgen.ProxyConfig
+
+						if *req.PageNumber == 0 {
+							json200 = &pageOne
+						}
+
+						if *req.PageNumber == 1 {
+							json200 = &pageTwo
+						}
+
+						return &clientgen.GetProxyConfigResponse{
+							HTTPResponse: &http.Response{
+								StatusCode: http.StatusOK,
+							},
+							JSON200: json200,
+						}, nil
+					},
+				},
+			},
+			expected: expected{
+				err: nil,
+				config: []domain.ProxyConfig{
+					domain.ToProxyConfig(pageOne),
+					domain.ToProxyConfig(pageTwo),
+				},
+				getProxyConfigCalls: 2,
+			},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			c := ClientService{client: tc.mocks.clientService}
+
+			actual, err := c.PageProxyConfig(context.Background(), tc.args.input)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+				assert.True(t, errors.Is(err, tc.expected.err))
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tc.expected.config, actual)
+			assert.Equal(t, tc.expected.getProxyConfigCalls, tc.mocks.clientService.GetProxyConfigCalls())
+		})
+	}
+}
+
+func mustMarshal(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func toPtr[T any](t T) *T {
+	return &t
 }

--- a/services/metric_service_test.go
+++ b/services/metric_service_test.go
@@ -335,7 +335,7 @@ func TestMetricService_SendMetrics(t *testing.T) {
 			logger, _ := log.NewStructuredLogger("DEBUG")
 			metricsService, _ := NewMetricService(logger, defaultMetricsURL, true, prometheus.NewRegistry())
 			metricsService.metrics = tc.metrics
-			metricsService.client = mockService{postMetricsWithResp: tc.postMetricsWithResp}
+			metricsService.client = &mockService{postMetricsWithResp: tc.postMetricsWithResp}
 
 			metricsService.SendMetrics(context.Background(), "1")
 


### PR DESCRIPTION
**What**

- Adds a methods we need to the `ClientService` client for fetching config from the new endpoints
- Calls this method in the config code that gets called on startup

**Why**

- This fetches the config we need to populate the cache when the Proxy starts up
- In the next PR we can add the code to load this config into the cache