### PR TITLE
FFM-9186 Push metrics onto redis when operating as a ReadReplica

### DIFF
--- a/domain/requests.go
+++ b/domain/requests.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // AuthRequest contains the fields sent in an authentication request
@@ -64,6 +65,11 @@ type StreamResponse struct {
 type MetricsRequest struct {
 	EnvironmentID string `json:"environment_id"`
 	clientgen.Metrics
+}
+
+// MarshalBinary makes MetricsRequest implement the encoding.BinaryMarshaler func
+func (m *MetricsRequest) MarshalBinary() (data []byte, err error) {
+	return jsoniter.Marshal(m)
 }
 
 // HealthResponse contains the fields returned in a healthcheck response

--- a/proxy-service/service.go
+++ b/proxy-service/service.go
@@ -88,7 +88,7 @@ type clientService interface {
 
 // MetricService is the interface for storing metrics
 type MetricService interface {
-	StoreMetrics(metrics domain.MetricsRequest) error
+	StoreMetrics(ctx context.Context, metrics domain.MetricsRequest) error
 }
 
 // SDKClients is an interface that can be used to find out if internal sdks are connected to the SaaS FF stream
@@ -382,7 +382,7 @@ func (s Service) Stream(ctx context.Context, req domain.StreamRequest) (domain.S
 func (s Service) Metrics(ctx context.Context, req domain.MetricsRequest) error {
 
 	s.logger.Debug(ctx, "got metrics request", "metrics", fmt.Sprintf("%+v", req))
-	return s.metricService.StoreMetrics(req)
+	return s.metricService.StoreMetrics(ctx, req)
 }
 
 // Health checks the health of the system

--- a/services/metric_service.go
+++ b/services/metric_service.go
@@ -90,7 +90,7 @@ func NewMetricService(l log.Logger, addr string, token string, enabled bool, reg
 }
 
 // StoreMetrics aggregates and stores metrics
-func (m MetricService) StoreMetrics(req domain.MetricsRequest) error {
+func (m MetricService) StoreMetrics(_ context.Context, req domain.MetricsRequest) error {
 	if !m.enabled {
 		return nil
 	}

--- a/services/metric_service_test.go
+++ b/services/metric_service_test.go
@@ -253,7 +253,7 @@ func TestMetricService_StoreMetrics(t *testing.T) {
 			}
 
 			for _, metric := range tc.metrics {
-				metricService.StoreMetrics(metric)
+				metricService.StoreMetrics(context.Background(), metric)
 			}
 
 			actual := metricService.metrics

--- a/services/metric_stream_test.go
+++ b/services/metric_stream_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockStream struct {
+	pub func() error
+}
+
+func (m mockStream) Pub(ctx context.Context, channel string, value interface{}) error {
+	return m.pub()
+}
+
+func TestMetricsStream_StoreMetrics(t *testing.T) {
+	testCases := map[string]struct {
+		mockStream mockStream
+		shouldErr  bool
+	}{
+		"Given the I call StoreMetrics and the stream errors": {
+			mockStream: mockStream{pub: func() error {
+				return errors.New("an error")
+			}},
+			shouldErr: true,
+		},
+		"Given the I call StoreMetrics and the stream doesn't error": {
+			mockStream: mockStream{pub: func() error {
+				return nil
+			}},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			ms := NewMetricsStream(tc.mockStream)
+			err := ms.StoreMetrics(context.Background(), domain.MetricsRequest{})
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/services/metrics_stream.go
+++ b/services/metrics_stream.go
@@ -1,0 +1,27 @@
+package services
+
+import (
+	"context"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/stream"
+)
+
+// MetricsStream is a type for publishing metrics to a stream and implements the MetricService interface
+type MetricsStream struct {
+	stream  stream.Stream
+	channel string
+}
+
+// NewMetricsStream creates a metrics stream
+func NewMetricsStream(s stream.Stream) MetricsStream {
+	return MetricsStream{
+		stream:  s,
+		channel: "stream:sdk_metrics",
+	}
+}
+
+// StoreMetrics pushes metrics onto a stream
+func (m MetricsStream) StoreMetrics(ctx context.Context, req domain.MetricsRequest) error {
+	return m.stream.Pub(ctx, m.channel, &req)
+}

--- a/stream/redis.go
+++ b/stream/redis.go
@@ -1,0 +1,52 @@
+package stream
+
+import (
+	"context"
+	"encoding"
+	"fmt"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// RedisStream is a implementation of the Stream interface that is used for interacting with redis streams
+type RedisStream struct {
+	client redis.UniversalClient
+	maxLen int64
+}
+
+// NewRedisStream creates a new redis streams client
+func NewRedisStream(u redis.UniversalClient) RedisStream {
+	return RedisStream{
+		client: u,
+	}
+}
+
+// Pub publishes events to a redis stream, if the stream doesn't exist it will create
+// the stream and then publish the event
+func (r RedisStream) Pub(ctx context.Context, stream string, v interface{}) error {
+	var err error
+	values := v
+
+	// If the thing we want to publish implements the BinaryMarshaler interface
+	// then use it's encoding
+	bm, ok := v.(encoding.BinaryMarshaler)
+	if ok {
+		values, err = bm.MarshalBinary()
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := r.client.XAdd(ctx, &redis.XAddArgs{
+		Stream: stream,
+		ID:     "*",
+		Values: map[string]interface{}{
+			"index": values,
+		},
+		MaxLen: r.maxLen,
+	}).Err(); err != nil {
+		return fmt.Errorf(":%w: %s", ErrPublishing, err)
+	}
+
+	return nil
+}

--- a/stream/redis_test.go
+++ b/stream/redis_test.go
@@ -1,0 +1,97 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisStream_Pub(t *testing.T) {
+	type args struct {
+		stream string
+		msg    string
+	}
+
+	type expected struct {
+		stream  string
+		message map[string]interface{}
+		err     error
+	}
+
+	testCases := map[string]struct {
+		args      args
+		shouldErr bool
+		setErr    func(m *miniredis.Miniredis)
+		expected  expected
+	}{
+		"Given I call Pub and the redis client doesn't error": {
+			shouldErr: false,
+			args: args{
+				stream: "test-stream",
+				msg:    "foo",
+			},
+			expected: expected{
+				stream: "test-stream",
+				message: map[string]interface{}{
+					"index": "foo",
+				},
+			},
+		},
+		"Given I call Pub and the redis client errors": {
+			shouldErr: true,
+			args: args{
+				stream: "test-stream",
+				msg:    "foo",
+			},
+			setErr: func(m *miniredis.Miniredis) {
+				m.SetError("an error")
+			},
+			expected: expected{
+				err: ErrPublishing,
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		m := miniredis.RunT(t)
+		rc := redis.NewClient(&redis.Options{
+			Addr: m.Addr(),
+		})
+
+		t.Run(desc, func(t *testing.T) {
+			if tc.setErr != nil {
+				tc.setErr(m)
+			}
+
+			rs := NewRedisStream(rc)
+			err := rs.Pub(context.Background(), tc.args.stream, tc.args.msg)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+				assert.True(t, errors.Is(err, tc.expected.err))
+			} else {
+				assert.Nil(t, err)
+
+				xs, err := rc.XRead(context.Background(), &redis.XReadArgs{
+					Streams: []string{"test-stream", "0"},
+					Count:   0,
+					Block:   0,
+				}).Result()
+				assert.Nil(t, err)
+
+				for _, x := range xs {
+					assert.Equal(t, "test-stream", x.Stream)
+					for _, msg := range x.Messages {
+						assert.Equal(t, tc.expected.message, msg.Values)
+					}
+				}
+			}
+		})
+	}
+}

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -1,0 +1,16 @@
+package stream
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	// ErrPublishing is the error returned when we fail to publish an event to a stream
+	ErrPublishing = errors.New("failed to publish to stream")
+)
+
+// Stream defines the stream interface
+type Stream interface {
+	Pub(ctx context.Context, channel string, value interface{}) error
+}

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -81,7 +81,7 @@ func (m *mockClientService) Targets() []domain.Target {
 	return targets
 }
 
-func (m *mockMetricService) StoreMetrics(req domain.MetricsRequest) error {
+func (m *mockMetricService) StoreMetrics(ctx context.Context, req domain.MetricsRequest) error {
 	return m.storeMetrics(req)
 }
 


### PR DESCRIPTION
**What**

- Creates a Stream interface and a RedisCLient that implements this interface
- Creates a MetricsStream type that implements the MetricService interface

**Why**

- When the Proxy is operating as a readreplica we want to use the MetricStream type and push metrics onto a redis stream rather than using the MetricsClient that forwards requests on to Harness SaaS.

**Testing**

- Unit tests
- Running locally when I start my proxuy with READ_REPLICA=true and point an SDK at it. When the SDK sends metrics to the Proxy I can see it pushing them onto the redis stream