### PR TITLE
FFM-9190 Add SSE Client

### DIFF
--- a/clients/client_service/stream.go
+++ b/clients/client_service/stream.go
@@ -1,0 +1,82 @@
+package clientservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/harness/ff-proxy/v2/stream"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/r3labs/sse/v2"
+)
+
+type messageHandler interface {
+	HandleMessage(m domain.SSEMessage) error
+}
+
+// Stream is the type that subscribes to stream that relays Proxy events and handles events coming off the stream
+type Stream struct {
+	log            log.Logger
+	subscriber     stream.Subscriber
+	messageHandler messageHandler
+}
+
+// NewStream opens a subscription to the client service's stream endpoint
+func NewStream(l log.Logger, s stream.Subscriber, m messageHandler) Stream {
+	l = l.With("component", "Start")
+	return Stream{
+		log:            l,
+		subscriber:     s,
+		messageHandler: m,
+	}
+}
+
+// Start connects to the stream and registers a handler to handle events coming off the stream.
+// If the stream disconnects backoff and attempt to subscribe again.
+func (s Stream) Start(ctx context.Context) {
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				err := s.subscriber.Sub(ctx, "*", "", func(id string, v interface{}) error {
+					msg, err := parseMessage(v)
+					if err != nil {
+						return nil
+					}
+
+					if err := s.messageHandler.HandleMessage(msg); err != nil {
+						return nil
+					}
+
+					return nil
+				})
+				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						return
+					}
+
+					time.Sleep(30 * time.Second)
+				}
+			}
+		}
+	}()
+}
+
+func parseMessage(v interface{}) (domain.SSEMessage, error) {
+	event, ok := v.(*sse.Event)
+	if !ok {
+		return domain.SSEMessage{}, fmt.Errorf("expected message type to be *sse.Event, got=%T", v)
+	}
+
+	m := domain.SSEMessage{}
+	if err := jsoniter.Unmarshal(event.Data, &m); err != nil {
+		return domain.SSEMessage{}, err
+	}
+
+	return m, nil
+}

--- a/clients/client_service/stream_test.go
+++ b/clients/client_service/stream_test.go
@@ -1,0 +1,119 @@
+package clientservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/harness/ff-proxy/v2/stream"
+	"github.com/r3labs/sse/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSubscriber struct {
+	sub func() (interface{}, error)
+}
+
+func (m *mockSubscriber) Sub(ctx context.Context, channel string, id string, fn stream.HandleMessageFn) error {
+	v, err := m.sub()
+	if err != nil {
+		return err
+	}
+
+	return fn("", v)
+}
+
+type mockMessageHandler struct {
+	msg chan struct{}
+}
+
+func (m *mockMessageHandler) HandleMessage(msg domain.SSEMessage) error {
+	m.msg <- struct{}{}
+	return nil
+}
+
+func TestStream_Start(t *testing.T) {
+	type mocks struct {
+		subscriber     *mockSubscriber
+		messageHandler *mockMessageHandler
+	}
+
+	type expected struct {
+		messagesHandled int
+	}
+
+	testCases := map[string]struct {
+		mocks    mocks
+		expected expected
+	}{
+		"Given I call Start and the subscriber errors": {
+			mocks: mocks{
+				subscriber: &mockSubscriber{
+					sub: func() (interface{}, error) {
+						return nil, errors.New("an error")
+					},
+				},
+				messageHandler: &mockMessageHandler{
+					msg: make(chan struct{}),
+				},
+			},
+			expected: expected{messagesHandled: 0},
+		},
+		"Given I call Start and the subscriber returns a message that isn't an *sse.Event": {
+			mocks: mocks{
+				subscriber: &mockSubscriber{
+					sub: func() (interface{}, error) {
+						return "message", nil
+					},
+				},
+				messageHandler: &mockMessageHandler{
+					msg: make(chan struct{}),
+				},
+			},
+			expected: expected{messagesHandled: 0},
+		},
+		"Given I call Start and the subscriber returns a message that is an *sse.Event": {
+			mocks: mocks{
+				subscriber: &mockSubscriber{
+					sub: func() (interface{}, error) {
+						return &sse.Event{Data: []byte(`{}`)}, nil
+					},
+				},
+				messageHandler: &mockMessageHandler{
+					msg: make(chan struct{}),
+				},
+			},
+			expected: expected{messagesHandled: 1},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			p := NewStream(log.NewNoOpLogger(), tc.mocks.subscriber, tc.mocks.messageHandler)
+			p.Start(ctx)
+
+			msgsHandled := 0
+			for msgsHandled < tc.expected.messagesHandled {
+				select {
+				case <-ctx.Done():
+					t.Errorf("timed out waiting for subscriber to finish")
+				case <-tc.mocks.messageHandler.msg:
+					msgsHandled++
+				}
+			}
+			cancel()
+
+			assert.Equal(t, tc.expected.messagesHandled, msgsHandled)
+
+		})
+	}
+}

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -307,6 +307,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// If this isn't a read replica Proxy then we'll want to start up a stream with the client
+	// service and receive events
+	if !readReplica {
+		sseClient := stream.NewSSEClient(logger, clientService, proxyKey, conf.Token(), conf.ClusterIdentifier())
+		clientServiceStream := clientservice.NewStream(logger, sseClient, nil)
+		clientServiceStream.Start(ctx)
+	}
+
 	metricSvc := createMetricsService(ctx, logger, conf, promReg, readReplica, redisClient)
 
 	if generateOfflineConfig {

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,9 @@ type Config interface {
 
 	// Token returns the authToken that the Config uses to communicate with Harness SaaS
 	Token() string
+
+	// ClusterIdentifier returns the identifier of the cluster that the Config authenticated against
+	ClusterIdentifier() string
 }
 
 // NewConfig creates either a local or remote config type that implements the Config interface

--- a/config/local/config.go
+++ b/config/local/config.go
@@ -46,6 +46,12 @@ func (c Config) Token() string {
 	return ""
 }
 
+// ClusterIdentifier returns an empty string rather than a clusterIdentifier because local config
+// loads config from a file and doesn't make any requests to Harness SaaS
+func (c Config) ClusterIdentifier() string {
+	return ""
+}
+
 // Populate populates the repos with the config loaded from the file system
 func (c Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error {
 	authConfig := make([]domain.AuthConfig, 0, len(c.config))

--- a/config/remote/config.go
+++ b/config/remote/config.go
@@ -10,8 +10,9 @@ import (
 
 // Config is the type that fetches config from Harness SaaS
 type Config struct {
-	key   string
-	token string
+	key               string
+	token             string
+	clusterIdentifier string
 
 	clientService domain.ClientService
 }
@@ -30,6 +31,11 @@ func (c *Config) Token() string {
 	return c.token
 }
 
+// ClusterIdentifier returns the identifier of the cluster that the Config authenticated against
+func (c *Config) ClusterIdentifier() string {
+	return c.clusterIdentifier
+}
+
 // Populate populates repositories with the config
 func (c *Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error {
 	authResp, err := authenticate(c.key, c.clientService)
@@ -37,6 +43,7 @@ func (c *Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRep
 		return err
 	}
 	c.token = authResp.Token
+	c.clusterIdentifier = authResp.ClusterIdentifier
 
 	proxyConfig, err := retrieveConfig(c.key, authResp.Token, authResp.ClusterIdentifier, c.clientService)
 	if err != nil {

--- a/domain/sse.go
+++ b/domain/sse.go
@@ -1,0 +1,9 @@
+package domain
+
+// SSEMessage is basic object for marshalling data from ff stream
+type SSEMessage struct {
+	Event      string `json:"event"`
+	Domain     string `json:"domain"`
+	Identifier string `json:"identifier"`
+	Version    int    `json:"version"`
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	cloud.google.com/go/profiler v0.3.1
 	github.com/alicebob/miniredis/v2 v2.30.4
-	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/deepmap/oapi-codegen v1.11.0
 	github.com/fanout/go-gripcontrol v0.0.0-20221004121322-47dacded330e
 	github.com/fanout/go-pubcontrol v0.0.0-20221004123744-4d052349ceb5
@@ -23,10 +22,11 @@ require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.11.1
 	github.com/r3labs/sse v0.0.0-20201126193848-34e640891548
+	github.com/r3labs/sse/v2 v2.10.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/zap v1.19.1
-	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
+	gopkg.in/cenkalti/backoff.v1 v1.1.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -90,6 +90,5 @@ require (
 	google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e // indirect
 	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZp
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.30.4 h1:8S4/o1/KoUArAGbGwPxcwf0krlzceva2XVOSchFS7Eo=
 github.com/alicebob/miniredis/v2 v2.30.4/go.mod h1:b25qWj4fCEsBeAAR2mlb0ufImGC6uH3VlUfb/HS5zKg=
-github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
-github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -91,8 +89,8 @@ github.com/fanout/go-pubcontrol v0.0.0-20221004123744-4d052349ceb5 h1:6ezrSwHyJ2
 github.com/fanout/go-pubcontrol v0.0.0-20221004123744-4d052349ceb5/go.mod h1:7E12GoiO4rKf3D2aN6yi/4i+OdDaaTV0meewu6SBLDQ=
 github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/getkin/kin-openapi v0.94.0/go.mod h1:LWZfzOd7PRy8GJ1dJ6mCU6tNdSfOwRac1BUPam4aw6Q=
 github.com/getkin/kin-openapi v0.98.0 h1:lIACvCG9cxmFsEywz+LCoVhcZHFLUy+Nv5QSkb43eAE=
 github.com/getkin/kin-openapi v0.98.0/go.mod h1:w4lRPHiyOdwGbOkLIyk+P0qCwlu7TXPCHD/64nSXzgE=
@@ -208,8 +206,6 @@ github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57Q
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/harness/ff-golang-server-sdk v0.1.10 h1:MAextRMcZOdA7HOMGGOJNF2gdXB+2s0tT2vA/6NU4v4=
 github.com/harness/ff-golang-server-sdk v0.1.10/go.mod h1:zTiSaSQc5nD5Ofug37KJxijyFHX/xG1JodqMFxNqYI0=
-github.com/harness/ff-proxy v1.0.0 h1:rHuIziQWNxOMdTYpk8q3B/FsUwFssxQj2zUATSnpc74=
-github.com/harness/ff-proxy v1.0.0/go.mod h1:iLETXG74VwhxmlY72ebYc6R/syhhwwPqTnMmHYH8fgA=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -347,6 +343,8 @@ github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/r3labs/sse v0.0.0-20201126193848-34e640891548 h1:ewzX4RiFeFXl8APBmMqXBXR5CZoF/jctB71BuLg7d3s=
 github.com/r3labs/sse v0.0.0-20201126193848-34e640891548/go.mod h1:S8xSOnV3CgpNrWd0GQ/OoQfMtlg2uPRSuTzcSGrzwK8=
+github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=
+github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
@@ -429,8 +427,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
-golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -1,0 +1,56 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/r3labs/sse"
+	"gopkg.in/cenkalti/backoff.v1"
+)
+
+// SSE is the interface for the underlying SSE client we're using
+type SSE interface {
+	SubscribeWithContext(ctx context.Context, stream string, handler func(msg *sse.Event)) error
+}
+
+// SSEClient is an implementation of the Subscriber interface for interacting with SSE Streams
+type SSEClient struct {
+	log log.Logger
+	sse SSE
+}
+
+// NewSSEClient creates an SSEClient
+func NewSSEClient(l log.Logger, url string, key string, token string, clusterIdentfier string) *SSEClient {
+	c := sse.NewClient(fmt.Sprintf("%s/stream?clusterIdentifier=%s", url, clusterIdentfier))
+	c.Headers = map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", token),
+		"API-Key":       key,
+	}
+	c.ReconnectStrategy = &backoff.StopBackOff{}
+
+	return &SSEClient{
+		log: l,
+		sse: c,
+	}
+}
+
+// Sub makes SSEClient implement the Stream & Subscriber interfaces
+func (c *SSEClient) Sub(ctx context.Context, channel string, _ string, fn HandleMessageFn) error {
+	err := c.sse.SubscribeWithContext(ctx, channel, func(msg *sse.Event) {
+		// If we get a message with no data we just want to carry on and receive the next message
+		if len(msg.Data) <= 0 {
+			return
+		}
+
+		// If the callback handling the message errors we probably don't want to bubble
+		// the error up and kill the subscription so just log it and carry on
+		if err := fn("", msg); err != nil {
+			c.log.Warn("failed to handle message", "err", err)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrSubscribing, err)
+	}
+	return nil
+}

--- a/stream/sse_test.go
+++ b/stream/sse_test.go
@@ -1,0 +1,67 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/r3labs/sse"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockSSEClient struct {
+	sub func() error
+}
+
+func (m mockSSEClient) SubscribeWithContext(ctx context.Context, stream string, fn func(msg *sse.Event)) error {
+	return m.sub()
+}
+
+func TestSSEClient_Sub(t *testing.T) {
+	type mocks struct {
+		sseClient mockSSEClient
+	}
+
+	type expected struct {
+		err error
+	}
+
+	testCases := map[string]struct {
+		mocks     mocks
+		shouldErr bool
+		expected  expected
+	}{
+		"Given the underlying SSEClient errors when I call Sub": {
+			mocks: mocks{sseClient: mockSSEClient{sub: func() error {
+				return errors.New("an error")
+			}}},
+
+			shouldErr: true,
+			expected:  expected{err: ErrSubscribing},
+		},
+		"Given the underlying SSEClient doesn't error when I call Sub": {
+			mocks: mocks{sseClient: mockSSEClient{sub: func() error {
+				return nil
+			}}},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			sc := SSEClient{sse: tc.mocks.sseClient}
+			err := sc.Sub(context.Background(), "", "", nil)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+				assert.True(t, errors.Is(err, tc.expected.err))
+			} else {
+				assert.Nil(t, err)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
**What**

- Create a client for interacting with SSE streams that implements the
  Subscriber interface
- Adds a `Stream` client to the client services package that we can use
  to start up a stream with SaaS

**Why**

- We need to subscribe to this stream on startup so we can receive
  events to let us know if flags/segments/environment config has changed

**Testing**

- Just unit tests for now