### PR TITLE
FFM-9552 Create MessageHandler for refreshing cache

### DIFF
--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -1,0 +1,106 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/harness/ff-proxy/v2/log"
+
+	"github.com/harness/ff-proxy/v2/domain"
+)
+
+const (
+	// domainFeature identifies flag messages from ff server or stream
+	domainFeature = "flag"
+
+	// domainSegment identifies segment messages from ff server or stream
+	domainSegment = "target-segment"
+
+	// domainProxy identifiers proxy messages from the ff server
+	domainProxy = "proxy"
+
+	// patchEvent identifies a patch event from the SSE stream
+	patchEvent = "patch"
+
+	// deleteEvent identifies a delete event from the SSE stream
+	deleteEvent = "delete"
+
+	//createEvent identifies a create event from the SSE stream
+	createEvent = "create"
+
+	proxyKeyDeleted     = "proxyKeyDeleted"
+	environmentsAdded   = "environmentsAdded"
+	environmentsRemoved = "environmentsRemoved"
+	apiKeyAdded         = "apiKeyAdded"
+	apiKeyRemoved       = "apiKeyRemoved"
+)
+
+var (
+	// ErrUnexpectedMessageDomain is the error returned when an SSE message has a message domain we aren't expecting
+	ErrUnexpectedMessageDomain = errors.New("unexpected message domain")
+
+	// ErrUnexpectedEventType is the error returned when an SSE message has an event type we aren't expecting
+	ErrUnexpectedEventType = errors.New("unexpected event type")
+)
+
+// Refresher is a type for handling SSE events from Harness Saas
+type Refresher struct {
+	log log.Logger
+}
+
+// NewRefresher creates a Refresher
+func NewRefresher(l log.Logger) Refresher {
+	l = l.With("component", "Refresher")
+	return Refresher{log: l}
+}
+
+// HandleMessage makes Refresher implement the MessageHandler interface
+func (s Refresher) HandleMessage(ctx context.Context, msg domain.SSEMessage) error {
+	switch msg.Domain {
+	case domainFeature:
+		return handleFeatureMessage(ctx, msg)
+	case domainSegment:
+		return handleSegmentMessage(ctx, msg)
+	case domainProxy:
+		return handleProxyMessage(ctx, msg)
+	default:
+		return fmt.Errorf("%w: %s", ErrUnexpectedMessageDomain, msg.Domain)
+	}
+
+}
+
+func handleFeatureMessage(_ context.Context, msg domain.SSEMessage) error {
+	switch msg.Event {
+	case deleteEvent:
+	case patchEvent, createEvent:
+
+	default:
+		return fmt.Errorf("%w %q for FeatureMessage", ErrUnexpectedEventType, msg.Event)
+	}
+	return nil
+}
+
+func handleSegmentMessage(_ context.Context, msg domain.SSEMessage) error {
+	switch msg.Event {
+	case deleteEvent:
+	case patchEvent, createEvent:
+
+	default:
+		return fmt.Errorf("%w %q for SegmentMessage", ErrUnexpectedEventType, msg.Event)
+	}
+	return nil
+}
+
+func handleProxyMessage(_ context.Context, msg domain.SSEMessage) error {
+	switch msg.Event {
+	case proxyKeyDeleted:
+	case environmentsAdded:
+	case environmentsRemoved:
+	case apiKeyAdded:
+	case apiKeyRemoved:
+	default:
+		return fmt.Errorf("%w %q for Proxymessage", ErrUnexpectedEventType, msg.Event)
+	}
+	return nil
+}

--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -1,0 +1,192 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRefresher_HandleMessage(t *testing.T) {
+	type args struct {
+		message domain.SSEMessage
+	}
+
+	type expected struct {
+		err error
+	}
+
+	testCases := map[string]struct {
+		args      args
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I have an SSEMessage with the domain 'Foo'": {
+			args: args{
+				message: domain.SSEMessage{Domain: "Foo"},
+			},
+			expected:  expected{err: ErrUnexpectedMessageDomain},
+			shouldErr: true,
+		},
+		"Given I have an SSEMessage with the domain 'flag' event 'foo'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainFeature,
+					Event:  "foo",
+				},
+			},
+			expected:  expected{err: ErrUnexpectedEventType},
+			shouldErr: true,
+		},
+		"Given I have an SSEMessage with the domain 'target-segment' event 'foo'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainSegment,
+					Event:  "foo",
+				},
+			},
+			expected:  expected{err: ErrUnexpectedEventType},
+			shouldErr: true,
+		},
+		"Given I have an SSEMessage with the domain 'flag' event 'patch'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainFeature,
+					Event:  patchEvent,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'flag' event 'create'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainFeature,
+					Event:  createEvent,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'flag' event 'delete'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainFeature,
+					Event:  deleteEvent,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'target-segment' event 'patch'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainSegment,
+					Event:  patchEvent,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'target-segment' event 'create'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainSegment,
+					Event:  createEvent,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'target-segment' event 'delete'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainSegment,
+					Event:  deleteEvent,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'proxy' event 'foo'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainProxy,
+					Event:  "foo",
+				},
+			},
+			expected:  expected{err: ErrUnexpectedEventType},
+			shouldErr: true,
+		},
+		"Given I have an SSEMessage with the domain 'proxy' event 'proxyKeyDeleted'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainProxy,
+					Event:  proxyKeyDeleted,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'proxy' event 'environmentsAdded'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainProxy,
+					Event:  environmentsAdded,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'proxy' event 'environmentsRemoved'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainProxy,
+					Event:  environmentsRemoved,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'proxy' event 'apiKeyAdded'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainProxy,
+					Event:  apiKeyAdded,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'proxy' event 'apiKeyRemoved'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domainProxy,
+					Event:  apiKeyRemoved,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			r := NewRefresher(log.NewNoOpLogger())
+			err := r.HandleMessage(context.Background(), tc.args.message)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+				assert.True(t, errors.Is(err, tc.expected.err))
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/clients/client_service/stream.go
+++ b/clients/client_service/stream.go
@@ -14,7 +14,7 @@ import (
 )
 
 type messageHandler interface {
-	HandleMessage(m domain.SSEMessage) error
+	HandleMessage(ctx context.Context, m domain.SSEMessage) error
 }
 
 // Stream is the type that subscribes to stream that relays Proxy events and handles events coming off the stream
@@ -49,7 +49,7 @@ func (s Stream) Start(ctx context.Context) {
 						return nil
 					}
 
-					if err := s.messageHandler.HandleMessage(msg); err != nil {
+					if err := s.messageHandler.HandleMessage(ctx, msg); err != nil {
 						return nil
 					}
 

--- a/clients/client_service/stream_test.go
+++ b/clients/client_service/stream_test.go
@@ -30,7 +30,7 @@ type mockMessageHandler struct {
 	msg chan struct{}
 }
 
-func (m *mockMessageHandler) HandleMessage(msg domain.SSEMessage) error {
+func (m *mockMessageHandler) HandleMessage(ctx context.Context, msg domain.SSEMessage) error {
 	m.msg <- struct{}{}
 	return nil
 }

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -310,8 +310,9 @@ func main() {
 	// If this isn't a read replica Proxy then we'll want to start up a stream with the client
 	// service and receive events
 	if !readReplica {
+		messageHandler := cache.NewRefresher(logger)
 		sseClient := stream.NewSSEClient(logger, clientService, proxyKey, conf.Token(), conf.ClusterIdentifier())
-		clientServiceStream := clientservice.NewStream(logger, sseClient, nil)
+		clientServiceStream := clientservice.NewStream(logger, sseClient, messageHandler)
 		clientServiceStream.Start(ctx)
 	}
 


### PR DESCRIPTION
**What**

- Creates a SSEEventHandler type that implements the MessageHandler interface

**Why**

- We can pass this to the type that connects to the SaaS SSE stream and then whenver we receive an event call `SSEEventHandler.HandleMessage`
- For now this type doesn't do anything but in here we'll want to do the following
  - Refresh the cache
  - Forward the event on to SDKs
  - Push the event onto a redis stream so read replicas can forward events on to SDKs

**Testing**

- Unit tests for now. We'll be able to add more tests as we add extra functionality in here