### PR TITLE
FFM-9191 Forward SSE events on to SDKs

### DIFF
--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -10,32 +10,6 @@ import (
 	"github.com/harness/ff-proxy/v2/domain"
 )
 
-const (
-	// domainFeature identifies flag messages from ff server or stream
-	domainFeature = "flag"
-
-	// domainSegment identifies segment messages from ff server or stream
-	domainSegment = "target-segment"
-
-	// domainProxy identifiers proxy messages from the ff server
-	domainProxy = "proxy"
-
-	// patchEvent identifies a patch event from the SSE stream
-	patchEvent = "patch"
-
-	// deleteEvent identifies a delete event from the SSE stream
-	deleteEvent = "delete"
-
-	//createEvent identifies a create event from the SSE stream
-	createEvent = "create"
-
-	proxyKeyDeleted     = "proxyKeyDeleted"
-	environmentsAdded   = "environmentsAdded"
-	environmentsRemoved = "environmentsRemoved"
-	apiKeyAdded         = "apiKeyAdded"
-	apiKeyRemoved       = "apiKeyRemoved"
-)
-
 var (
 	// ErrUnexpectedMessageDomain is the error returned when an SSE message has a message domain we aren't expecting
 	ErrUnexpectedMessageDomain = errors.New("unexpected message domain")
@@ -58,11 +32,11 @@ func NewRefresher(l log.Logger) Refresher {
 // HandleMessage makes Refresher implement the MessageHandler interface
 func (s Refresher) HandleMessage(ctx context.Context, msg domain.SSEMessage) error {
 	switch msg.Domain {
-	case domainFeature:
+	case domain.MsgDomainFeature:
 		return handleFeatureMessage(ctx, msg)
-	case domainSegment:
+	case domain.MsgDomainSegment:
 		return handleSegmentMessage(ctx, msg)
-	case domainProxy:
+	case domain.MsgDomainProxy:
 		return handleProxyMessage(ctx, msg)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnexpectedMessageDomain, msg.Domain)
@@ -72,8 +46,8 @@ func (s Refresher) HandleMessage(ctx context.Context, msg domain.SSEMessage) err
 
 func handleFeatureMessage(_ context.Context, msg domain.SSEMessage) error {
 	switch msg.Event {
-	case deleteEvent:
-	case patchEvent, createEvent:
+	case domain.EventDelete:
+	case domain.EventPatch, domain.EventCreate:
 
 	default:
 		return fmt.Errorf("%w %q for FeatureMessage", ErrUnexpectedEventType, msg.Event)
@@ -83,8 +57,8 @@ func handleFeatureMessage(_ context.Context, msg domain.SSEMessage) error {
 
 func handleSegmentMessage(_ context.Context, msg domain.SSEMessage) error {
 	switch msg.Event {
-	case deleteEvent:
-	case patchEvent, createEvent:
+	case domain.EventDelete:
+	case domain.EventPatch, domain.EventCreate:
 
 	default:
 		return fmt.Errorf("%w %q for SegmentMessage", ErrUnexpectedEventType, msg.Event)
@@ -94,11 +68,11 @@ func handleSegmentMessage(_ context.Context, msg domain.SSEMessage) error {
 
 func handleProxyMessage(_ context.Context, msg domain.SSEMessage) error {
 	switch msg.Event {
-	case proxyKeyDeleted:
-	case environmentsAdded:
-	case environmentsRemoved:
-	case apiKeyAdded:
-	case apiKeyRemoved:
+	case domain.EventProxyKeyDeleted:
+	case domain.EventEnvironmentAdded:
+	case domain.EventEnvironmentRemoved:
+	case domain.EventAPIKeyAdded:
+	case domain.EventAPIKeyRemoved:
 	default:
 		return fmt.Errorf("%w %q for Proxymessage", ErrUnexpectedEventType, msg.Event)
 	}

--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -34,7 +34,7 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'flag' event 'foo'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainFeature,
+					Domain: domain.MsgDomainFeature,
 					Event:  "foo",
 				},
 			},
@@ -44,7 +44,7 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'target-segment' event 'foo'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainSegment,
+					Domain: domain.MsgDomainSegment,
 					Event:  "foo",
 				},
 			},
@@ -54,8 +54,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'flag' event 'patch'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainFeature,
-					Event:  patchEvent,
+					Domain: domain.MsgDomainFeature,
+					Event:  domain.EventPatch,
 				},
 			},
 			expected:  expected{err: nil},
@@ -64,8 +64,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'flag' event 'create'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainFeature,
-					Event:  createEvent,
+					Domain: domain.MsgDomainFeature,
+					Event:  domain.EventCreate,
 				},
 			},
 			expected:  expected{err: nil},
@@ -74,8 +74,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'flag' event 'delete'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainFeature,
-					Event:  deleteEvent,
+					Domain: domain.MsgDomainFeature,
+					Event:  domain.EventDelete,
 				},
 			},
 			expected:  expected{err: nil},
@@ -84,8 +84,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'target-segment' event 'patch'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainSegment,
-					Event:  patchEvent,
+					Domain: domain.MsgDomainSegment,
+					Event:  domain.EventPatch,
 				},
 			},
 			expected:  expected{err: nil},
@@ -94,8 +94,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'target-segment' event 'create'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainSegment,
-					Event:  createEvent,
+					Domain: domain.MsgDomainSegment,
+					Event:  domain.EventCreate,
 				},
 			},
 			expected:  expected{err: nil},
@@ -104,8 +104,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'target-segment' event 'delete'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainSegment,
-					Event:  deleteEvent,
+					Domain: domain.MsgDomainSegment,
+					Event:  domain.EventDelete,
 				},
 			},
 			expected:  expected{err: nil},
@@ -114,7 +114,7 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'proxy' event 'foo'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainProxy,
+					Domain: domain.MsgDomainProxy,
 					Event:  "foo",
 				},
 			},
@@ -124,8 +124,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'proxy' event 'proxyKeyDeleted'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainProxy,
-					Event:  proxyKeyDeleted,
+					Domain: domain.MsgDomainProxy,
+					Event:  domain.EventProxyKeyDeleted,
 				},
 			},
 			expected:  expected{err: nil},
@@ -134,8 +134,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'proxy' event 'environmentsAdded'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainProxy,
-					Event:  environmentsAdded,
+					Domain: domain.MsgDomainProxy,
+					Event:  domain.EventEnvironmentAdded,
 				},
 			},
 			expected:  expected{err: nil},
@@ -144,8 +144,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'proxy' event 'environmentsRemoved'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainProxy,
-					Event:  environmentsRemoved,
+					Domain: domain.MsgDomainProxy,
+					Event:  domain.EventEnvironmentRemoved,
 				},
 			},
 			expected:  expected{err: nil},
@@ -154,8 +154,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'proxy' event 'apiKeyAdded'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainProxy,
-					Event:  apiKeyAdded,
+					Domain: domain.MsgDomainProxy,
+					Event:  domain.EventAPIKeyAdded,
 				},
 			},
 			expected:  expected{err: nil},
@@ -164,8 +164,8 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		"Given I have an SSEMessage with the domain 'proxy' event 'apiKeyRemoved'": {
 			args: args{
 				message: domain.SSEMessage{
-					Domain: domainProxy,
-					Event:  apiKeyRemoved,
+					Domain: domain.MsgDomainProxy,
+					Event:  domain.EventAPIKeyRemoved,
 				},
 			},
 			expected:  expected{err: nil},

--- a/clients/client_service/stream.go
+++ b/clients/client_service/stream.go
@@ -13,19 +13,15 @@ import (
 	"github.com/r3labs/sse/v2"
 )
 
-type messageHandler interface {
-	HandleMessage(ctx context.Context, m domain.SSEMessage) error
-}
-
 // Stream is the type that subscribes to stream that relays Proxy events and handles events coming off the stream
 type Stream struct {
 	log            log.Logger
 	subscriber     stream.Subscriber
-	messageHandler messageHandler
+	messageHandler domain.MessageHandler
 }
 
 // NewStream opens a subscription to the client service's stream endpoint
-func NewStream(l log.Logger, s stream.Subscriber, m messageHandler) Stream {
+func NewStream(l log.Logger, s stream.Subscriber, m domain.MessageHandler) Stream {
 	l = l.With("component", "Start")
 	return Stream{
 		log:            l,
@@ -60,6 +56,7 @@ func (s Stream) Start(ctx context.Context) {
 						return
 					}
 
+					s.log.Warn("disconnected from Harness SaaS stream, backing off and retrying in 30 seconds: %s", err)
 					time.Sleep(30 * time.Second)
 				}
 			}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 
 	jsoniter "github.com/json-iterator/go"
@@ -70,4 +71,18 @@ func SafePtrDereference[T any](t *T) T {
 		return d
 	}
 	return *t
+}
+
+// MessageHandler defines the interface for handling an SSE message
+type MessageHandler interface {
+	HandleMessage(ctx context.Context, m SSEMessage) error
+}
+
+// NoOpMessageHandler is a message handler that does nothing
+type NoOpMessageHandler struct {
+}
+
+// HandleMessage makes NoOpMessageHandler implement the MessageHandler interface
+func (n NoOpMessageHandler) HandleMessage(_ context.Context, _ SSEMessage) error {
+	return nil
 }

--- a/domain/sse.go
+++ b/domain/sse.go
@@ -2,8 +2,36 @@ package domain
 
 // SSEMessage is basic object for marshalling data from ff stream
 type SSEMessage struct {
-	Event      string `json:"event"`
-	Domain     string `json:"domain"`
-	Identifier string `json:"identifier"`
-	Version    int    `json:"version"`
+	Event        string   `json:"event"`
+	Domain       string   `json:"domain"`
+	Identifier   string   `json:"identifier"`
+	Version      int      `json:"version"`
+	Environment  string   `json:"environment"`
+	Environments []string `json:"environments,omitempty"`
 }
+
+const (
+	// MsgDomainFeature identifies flag messages from ff server or stream
+	MsgDomainFeature = "flag"
+
+	// MsgDomainSegment identifies segment messages from ff server or stream
+	MsgDomainSegment = "target-segment"
+
+	// MsgDomainProxy identifiers proxy messages from the ff server
+	MsgDomainProxy = "proxy"
+
+	// EventPatch identifies a patch event from the SSE stream
+	EventPatch = "patch"
+
+	// EventDelete identifies a delete event from the SSE stream
+	EventDelete = "delete"
+
+	// EventCreate identifies a create event from the SSE stream
+	EventCreate = "create"
+
+	EventProxyKeyDeleted    = "proxyKeyDeleted"
+	EventEnvironmentAdded   = "environmentsAdded"
+	EventEnvironmentRemoved = "environmentsRemoved"
+	EventAPIKeyAdded        = "apiKeyAdded"
+	EventAPIKeyRemoved      = "apiKeyRemoved"
+)

--- a/stream/forwarder.go
+++ b/stream/forwarder.go
@@ -1,0 +1,52 @@
+package stream
+
+import (
+	"context"
+
+	"github.com/harness/ff-proxy/v2/domain"
+
+	"github.com/harness/ff-proxy/v2/log"
+)
+
+// Forwarder is a type that can be used to handle messages from a stream and
+// forward them on to another stream
+type Forwarder struct {
+	log    log.Logger
+	next   domain.MessageHandler
+	stream Publisher
+}
+
+// NewForwarder creates a Forwarder
+func NewForwarder(l log.Logger, stream Publisher, next domain.MessageHandler) Forwarder {
+	l = l.With("component", "Forwarder")
+	return Forwarder{
+		log:    l,
+		next:   next,
+		stream: stream,
+	}
+}
+
+// HandleMessage makes Forwarder implement the MessageHandler interface. It calls the decorated
+// MessageHandler and once that's returned forwards it on to the next stream.
+func (s Forwarder) HandleMessage(ctx context.Context, msg domain.SSEMessage) (err error) {
+	defer func() {
+		// If we get an error handling the message we probably don't want to forward it on
+		if err != nil {
+			return
+		}
+
+		// Flag and TargetSegment change messages are the only ones we need to care about
+		// forwarding on to the read replica Proxy or SDKs
+		if msg.Domain != domain.MsgDomainFeature && msg.Domain != domain.MsgDomainSegment {
+			return
+		}
+
+		topic := msg.Environment
+
+		if err := s.stream.Pub(ctx, topic, msg); err != nil {
+			s.log.Error("failed to forward SSEEvent to channel=%s: %s", "", err)
+		}
+	}()
+
+	return s.next.HandleMessage(ctx, msg)
+}

--- a/stream/forwarder_test.go
+++ b/stream/forwarder_test.go
@@ -1,0 +1,196 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/harness/ff-proxy/v2/domain"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/harness/ff-proxy/v2/log"
+)
+
+type mockPublisher struct {
+	*sync.Mutex
+	pub             func() error
+	eventsForwarded int
+}
+
+func (m *mockPublisher) Pub(ctx context.Context, channel string, value interface{}) error {
+	m.Lock()
+	defer m.Unlock()
+	m.eventsForwarded++
+	return m.pub()
+}
+
+func (m *mockPublisher) getEventsForwarded() int {
+	m.Lock()
+	defer m.Unlock()
+	return m.eventsForwarded
+}
+
+type mockMessageHandler struct {
+	handleMessage func() error
+}
+
+func (m mockMessageHandler) HandleMessage(ctx context.Context, msg domain.SSEMessage) error {
+	return m.handleMessage()
+}
+
+func TestForwarder_HandleMesssage(t *testing.T) {
+	type args struct {
+		message domain.SSEMessage
+	}
+
+	type mocks struct {
+		publisher      *mockPublisher
+		messageHandler mockMessageHandler
+	}
+
+	type expected struct {
+		eventsForwarded int
+	}
+
+	testCases := map[string]struct {
+		args      args
+		mocks     mocks
+		expected  expected
+		shouldErr bool
+	}{
+		"Given the wrapper MessageHandler fails to handle the message": {
+			args: args{message: domain.SSEMessage{}},
+			mocks: mocks{
+				publisher: &mockPublisher{Mutex: &sync.Mutex{}},
+				messageHandler: mockMessageHandler{handleMessage: func() error {
+					return errors.New("an error")
+				}},
+			},
+			expected: expected{
+				eventsForwarded: 0,
+			},
+			shouldErr: true,
+		},
+		"Given I have an SSEMessage with an empty domain": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: "",
+				},
+			},
+			mocks: mocks{
+				publisher: &mockPublisher{Mutex: &sync.Mutex{}},
+				messageHandler: mockMessageHandler{handleMessage: func() error {
+					return nil
+				}},
+			},
+			expected: expected{
+				eventsForwarded: 0,
+			},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with a domain that isn't 'flag' or 'target-segment'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: "foo",
+				},
+			},
+			mocks: mocks{
+				publisher: &mockPublisher{Mutex: &sync.Mutex{}},
+				messageHandler: mockMessageHandler{handleMessage: func() error {
+					return nil
+				}},
+			},
+			expected: expected{
+				eventsForwarded: 0,
+			},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'flag' but the stream fails to publish": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domain.MsgDomainFeature,
+				},
+			},
+			mocks: mocks{
+				publisher: &mockPublisher{
+					Mutex: &sync.Mutex{},
+					pub: func() error {
+						return errors.New("an error")
+					},
+				},
+				messageHandler: mockMessageHandler{handleMessage: func() error {
+					return nil
+				}},
+			},
+			expected: expected{
+				eventsForwarded: 1,
+			},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'flag'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domain.MsgDomainFeature,
+				},
+			},
+			mocks: mocks{
+				publisher: &mockPublisher{
+					Mutex: &sync.Mutex{},
+					pub: func() error {
+						return nil
+					},
+				},
+				messageHandler: mockMessageHandler{handleMessage: func() error {
+					return nil
+				}},
+			},
+			expected: expected{
+				eventsForwarded: 1,
+			},
+			shouldErr: false,
+		},
+		"Given I have an SSEMessage with the domain 'target-segment'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domain.MsgDomainSegment,
+				},
+			},
+			mocks: mocks{
+				publisher: &mockPublisher{
+					Mutex: &sync.Mutex{},
+					pub: func() error {
+						return nil
+					},
+				},
+				messageHandler: mockMessageHandler{handleMessage: func() error {
+					return nil
+				}},
+			},
+			expected: expected{
+				eventsForwarded: 1,
+			},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			s := NewForwarder(log.NewNoOpLogger(), tc.mocks.publisher, tc.mocks.messageHandler)
+
+			err := s.HandleMessage(context.Background(), tc.args.message)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tc.expected.eventsForwarded, tc.mocks.publisher.getEventsForwarded())
+		})
+	}
+}

--- a/stream/pushpin.go
+++ b/stream/pushpin.go
@@ -1,0 +1,49 @@
+package stream
+
+import (
+	"context"
+	"fmt"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/fanout/go-pubcontrol"
+)
+
+// GripStream is the interface for publishing events to a grip channel
+type gripStream interface {
+	// PublishHttpStream publishes an HTTP stream format message to all the configured PubControlClients
+	// with a specified channel, message, and optional ID, previous ID, and callback.
+	// Note that the 'http_stream' parameter can be provided as either an HttpStreamFormat
+	// instance or a string / byte array (in which case an HttpStreamFormat instance will
+	// automatically be created and have the 'content' field set to the specified value).
+	PublishHttpStream(channel string, content interface{}, id string, prevID string) error
+
+	Publish(channel string, item *pubcontrol.Item) error
+}
+
+// Pushpin is a type that implements the Publisher interface and is used to publish to pushpin channels
+type Pushpin struct {
+	stream gripStream
+}
+
+// NewPushpin creates a new Pushpin
+func NewPushpin(gs gripStream) Pushpin {
+	return Pushpin{
+		stream: gs,
+	}
+}
+
+// Pub makes Pushpin implement the Publisher interface and is used to publish messages to a pushpin channel
+func (p Pushpin) Pub(_ context.Context, channel string, value interface{}) error {
+	b, err := jsoniter.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("%w: failed to marshal message to bytes: %s", ErrPublishing, err)
+	}
+
+	content := fmt.Sprintf("event: *\ndata: %s\n\n", b)
+
+	if err := p.stream.PublishHttpStream(channel, content, "", ""); err != nil {
+		return fmt.Errorf("PushpinStream: %w: %s", ErrPublishing, err)
+	}
+	return nil
+}

--- a/stream/pushpin_test.go
+++ b/stream/pushpin_test.go
@@ -1,0 +1,81 @@
+package stream
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fanout/go-pubcontrol"
+)
+
+type mockGripStream struct {
+	pub func() error
+}
+
+func (m mockGripStream) PublishHttpStream(channel string, content interface{}, id string, prevID string) error {
+	return m.pub()
+}
+
+func (m mockGripStream) Publish(channel string, item *pubcontrol.Item) error {
+	return nil
+}
+
+func TestPushpin_Pub(t *testing.T) {
+	type args struct {
+		message interface{}
+	}
+	type mocks struct {
+		gripStream mockGripStream
+	}
+
+	type expected struct {
+		err error
+	}
+
+	testCases := map[string]struct {
+		args      args
+		mocks     mocks
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I call Pub and the gripStream client errors": {
+			args: args{message: "foo"},
+			mocks: mocks{gripStream: mockGripStream{
+				pub: func() error {
+					return errors.New("an error")
+				},
+			}},
+			shouldErr: true,
+			expected:  expected{err: ErrPublishing},
+		},
+		"Given I call Pub and the gripStream client doesn't error": {
+			args: args{message: "foo"},
+			mocks: mocks{gripStream: mockGripStream{
+				pub: func() error {
+					return nil
+				},
+			}},
+			shouldErr: false,
+			expected:  expected{err: nil},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			p := NewPushpin(tc.mocks.gripStream)
+			err := p.Pub(context.Background(), "", "foo")
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+				assert.True(t, errors.Is(err, tc.expected.err))
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/stream/redis.go
+++ b/stream/redis.go
@@ -43,7 +43,7 @@ func (r RedisStream) Pub(ctx context.Context, stream string, v interface{}) erro
 		Values: formatRedisMessage(values),
 		MaxLen: r.maxLen,
 	}).Err(); err != nil {
-		return fmt.Errorf(":%w: %s", ErrPublishing, err)
+		return fmt.Errorf("RedisStream: %w: %s", ErrPublishing, err)
 	}
 
 	return nil
@@ -68,7 +68,7 @@ func (r RedisStream) Sub(ctx context.Context, stream string, id string, handleMe
 				Block:   0,
 			}).Result()
 			if err != nil {
-				return fmt.Errorf("%w: %s", ErrSubscribing, err)
+				return fmt.Errorf("RedisStream: %w: %s", ErrSubscribing, err)
 			}
 
 			for _, x := range xs {

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/harness/ff-proxy/v2/log"
-	"github.com/r3labs/sse"
+	"github.com/r3labs/sse/v2"
 	"gopkg.in/cenkalti/backoff.v1"
 )
 
@@ -21,8 +21,8 @@ type SSEClient struct {
 }
 
 // NewSSEClient creates an SSEClient
-func NewSSEClient(l log.Logger, url string, key string, token string, clusterIdentfier string) *SSEClient {
-	c := sse.NewClient(fmt.Sprintf("%s/stream?clusterIdentifier=%s", url, clusterIdentfier))
+func NewSSEClient(l log.Logger, url string, key string, token string) *SSEClient {
+	c := sse.NewClient(url)
 	c.Headers = map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", token),
 		"API-Key":       key,

--- a/stream/sse_test.go
+++ b/stream/sse_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/r3labs/sse"
+	"github.com/r3labs/sse/v2"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
**What**

- Adds code to implement forwarding SSE events to SDKs
  - Creates a `Pushpin` client that implements our Publisher interface. This is used for publishing events to the Proxy's puhspin
  - Creates a 'Stream Forwarder' which is used for handling SSE messages and forwarding them on to another stream. We can reuse this for forwarding events to Redis by just passing in a redis client instead of a Pushpin client.
- Does a little refactoring moving some types, constants that are used by multiple package to `domain`

**Why**

- When the Proxy receives an SSE event from ff-server it needs to
  forward it on to connected SDKs so they know a change has occured

**Testing**

- Unit tests
- Running a local ff-server, proxy & SDK. When my SDK is connected to
  the Proxy and I toggle a flag on/off in ff-server I can see the SDK
getting the event. The SDK doesn't get the correct evaluation yet
because we haven't implemented the cache refreshing yet.



https://github.com/harness/ff-proxy/assets/16992818/267aa22c-572b-49d0-bd19-0d3c6ba5c830


