### PR TITLE
FFM-9192 Forward SSE events onto redis

### DIFF
--- a/domain/sse.go
+++ b/domain/sse.go
@@ -1,5 +1,7 @@
 package domain
 
+import jsoniter "github.com/json-iterator/go"
+
 // SSEMessage is basic object for marshalling data from ff stream
 type SSEMessage struct {
 	Event        string   `json:"event"`
@@ -8,6 +10,11 @@ type SSEMessage struct {
 	Version      int      `json:"version"`
 	Environment  string   `json:"environment"`
 	Environments []string `json:"environments,omitempty"`
+}
+
+// MarshalBinary makes SSEMessage implement the BinaryMarshaler interface
+func (s SSEMessage) MarshalBinary() ([]byte, error) {
+	return jsoniter.Marshal(s)
 }
 
 const (


### PR DESCRIPTION
**What**

- Forwards SSE events onto redis

**Why**

- Read replica Proxy's have no connection to Harness SaaS so need a way to recevie SSE events for changes and pass them on to SDKs. Getting the 'Writer' Proxy to forward the events on to a redis stream means that Read Replica's can subscribe to this stream and forward SSE events on to SDKs

**Testing**

- Added a unit test for when we've multiple Forwarders but to really test this logic we'll need to add e2e tests.
- Tested locally 

https://github.com/harness/ff-proxy/assets/16992818/a8bac085-cf6a-4360-a484-545716bb524a


