### PR TITLE
FFM-9620 Poll SaaS for changes when the stream disconnects

### DIFF
--- a/stream/sse.go
+++ b/stream/sse.go
@@ -27,6 +27,9 @@ func NewSSEClient(l log.Logger, url string, key string, token string) *SSEClient
 		"Authorization": fmt.Sprintf("Bearer %s", token),
 		"API-Key":       key,
 	}
+
+	// don't use the default exponentialBackoff strategy - we'll have our own disconnect logic
+	// that we'll implement
 	c.ReconnectStrategy = &backoff.StopBackOff{}
 
 	return &SSEClient{


### PR DESCRIPTION
**What**

- Adds an optional onDisconnect function to the `Stream` type. This  gets called
whenever we exit the `Sub` method which happens any time we have a
stream connection that disconnects or if we fail trying to
connect/reconnect to the stream
- Adds a Backoffer to the `Stream` type. This defaults to one minute

**Why**

- If the SaaS -> Proxy stream disconnects we need to get the Proxy to
  poll SaaS for changes to make sure it doesn't miss out on any. These
changes mean that if the SaaS -> Proxy stream disconnects we'll poll
every `backoffDuration` until the stream reconnects

**Testing**

- Unit tests
- Tested out locally