### PR TITLE
FFM-9631 - Disconnect SDK streams in Read Replica

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
@@ -72,20 +71,6 @@ func SafePtrDereference[T any](t *T) T {
 		return d
 	}
 	return *t
-}
-
-// MessageHandler defines the interface for handling an SSE message
-type MessageHandler interface {
-	HandleMessage(ctx context.Context, m SSEMessage) error
-}
-
-// NoOpMessageHandler is a message handler that does nothing
-type NoOpMessageHandler struct {
-}
-
-// HandleMessage makes NoOpMessageHandler implement the MessageHandler interface
-func (n NoOpMessageHandler) HandleMessage(_ context.Context, _ SSEMessage) error {
-	return nil
 }
 
 // SafeMap is a map of environmentIDs to sdks

--- a/domain/message_handlers.go
+++ b/domain/message_handlers.go
@@ -1,0 +1,53 @@
+package domain
+
+import (
+	"context"
+	"io"
+)
+
+// MessageHandler defines the interface for handling an SSE message
+type MessageHandler interface {
+	HandleMessage(ctx context.Context, m SSEMessage) error
+}
+
+// NoOpMessageHandler is a message handler that does nothing
+type NoOpMessageHandler struct {
+}
+
+// HandleMessage makes NoOpMessageHandler implement the MessageHandler interface
+func (n NoOpMessageHandler) HandleMessage(_ context.Context, _ SSEMessage) error {
+	return nil
+}
+
+// ReadReplicaMessageHandler defines the message handler used by the read replica.
+// The ReadReplica doesn't need to care about 99% of the messages it receives, and
+// the only thing it really needs to do is forward these messages on to any connected
+// SDKs. However, if the 'Writer' Proxy connects/disconnects from the Harness SaaS stream,
+// it sends a message to the read replica(s) to let them know about this event.
+//
+// The Replica can then use these events to forcibly disconnect SDKs and block new stream
+// requests until the Writer Proxy -> SaaS stream has been reestablished
+type ReadReplicaMessageHandler struct {
+}
+
+// NewReadReplicaMessageHandler creates a ReadReplicaMessageHandler
+func NewReadReplicaMessageHandler() ReadReplicaMessageHandler {
+	return ReadReplicaMessageHandler{}
+}
+
+// HandleMessage makes ReadReplicaMessageHandler implement the MessageHandler interface.
+// It checks the message's event type & domain and calls the appropriate method to deal with these.
+func (r ReadReplicaMessageHandler) HandleMessage(_ context.Context, msg SSEMessage) error {
+	// Any other event types we don't care about, we just want our chain of message handlers
+	// to forward this on to pushpin so SDKs get these events.
+	if msg.Event != "stream_action" {
+		return nil
+	}
+
+	// Return EOF to indicate the stream was closed
+	if msg.Domain == "disconnect" {
+		return io.EOF
+	}
+
+	return nil
+}

--- a/stream/on_connect_disconnect_handlers.go
+++ b/stream/on_connect_disconnect_handlers.go
@@ -1,0 +1,82 @@
+package stream
+
+import (
+	"context"
+	"time"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
+)
+
+// pollFn defines the function that polls Harness SaaS for changes
+type pollFn func() error
+
+// getConnectedStreamsFn defines the function that returns the names of open streams between the Proxy & SDKs
+type getConnectedStreamsFn func() map[string]interface{}
+
+// SaasStreamOnDisconnect is called anytime we disconnect or fail to reconnect to the SaaS SSE stream and does the following
+// - Sets the status of the SaaS stream in the cache to unhealthy, this means any new /stream requests to writer or read proxy's will be rejects
+// - Polls saas for the latest config and refreshes the cache with any changes
+// - Closes any 'Write Replica' Proxy -> SDK streams
+// - Notifies 'read replica' proxy's that there's been a disconnection between the 'Write replica' and SaaS
+func SaasStreamOnDisconnect(l log.Logger, streamHealth Health, pp Pushpin, redisSSEStream Stream, streams getConnectedStreamsFn, pollFn pollFn) func() {
+	return func() {
+		l.Info("disconnected from Harness SaaS SSE Stream")
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		// Set to false so the ProxyService will reject any /stream requests from SDKs until we've reconnected
+		_ = streamHealth.SetUnhealthy(ctx)
+
+		// Poll latest config from SaaS, this is to make sure we don't miss any changes that could have
+		// happened while the stream was disconnected
+		if err := pollFn(); err != nil {
+			l.Error("SSE stream disconnected, failed to poll for new config", "err", err)
+		} else {
+			l.Info("successfully polled Harness SaaS for changes")
+		}
+
+		// Close any open stream between this Proxy and SDKs. This is to force SDKs to poll the Proxy for
+		// changes until we've a healthy SaaS -> Proxy stream to make sure they don't miss out on changes
+		// the Proxy may have pulled down while the Proxy -> Saas stream was down.
+		for streamID := range streams() {
+			if err := pp.CloseStream(streamID); err != nil {
+				l.Error("failed to close Proxy->SDK stream", "streamID", streamID, "err", err)
+			}
+		}
+
+		// Publish an event to the redis stream that the read replica proxy's are listening on to let them
+		// know we've disconnected from SaaS.
+		if err := redisSSEStream.Publish(ctx, domain.SSEMessage{Event: "stream_action", Domain: "disconnect"}); err != nil {
+			l.Error("failed to publish stream disconnect message to redis", "err", err)
+		}
+	}
+}
+
+// SaasStreamOnConnect sets the status of the SaaS stream to healthy in the cache
+func SaasStreamOnConnect(l log.Logger, streamHealth Health) func() {
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		defer cancel()
+
+		l.Info("connected to Harness SaaS SSE Stream")
+		if err := streamHealth.SetHealthy(ctx); err != nil {
+			l.Error("failed to update SaaS stream status in cache", "err", err)
+		}
+	}
+}
+
+// ReadReplicaSSEStreamOnDisconnect closes any open 'Read Replica' Proxy -> SDK streams
+func ReadReplicaSSEStreamOnDisconnect(l log.Logger, pp Pushpin, streams getConnectedStreamsFn) func() {
+	return func() {
+		// Close any open stream between this Proxy and SDKs. This is to force SDKs to poll the Proxy for
+		// changes until we've a healthy SaaS -> Proxy stream to make sure they don't miss out on changes
+		// the Proxy may have pulled down while the Proxy -> Saas stream was down.
+		for streamID := range streams() {
+			if err := pp.CloseStream(streamID); err != nil {
+				l.Error("failed to close Proxy->SDK stream", "streamID", streamID, "err", err)
+			}
+		}
+	}
+}

--- a/stream/redis.go
+++ b/stream/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding"
 	"fmt"
+	"io"
 
 	"github.com/go-redis/redis/v8"
 )
@@ -74,6 +75,11 @@ func (r RedisStream) Sub(ctx context.Context, stream string, id string, handleMe
 			for _, x := range xs {
 				for _, msg := range x.Messages {
 					if err := handleMessage(msg.ID, parseRedisMessage(msg.Values)); err != nil {
+						// If we get an EOF error then we'll want to bubble this up since this
+						// signals that there's been a disconnect
+						if err == io.EOF {
+							return err
+						}
 						continue
 					}
 				}

--- a/stream/redis_test.go
+++ b/stream/redis_test.go
@@ -3,6 +3,7 @@ package stream
 import (
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
@@ -134,6 +135,17 @@ func TestRedisStream_Sub(t *testing.T) {
 			expected: expected{
 				messages: []interface{}{"foo", "bar"},
 				err:      context.Canceled,
+			},
+		},
+		"Given I have two messages and the callback errors with EOF then I will NOT get both messages": {
+			stream:      "test-stream",
+			messages:    []string{"foo", "bar"},
+			callbackErr: io.EOF,
+
+			shouldErr: true,
+			expected: expected{
+				messages: []interface{}{"foo"},
+				err:      io.EOF,
 			},
 		},
 		"Given I have two messages and redis doesn't error": {

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -57,3 +57,11 @@ func (s *SSEClient) Sub(ctx context.Context, channel string, _ string, fn Handle
 	}
 	return nil
 }
+
+// Pub ...
+// TODO: Temporarily adding this to make this type implement the Stream interface. There's some
+// cleaner refactoring I can do around this and the pushpin type but I don't want to make this
+// PR bigger than it needs to be.
+func (s *SSEClient) Pub(_ context.Context, _ string, _ interface{}) error {
+	return nil
+}

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -26,6 +26,8 @@ func (m *mockSubscriber) Sub(ctx context.Context, channel string, id string, fn 
 	return fn("", v)
 }
 
+func (m *mockSubscriber) Pub(ctx context.Context, channel string, msg interface{}) error { return nil }
+
 type mockMsgHandler struct {
 	msg chan struct{}
 }


### PR DESCRIPTION
**What**

- Makes changes so that when we're running a 'Writer' Proxy & 'Read Replica' Proxy and the SaaS stream goes down the following happens
  - Writer Proxy updates the key in the cache with the  streams health to be unhealthy
  - Writer Proxy kills any streams SDKs have with it
  - Writer Proxy publishes a 'disconnect' event to a redis stream that Read Replicas subscribe to 
  - Read replica gets the 'disconnect' event and closes any streams SDKs have with it
- Did a bit of refactoring to move some of the `OnConnect` `OnDisconnect` functions out of the main.go as they were starting to get a bit messy in there

**Why**

If the Writer Proxy -> SaaS stream is down we need to kill all SDK streams whether they're connected to a 'Writer' Proxy or Read replica Proxy to force the SDKs to poll the Proxy's for changes. Once the Writer Proxy -> Saas stream is back up then we allow streaming connections to all Proxy's. 

**Testing**

- Really need e2e tests to test this properly but I have been able to test this all out locally doing the following
  - Start ff-server & ff-server-pushpin
  -  Start 'Writer' Proxy
  - Start Read replica Proxy
  - Hit Read replica Proxy's /stream endpoint
  - Toggle a flag & the Read Replica Proxy forwards on the event
  - Kill ff-server-pushpin
  - The `/stream` request with the Read Replica Proxy is killed 
  - When I try to hit /stream again my request is rejected until I bring ff-server-pushpin back up and the Writer is able to reestablish the stream
