### PR TITLE
[FFM-9612]: Add a new environment - fetch proxyConfig for the environment

### DIFF
--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/harness/ff-proxy/v2/domain"
 	"github.com/harness/ff-proxy/v2/log"
 )
@@ -97,7 +98,7 @@ func (s Refresher) handleProxyMessage(ctx context.Context, msg domain.SSEMessage
 	return nil
 }
 
-//handleAddEnvironmentEvent fetches proxyConfig for all added environments and sets them on.
+// handleAddEnvironmentEvent fetches proxyConfig for all added environments and sets them on.
 func (s Refresher) handleAddEnvironmentEvent(ctx context.Context, environments []string) error {
 	for _, env := range environments {
 		input := domain.GetProxyConfigInput{

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -75,6 +75,7 @@ func handleSegmentMessage(_ context.Context, msg domain.SSEMessage) error {
 func (s Refresher) handleProxyMessage(ctx context.Context, msg domain.SSEMessage) error {
 	switch msg.Event {
 	case domain.EventProxyKeyDeleted:
+		// todo
 		return nil
 	case domain.EventEnvironmentAdded:
 		if err := s.handleAddEnvironmentEvent(ctx, msg.Environments); err != nil {
@@ -82,10 +83,13 @@ func (s Refresher) handleProxyMessage(ctx context.Context, msg domain.SSEMessage
 			return err
 		}
 	case domain.EventEnvironmentRemoved:
+		// todo
 		return nil
 	case domain.EventAPIKeyAdded:
+		// todo
 		return nil
 	case domain.EventAPIKeyRemoved:
+		// todo
 		return nil
 	default:
 		return fmt.Errorf("%w %q for Proxymessage", ErrUnexpectedEventType, msg.Event)

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -110,13 +110,10 @@ func (s Refresher) handleAddEnvironmentEvent(ctx context.Context, environments [
 			PageSize:          10,
 		}
 		// fetch the proxy config.
-		proxyConfig, err := s.clientService.PageProxyConfig(ctx, input)
+		_, err := s.clientService.PageProxyConfig(ctx, input)
 		if err != nil {
 			s.log.Error("unable to fetch config for the environment: ", env)
 			return err
-		}
-		if len(proxyConfig) > 0 {
-			// todo set proxy config.
 		}
 	}
 	return nil

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
-	"github.com/harness/ff-proxy/v2/log"
-
 	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
 )
 
 var (
@@ -20,13 +18,20 @@ var (
 
 // Refresher is a type for handling SSE events from Harness Saas
 type Refresher struct {
-	log log.Logger
+	proxyKey          string
+	authToken         string
+	clusterIdentifier string
+	log               log.Logger
+	clientService     domain.ClientService
+	authRepo          domain.AuthRepo
+	featureRepo       domain.FeatureFlag
+	segmentRepo       domain.SegmentRepo
 }
 
 // NewRefresher creates a Refresher
-func NewRefresher(l log.Logger) Refresher {
+func NewRefresher(l log.Logger, proxyKey, authToken, clusterIdentifier string, client domain.ClientService) Refresher {
 	l = l.With("component", "Refresher")
-	return Refresher{log: l}
+	return Refresher{log: l, proxyKey: proxyKey, authToken: authToken, clusterIdentifier: clusterIdentifier, clientService: client}
 }
 
 // HandleMessage makes Refresher implement the MessageHandler interface
@@ -37,7 +42,7 @@ func (s Refresher) HandleMessage(ctx context.Context, msg domain.SSEMessage) err
 	case domain.MsgDomainSegment:
 		return handleSegmentMessage(ctx, msg)
 	case domain.MsgDomainProxy:
-		return handleProxyMessage(ctx, msg)
+		return s.handleProxyMessage(ctx, msg)
 	default:
 		return fmt.Errorf("%w: %s", ErrUnexpectedMessageDomain, msg.Domain)
 	}
@@ -47,6 +52,7 @@ func (s Refresher) HandleMessage(ctx context.Context, msg domain.SSEMessage) err
 func handleFeatureMessage(_ context.Context, msg domain.SSEMessage) error {
 	switch msg.Event {
 	case domain.EventDelete:
+		// delete from the cache
 	case domain.EventPatch, domain.EventCreate:
 
 	default:
@@ -66,15 +72,47 @@ func handleSegmentMessage(_ context.Context, msg domain.SSEMessage) error {
 	return nil
 }
 
-func handleProxyMessage(_ context.Context, msg domain.SSEMessage) error {
+func (s Refresher) handleProxyMessage(ctx context.Context, msg domain.SSEMessage) error {
 	switch msg.Event {
 	case domain.EventProxyKeyDeleted:
+		return nil
 	case domain.EventEnvironmentAdded:
+		if err := s.handleAddEnvironmentEvent(ctx, msg.Environments); err != nil {
+			s.log.Error(err.Error())
+			return err
+		}
 	case domain.EventEnvironmentRemoved:
+		return nil
 	case domain.EventAPIKeyAdded:
+		return nil
 	case domain.EventAPIKeyRemoved:
+		return nil
 	default:
 		return fmt.Errorf("%w %q for Proxymessage", ErrUnexpectedEventType, msg.Event)
+	}
+	return nil
+}
+
+//handleAddEnvironmentEvent fetches proxyConfig for all added environments and sets them on.
+func (s Refresher) handleAddEnvironmentEvent(ctx context.Context, environments []string) error {
+	for _, env := range environments {
+		input := domain.GetProxyConfigInput{
+			Key:               s.proxyKey,
+			EnvID:             env,
+			AuthToken:         s.authToken,
+			ClusterIdentifier: s.clusterIdentifier,
+			PageNumber:        0,
+			PageSize:          10,
+		}
+		// fetch the proxy config.
+		proxyConfig, err := s.clientService.PageProxyConfig(ctx, input)
+		if err != nil {
+			s.log.Error("unable to fetch config for the environment: ", env)
+			return err
+		}
+		if len(proxyConfig) > 0 {
+			// todo set proxy config.
+		}
 	}
 	return nil
 }

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -80,7 +80,7 @@ func (s Refresher) handleProxyMessage(ctx context.Context, msg domain.SSEMessage
 		return nil
 	case domain.EventEnvironmentAdded:
 		if err := s.handleAddEnvironmentEvent(ctx, msg.Environments); err != nil {
-			s.log.Error(err.Error())
+			s.log.Error("failed to handle addEnvironmentEvent", "err", err)
 			return err
 		}
 	case domain.EventEnvironmentRemoved:
@@ -112,7 +112,7 @@ func (s Refresher) handleAddEnvironmentEvent(ctx context.Context, environments [
 		// fetch the proxy config.
 		_, err := s.clientService.PageProxyConfig(ctx, input)
 		if err != nil {
-			s.log.Error("unable to fetch config for the environment: ", env)
+			s.log.Error("unable to fetch config for the environment", "environment", env)
 			return err
 		}
 	}

--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"github.com/google/uuid"
 	"testing"
 
 	"github.com/harness/ff-proxy/v2/domain"
@@ -111,7 +112,7 @@ func TestRefresher_HandleMessage(t *testing.T) {
 			expected:  expected{err: nil},
 			shouldErr: false,
 		},
-		"Given I have an SSEMessage with the domain 'proxy' event 'foo'": {
+		"Given I have an SSEMessage with the domain 'proxyPatch' event 'foo'": {
 			args: args{
 				message: domain.SSEMessage{
 					Domain: domain.MsgDomainProxy,
@@ -121,7 +122,7 @@ func TestRefresher_HandleMessage(t *testing.T) {
 			expected:  expected{err: ErrUnexpectedEventType},
 			shouldErr: true,
 		},
-		"Given I have an SSEMessage with the domain 'proxy' event 'proxyKeyDeleted'": {
+		"Given I have an SSEMessage with the event 'proxy' event 'proxyKeyDeleted'": {
 			args: args{
 				message: domain.SSEMessage{
 					Domain: domain.MsgDomainProxy,
@@ -173,13 +174,20 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		},
 	}
 
+	mockClient := mockClientService{
+
+		PageProxyConfigFn: func(ctx context.Context, input domain.GetProxyConfigInput) ([]domain.ProxyConfig, error) {
+			return []domain.ProxyConfig{}, nil
+		},
+	}
+
 	for desc, tc := range testCases {
 		desc := desc
 		tc := tc
 
 		t.Run(desc, func(t *testing.T) {
 
-			r := NewRefresher(log.NewNoOpLogger())
+			r := NewRefresher(log.NewNoOpLogger(), "test_proxy_key", "test_auth_token", "1", mockClient)
 			err := r.HandleMessage(context.Background(), tc.args.message)
 			if tc.shouldErr {
 				assert.NotNil(t, err)
@@ -189,4 +197,84 @@ func TestRefresher_HandleMessage(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRefresher_handleAddEnvironmentEvent(t *testing.T) {
+	internalErr := errors.New("internal error")
+	type args struct {
+		message       domain.SSEMessage
+		clientService mockClientService
+	}
+
+	type expected struct {
+		err error
+	}
+
+	testCases := map[string]struct {
+		args      args
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I have error while attempting to fetch proxyConfig": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain:       domain.MsgDomainProxy,
+					Event:        domain.EventEnvironmentAdded,
+					Environments: []string{uuid.NewString(), uuid.NewString()},
+				},
+				clientService: mockClientService{
+					PageProxyConfigFn: func(ctx context.Context, input domain.GetProxyConfigInput) ([]domain.ProxyConfig, error) {
+						return []domain.ProxyConfig{}, internalErr
+					},
+				},
+			},
+			expected:  expected{err: internalErr},
+			shouldErr: true,
+		},
+		"Given I have an environment list not empty fetch proxyConfig": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain:       domain.MsgDomainProxy,
+					Event:        domain.EventEnvironmentAdded,
+					Environments: []string{uuid.NewString(), uuid.NewString()},
+				},
+				clientService: mockClientService{
+					PageProxyConfigFn: func(ctx context.Context, input domain.GetProxyConfigInput) ([]domain.ProxyConfig, error) {
+						return []domain.ProxyConfig{}, nil
+					},
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			r := NewRefresher(log.NewNoOpLogger(), "test_proxy_key", "test_auth_token", "1", tc.args.clientService)
+			err := r.HandleMessage(context.Background(), tc.args.message)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+				assert.True(t, errors.Is(err, tc.expected.err))
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+type mockClientService struct {
+	PageProxyConfigFn func(ctx context.Context, input domain.GetProxyConfigInput) ([]domain.ProxyConfig, error)
+}
+
+func (c mockClientService) AuthenticateProxyKey(ctx context.Context, key string) (domain.AuthenticateProxyKeyResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (c mockClientService) PageProxyConfig(ctx context.Context, input domain.GetProxyConfigInput) ([]domain.ProxyConfig, error) {
+	return c.PageProxyConfigFn(ctx, input)
 }

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -349,7 +349,7 @@ func main() {
 		//
 		// Layering them in this order means that the first thing we'll do when we receive an SSE message
 		// is attempt to refresh the cache, then if that's successful we'll forward the event on to Redis and Pushpin
-		cacheRefresher := cache.NewRefresher(logger)
+		cacheRefresher := cache.NewRefresher(logger, proxyKey, conf.Token(), conf.ClusterIdentifier(), clientSvc)
 		redisForwarder := stream.NewForwarder(
 			logger,
 			stream.NewRedisStream(redisClient),

--- a/domain/sse.go
+++ b/domain/sse.go
@@ -36,7 +36,8 @@ const (
 	// EventCreate identifies a create event from the SSE stream
 	EventCreate = "create"
 
-	EventProxyKeyDeleted    = "proxyKeyDeleted"
+	// Events for proxy
+	EventProxyKeyDeleted    = "deleteProxyKey"
 	EventEnvironmentAdded   = "environmentsAdded"
 	EventEnvironmentRemoved = "environmentsRemoved"
 	EventAPIKeyAdded        = "apiKeyAdded"


### PR DESCRIPTION
```
[FFM-9612]: Add a new environment - fetch proxyConfig for the environment
 ### What: 
Pull the proxy config for each environment added to the scope of the proxy key
 ### Why:
To update proxy and cache.
 ### Testing:
Locally + unittest
```

[FFM-9612]: https://harness.atlassian.net/browse/FFM-9612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ