### PR TITLE
[FFM-9613] : Remove all entries associated with environment.

### DIFF
--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -325,6 +325,16 @@ type mockAuthRepo struct {
 	addfn func(ctx context.Context, values ...domain.AuthConfig) error
 }
 
+func (m mockAuthRepo) Remove(ctx context.Context, id []string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthRepo) RemoveAllKeysForEnvironment(ctx context.Context, envID string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m mockAuthRepo) Add(ctx context.Context, values ...domain.AuthConfig) error {
 	return m.addfn(ctx, values...)
 }
@@ -333,12 +343,22 @@ type mockFlagRepo struct {
 	addfn func(ctx context.Context, values ...domain.FlagConfig) error
 }
 
+func (m mockFlagRepo) Remove(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m mockFlagRepo) Add(ctx context.Context, values ...domain.FlagConfig) error {
 	return m.addfn(ctx, values...)
 }
 
 type mockSegmentRepo struct {
 	addfn func(ctx context.Context, values ...domain.SegmentConfig) error
+}
+
+func (m mockSegmentRepo) Remove(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m mockSegmentRepo) Add(ctx context.Context, values ...domain.SegmentConfig) error {

--- a/config/local/config_test.go
+++ b/config/local/config_test.go
@@ -6,9 +6,10 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/harness/ff-proxy/v2/domain"
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -28,6 +29,16 @@ type mockAuthRepo struct {
 	add func(ctx context.Context, config ...domain.AuthConfig) error
 }
 
+func (m *mockAuthRepo) Remove(ctx context.Context, id []string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockAuthRepo) RemoveAllKeysForEnvironment(ctx context.Context, envID string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockAuthRepo) Add(ctx context.Context, config ...domain.AuthConfig) error {
 	if err := m.add(ctx, config...); err != nil {
 		return err
@@ -42,6 +53,11 @@ type mockSegmentRepo struct {
 	add func(ctx context.Context, config ...domain.SegmentConfig) error
 }
 
+func (m *mockSegmentRepo) Remove(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockSegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfig) error {
 	if err := m.add(ctx, config...); err != nil {
 		return err
@@ -54,6 +70,11 @@ type mockFlagRepo struct {
 	config []domain.FlagConfig
 
 	add func(ctx context.Context, config ...domain.FlagConfig) error
+}
+
+func (m *mockFlagRepo) Remove(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m *mockFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) error {

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -18,6 +18,16 @@ type mockAuthRepo struct {
 	add func(ctx context.Context, config ...domain.AuthConfig) error
 }
 
+func (m *mockAuthRepo) Remove(ctx context.Context, id []string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockAuthRepo) RemoveAllKeysForEnvironment(ctx context.Context, envID string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockAuthRepo) Add(ctx context.Context, config ...domain.AuthConfig) error {
 	if err := m.add(ctx, config...); err != nil {
 		return err
@@ -32,6 +42,11 @@ type mockSegmentRepo struct {
 	add func(ctx context.Context, config ...domain.SegmentConfig) error
 }
 
+func (m *mockSegmentRepo) Remove(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m *mockSegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfig) error {
 	if err := m.add(ctx, config...); err != nil {
 		return err
@@ -44,6 +59,11 @@ type mockFlagRepo struct {
 	config []domain.FlagConfig
 
 	add func(ctx context.Context, config ...domain.FlagConfig) error
+}
+
+func (m *mockFlagRepo) Remove(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m *mockFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) error {

--- a/domain/api_keys.go
+++ b/domain/api_keys.go
@@ -1,0 +1,13 @@
+package domain
+
+import (
+	"fmt"
+)
+
+// APIConfigsKey is the key that maps all APIKeys associated with environment.
+type APIConfigsKey string
+
+// NewAPIConfigsKey creates a APIConfigsKey from an environment and identifier. This key contains all the keys associated with the environment.
+func NewAPIConfigsKey(envID string) APIConfigsKey {
+	return APIConfigsKey(fmt.Sprintf("env-%s-api-configs", envID))
+}

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -6,6 +6,7 @@ import "context"
 type AuthRepo interface {
 	Add(ctx context.Context, config ...AuthConfig) error
 	Remove(ctx context.Context, id []string) error
+	RemoveAllKeysForEnvironment(ctx context.Context, envId string) error
 }
 
 // FlagRepo is the interface for the FlagRepository

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -6,7 +6,7 @@ import "context"
 type AuthRepo interface {
 	Add(ctx context.Context, config ...AuthConfig) error
 	Remove(ctx context.Context, id []string) error
-	RemoveAllKeysForEnvironment(ctx context.Context, envId string) error
+	RemoveAllKeysForEnvironment(ctx context.Context, envID string) error
 }
 
 // FlagRepo is the interface for the FlagRepository

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -5,14 +5,17 @@ import "context"
 // AuthRepo is the interface for the AuthRepository
 type AuthRepo interface {
 	Add(ctx context.Context, config ...AuthConfig) error
+	Remove(ctx context.Context, id []string) error
 }
 
 // FlagRepo is the interface for the FlagRepository
 type FlagRepo interface {
 	Add(ctx context.Context, config ...FlagConfig) error
+	Remove(ctx context.Context, id string) error
 }
 
 // SegmentRepo is the interface for the SegmentRepository
 type SegmentRepo interface {
 	Add(ctx context.Context, config ...SegmentConfig) error
+	Remove(ctx context.Context, id string) error
 }

--- a/repository/auth_repo.go
+++ b/repository/auth_repo.go
@@ -56,3 +56,13 @@ func (a AuthRepo) Get(ctx context.Context, key domain.AuthAPIKey) (string, bool)
 
 	return string(environment), true
 }
+
+// Remove removes from cache all provided keys
+func (a AuthRepo) Remove(ctx context.Context, keys []string) error {
+	for _, k := range keys {
+		if err := a.cache.Delete(ctx, k); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/repository/auth_repo.go
+++ b/repository/auth_repo.go
@@ -26,11 +26,11 @@ func NewAuthRepo(c cache.Cache) AuthRepo {
 // Add adds environment api key hash pairs to the cache
 func (a AuthRepo) Add(ctx context.Context, values ...domain.AuthConfig) error {
 
-	var key APIConfigsKey
+	var key domain.APIConfigsKey
 	apiKeys := make([]string, 0, len(values))
 
 	if len(values) > 0 {
-		key = NewAPIConfigsKey(string(values[0].EnvironmentID))
+		key = domain.NewAPIConfigsKey(string(values[0].EnvironmentID))
 	}
 
 	errs := []error{}
@@ -77,7 +77,7 @@ func (a AuthRepo) GetKeysForEnvironment(ctx context.Context, envID string) ([]st
 
 	var apiKeys []string
 
-	key := NewAPIConfigsKey(envID)
+	key := domain.NewAPIConfigsKey(envID)
 	if err := a.cache.Get(ctx, string(key), &apiKeys); err != nil {
 		return apiKeys, false
 	}
@@ -95,7 +95,7 @@ func (a AuthRepo) RemoveAllKeysForEnvironment(ctx context.Context, envID string)
 
 	// append the entry for the list of keys assocaited with environments
 	// we do that to delete them all in the next step.
-	key := NewAPIConfigsKey(envID)
+	key := domain.NewAPIConfigsKey(envID)
 	apiKeys = append(apiKeys, string(key))
 
 	//remove entries for all keys associated with environments
@@ -111,10 +111,4 @@ func (a AuthRepo) Remove(ctx context.Context, keys []string) error {
 		}
 	}
 	return nil
-}
-
-type APIConfigsKey string
-
-func NewAPIConfigsKey(envID string) APIConfigsKey {
-	return APIConfigsKey(fmt.Sprintf("env-%s-api-configs", envID))
 }

--- a/repository/feature_flag_repo.go
+++ b/repository/feature_flag_repo.go
@@ -87,3 +87,27 @@ func (f FeatureFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) e
 
 	return nil
 }
+
+// Remove removes all feature entries for given environment id
+func (f FeatureFlagRepo) Remove(ctx context.Context, id string) error {
+
+	//get all the feature for given key
+	flags, err := f.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	// remove featureConfigs entry
+	fcKey := domain.NewFeatureConfigsKey(id)
+	if err := f.cache.Delete(ctx, string(fcKey)); err != nil {
+		return err
+	}
+	// remove all individual feature entries for environment
+	for _, flag := range flags {
+
+		key := domain.NewFeatureConfigKey(id, flag.Feature)
+		if err := f.cache.Delete(ctx, string(key)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/repository/feature_flag_repo_test.go
+++ b/repository/feature_flag_repo_test.go
@@ -276,12 +276,12 @@ func TestFeatureFlagRepo_Remove(t *testing.T) {
 		repoConfig []domain.FlagConfig
 		shouldErr  bool
 	}{
-		"Given I call Remove with and the config does not exist": {
+		"Given I call Remove with and the Feature config does not exist": {
 			cache:      cache.NewMemCache(),
 			repoConfig: emptyConfig,
 			shouldErr:  true,
 		},
-		"Given I call Remove with and config does exist": {
+		"Given I call Remove with and the Feature config does exist": {
 			cache:      cache.NewMemCache(),
 			repoConfig: populatedConfig,
 			shouldErr:  false,

--- a/repository/segment_repo.go
+++ b/repository/segment_repo.go
@@ -78,3 +78,27 @@ func (s SegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfig) er
 
 	return nil
 }
+
+// Remove removes all segment entries for given environment id
+func (s SegmentRepo) Remove(ctx context.Context, id string) error {
+
+	//get all the segments for given key
+	segments, err := s.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	// remove segmentConfig entry
+	sKey := domain.NewSegmentsKey(id)
+	if err := s.cache.Delete(ctx, string(sKey)); err != nil {
+		return err
+	}
+	// remove all individual segment entries for environment
+	for _, segment := range segments {
+
+		key := domain.NewFeatureConfigKey(id, segment.Identifier)
+		if err := s.cache.Delete(ctx, string(key)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/repository/segment_repo.go
+++ b/repository/segment_repo.go
@@ -95,7 +95,7 @@ func (s SegmentRepo) Remove(ctx context.Context, id string) error {
 	// remove all individual segment entries for environment
 	for _, segment := range segments {
 
-		key := domain.NewFeatureConfigKey(id, segment.Identifier)
+		key := domain.NewSegmentKey(id, segment.Identifier)
 		if err := s.cache.Delete(ctx, string(key)); err != nil {
 			return err
 		}

--- a/repository/segment_repo_test.go
+++ b/repository/segment_repo_test.go
@@ -182,7 +182,7 @@ func TestSegmentRepo_Remove(t *testing.T) {
 			repoConfig: emptyConfig,
 			shouldErr:  true,
 		},
-		"Given I call Remove with and Segment config does exist": {
+		"Given I call Remove with and the Segment config does exist": {
 			cache:      cache.NewMemCache(),
 			repoConfig: populatedConfig,
 			shouldErr:  false,


### PR DESCRIPTION
```
[FFM-9613] : Remove all entries associated with environment.
 ### What: 
Added funcs to remove all the keys associated with then environment
Added cache entry for apikeys associated with environment 
 ### Why:
When we get an SSE event telling us an environment has been deleted we should remove any Flag, Segment and Auth config from the cache that’s related to this environment. 
 ### Testing:
Locally
```

[FFM-9613]: https://harness.atlassian.net/browse/FFM-9613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ