### PR TITLE
[FFM-9609] : Refresh Features

### DIFF
--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -42,7 +42,7 @@ func NewRefresher(l log.Logger, config config.Config, client domain.ClientServic
 func (s Refresher) HandleMessage(ctx context.Context, msg domain.SSEMessage) error {
 	switch msg.Domain {
 	case domain.MsgDomainFeature:
-		return handleFeatureMessage(ctx, msg)
+		return s.handleFeatureMessage(ctx, msg)
 	case domain.MsgDomainSegment:
 		return handleSegmentMessage(ctx, msg)
 	case domain.MsgDomainProxy:
@@ -53,12 +53,18 @@ func (s Refresher) HandleMessage(ctx context.Context, msg domain.SSEMessage) err
 
 }
 
-func handleFeatureMessage(_ context.Context, msg domain.SSEMessage) error {
+func (s Refresher) handleFeatureMessage(ctx context.Context, msg domain.SSEMessage) error {
 	switch msg.Event {
 	case domain.EventDelete:
-		// delete from the cache
+		if err := s.handleDeleteFeatureEvent(ctx, msg.Environment, msg.Identifier); err != nil {
+			s.log.Error("failed to handle feature delete event", "err", err)
+			return err
+		}
 	case domain.EventPatch, domain.EventCreate:
-
+		if err := s.handleFetchFeatureEvent(ctx, msg.Environment, msg.Identifier); err != nil {
+			s.log.Error("failed to handle feature update event", "err", err)
+			return err
+		}
 	default:
 		return fmt.Errorf("%w %q for FeatureMessage", ErrUnexpectedEventType, msg.Event)
 	}
@@ -153,7 +159,7 @@ func (s Refresher) handleRemoveEnvironmentEvent(ctx context.Context, environment
 			return fmt.Errorf("failed to remove apikey configs from cache for environment %s with error %s", env, err)
 		}
 
-		if err := s.flagRepo.Remove(ctx, env); err != nil {
+		if err := s.flagRepo.RemoveAllFeaturesForEnvironment(ctx, env); err != nil {
 			return fmt.Errorf("failed to remove flag config from cache for environment %s with error %s", env, err)
 		}
 
@@ -189,4 +195,33 @@ func (s Refresher) handleRemoveAPIKeyEvent(ctx context.Context, env, apiKey stri
 		return err
 	}
 	return s.authRepo.PatchAPIConfigForEnvironment(ctx, env, apiKey, domain.EventAPIKeyRemoved)
+}
+
+func (s Refresher) handleFetchFeatureEvent(ctx context.Context, env, id string) error {
+	s.log.Debug("updating featureConfig entry", "environment", env, "identifier", id)
+	return nil
+}
+
+func (s Refresher) handleDeleteFeatureEvent(ctx context.Context, env, identifier string) error {
+	s.log.Debug("removing featureConfig entry", "environment", env, "identifier", identifier)
+
+	// fetch and reset config map and delete the entry.
+	featureConfigs, err := s.clientService.FetchFeatureConfigForEnvironment(ctx, s.config.Token(), env)
+	if err != nil {
+		return err
+	}
+	features := make([]domain.FeatureFlag, 0, len(featureConfigs))
+	for _, v := range featureConfigs {
+		features = append(features, domain.FeatureFlag(v))
+	}
+
+	// set the config
+	if err := s.flagRepo.Add(ctx, domain.FlagConfig{
+		EnvironmentID:  env,
+		FeatureConfigs: features,
+	}); err != nil {
+		return err
+	}
+	// remove deleted flag entry.
+	return s.flagRepo.Remove(ctx, identifier)
 }

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -236,5 +236,5 @@ func (s Refresher) handleDeleteFeatureEvent(ctx context.Context, env, identifier
 		return err
 	}
 	// remove deleted flag entry.
-	return s.flagRepo.Remove(ctx, identifier)
+	return s.flagRepo.Remove(ctx, env, identifier)
 }

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -210,14 +210,10 @@ func (s Refresher) handleFetchFeatureEvent(ctx context.Context, env, id string) 
 	}
 
 	// set the config
-	if err := s.flagRepo.Add(ctx, domain.FlagConfig{
+	return s.flagRepo.Add(ctx, domain.FlagConfig{
 		EnvironmentID:  env,
 		FeatureConfigs: features,
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 func (s Refresher) handleDeleteFeatureEvent(ctx context.Context, env, identifier string) error {

--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -212,7 +212,7 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		removeAllFeaturesForEnvironmentFn: func(ctx context.Context, id string) error {
 			return nil
 		},
-		removeFn: func(ctx context.Context, id string) error {
+		removeFn: func(ctx context.Context, env, id string) error {
 			return nil
 		},
 		addFn: func(ctx context.Context, values ...domain.FlagConfig) error {
@@ -493,7 +493,7 @@ func (m mockAuthRepo) Add(ctx context.Context, values ...domain.AuthConfig) erro
 
 type mockFlagRepo struct {
 	addFn                             func(ctx context.Context, values ...domain.FlagConfig) error
-	removeFn                          func(ctx context.Context, id string) error
+	removeFn                          func(ctx context.Context, env, id string) error
 	removeAllFeaturesForEnvironmentFn func(ctx context.Context, id string) error
 }
 
@@ -501,8 +501,8 @@ func (m mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id st
 	return m.removeAllFeaturesForEnvironmentFn(ctx, id)
 }
 
-func (m mockFlagRepo) Remove(ctx context.Context, id string) error {
-	return m.removeFn(ctx, id)
+func (m mockFlagRepo) Remove(ctx context.Context, env, id string) error {
+	return m.removeFn(ctx, env, id)
 }
 func (m mockFlagRepo) Add(ctx context.Context, values ...domain.FlagConfig) error {
 	return m.addFn(ctx, values...)

--- a/clients/client_service/client.go
+++ b/clients/client_service/client.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 
 	"github.com/golang-jwt/jwt"
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/harness/ff-proxy/v2/domain"
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 	"github.com/harness/ff-proxy/v2/log"
 	"github.com/harness/ff-proxy/v2/token"
-	jsoniter "github.com/json-iterator/go"
 )
 
 var (
@@ -212,6 +213,26 @@ func (c Client) getProxyConfig(ctx context.Context, input domain.GetProxyConfigI
 			return clientgen.ProxyConfig{}, ErrInternal
 		}
 		return clientgen.ProxyConfig{}, err
+	}
+
+	return *resp.JSON200, nil
+}
+
+func (c Client) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.FeatureConfig, error) {
+	resp, err := c.client.GetFeatureConfigWithResponse(ctx, envId, &clientgen.GetFeatureConfigParams{}, func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+		return nil
+	})
+	if err != nil {
+		return []clientgen.FeatureConfig{}, fmt.Errorf("%w: %s", ErrInternal, err)
+	}
+
+	if resp.JSON200 == nil {
+		err, ok := statusCodeToErr[resp.StatusCode()]
+		if !ok {
+			return []clientgen.FeatureConfig{}, ErrInternal
+		}
+		return []clientgen.FeatureConfig{}, err
 	}
 
 	return *resp.JSON200, nil

--- a/clients/client_service/client.go
+++ b/clients/client_service/client.go
@@ -218,8 +218,8 @@ func (c Client) getProxyConfig(ctx context.Context, input domain.GetProxyConfigI
 	return *resp.JSON200, nil
 }
 
-func (c Client) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.FeatureConfig, error) {
-	resp, err := c.client.GetFeatureConfigWithResponse(ctx, envId, &clientgen.GetFeatureConfigParams{}, func(ctx context.Context, req *http.Request) error {
+func (c Client) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.FeatureConfig, error) {
+	resp, err := c.client.GetFeatureConfigWithResponse(ctx, envID, &clientgen.GetFeatureConfigParams{}, func(ctx context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 		return nil
 	})

--- a/config/local/config_test.go
+++ b/config/local/config_test.go
@@ -86,7 +86,7 @@ func (m *mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id s
 	panic("implement me")
 }
 
-func (m *mockFlagRepo) Remove(ctx context.Context, id string) error {
+func (m *mockFlagRepo) Remove(ctx context.Context, env, id string) error {
 	//TODO implement me
 	panic("implement me")
 }

--- a/config/local/config_test.go
+++ b/config/local/config_test.go
@@ -78,8 +78,12 @@ func (m *mockSegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfi
 
 type mockFlagRepo struct {
 	config []domain.FlagConfig
+	add    func(ctx context.Context, config ...domain.FlagConfig) error
+}
 
-	add func(ctx context.Context, config ...domain.FlagConfig) error
+func (m *mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m *mockFlagRepo) Remove(ctx context.Context, id string) error {

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	clientservice "github.com/harness/ff-proxy/v2/clients/client_service"
 	"github.com/harness/ff-proxy/v2/domain"
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 )
 
 type mockAuthRepo struct {
@@ -67,7 +68,14 @@ func (m *mockSegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfi
 type mockFlagRepo struct {
 	config []domain.FlagConfig
 
-	add func(ctx context.Context, config ...domain.FlagConfig) error
+	addFn                             func(ctx context.Context, config ...domain.FlagConfig) error
+	removeFn                          func(ctx context.Context, id string) error
+	removeAllFeaturesForEnvironmentFn func(ctx context.Context, id string) error
+}
+
+func (m *mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m *mockFlagRepo) Remove(ctx context.Context, id string) error {
@@ -76,7 +84,7 @@ func (m *mockFlagRepo) Remove(ctx context.Context, id string) error {
 }
 
 func (m *mockFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) error {
-	if err := m.add(ctx, config...); err != nil {
+	if err := m.addFn(ctx, config...); err != nil {
 		return err
 	}
 	m.config = append(m.config, config...)
@@ -86,6 +94,11 @@ func (m *mockFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) err
 type mockClientService struct {
 	authProxyKey    func() (domain.AuthenticateProxyKeyResponse, error)
 	pageProxyConfig func() ([]domain.ProxyConfig, error)
+}
+
+func (m mockClientService) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.FeatureConfig, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m mockClientService) AuthenticateProxyKey(ctx context.Context, key string) (domain.AuthenticateProxyKeyResponse, error) {
@@ -263,7 +276,7 @@ func TestConfig_Populate(t *testing.T) {
 					},
 				},
 				flagRepo: &mockFlagRepo{
-					add: func(ctx context.Context, config ...domain.FlagConfig) error {
+					addFn: func(ctx context.Context, config ...domain.FlagConfig) error {
 						return errors.New("an error")
 					},
 				},
@@ -301,7 +314,7 @@ func TestConfig_Populate(t *testing.T) {
 					},
 				},
 				flagRepo: &mockFlagRepo{
-					add: func(ctx context.Context, config ...domain.FlagConfig) error {
+					addFn: func(ctx context.Context, config ...domain.FlagConfig) error {
 						return nil
 					},
 				},
@@ -339,7 +352,7 @@ func TestConfig_Populate(t *testing.T) {
 					},
 				},
 				flagRepo: &mockFlagRepo{
-					add: func(ctx context.Context, config ...domain.FlagConfig) error {
+					addFn: func(ctx context.Context, config ...domain.FlagConfig) error {
 						return nil
 					},
 				},

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -69,7 +69,7 @@ type mockFlagRepo struct {
 	config []domain.FlagConfig
 
 	addFn                             func(ctx context.Context, config ...domain.FlagConfig) error
-	removeFn                          func(ctx context.Context, id string) error
+	removeFn                          func(ctx context.Context, env, id string) error
 	removeAllFeaturesForEnvironmentFn func(ctx context.Context, id string) error
 }
 
@@ -78,7 +78,7 @@ func (m *mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id s
 	panic("implement me")
 }
 
-func (m *mockFlagRepo) Remove(ctx context.Context, id string) error {
+func (m *mockFlagRepo) Remove(ctx context.Context, env, id string) error {
 	//TODO implement me
 	panic("implement me")
 }

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -15,6 +15,7 @@ type AuthRepo interface {
 type FlagRepo interface {
 	Add(ctx context.Context, config ...FlagConfig) error
 	Remove(ctx context.Context, id string) error
+	RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error
 }
 
 // SegmentRepo is the interface for the SegmentRepository

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -14,7 +14,7 @@ type AuthRepo interface {
 // FlagRepo is the interface for the FlagRepository
 type FlagRepo interface {
 	Add(ctx context.Context, config ...FlagConfig) error
-	Remove(ctx context.Context, id string) error
+	Remove(ctx context.Context, envID, id string) error
 	RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error
 }
 

--- a/domain/services.go
+++ b/domain/services.go
@@ -10,5 +10,5 @@ import (
 type ClientService interface {
 	AuthenticateProxyKey(ctx context.Context, key string) (AuthenticateProxyKeyResponse, error)
 	PageProxyConfig(ctx context.Context, input GetProxyConfigInput) ([]ProxyConfig, error)
-	FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.FeatureConfig, error)
+	FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.FeatureConfig, error)
 }

--- a/domain/services.go
+++ b/domain/services.go
@@ -2,10 +2,13 @@ package domain
 
 import (
 	"context"
+
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 )
 
 // ClientService defines the interface for interacting with the ff-client-service
 type ClientService interface {
 	AuthenticateProxyKey(ctx context.Context, key string) (AuthenticateProxyKeyResponse, error)
 	PageProxyConfig(ctx context.Context, input GetProxyConfigInput) ([]ProxyConfig, error)
+	FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.FeatureConfig, error)
 }

--- a/repository/feature_flag_repo.go
+++ b/repository/feature_flag_repo.go
@@ -89,8 +89,8 @@ func (f FeatureFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) e
 }
 
 // Remove removes the feature entry from the cache
-func (f FeatureFlagRepo) Remove(ctx context.Context, identifier string) error {
-	fcKey := domain.NewFeatureConfigsKey(identifier)
+func (f FeatureFlagRepo) Remove(ctx context.Context, env, identifier string) error {
+	fcKey := domain.NewFeatureConfigKey(env, identifier)
 	return f.cache.Delete(ctx, string(fcKey))
 }
 

--- a/repository/feature_flag_repo.go
+++ b/repository/feature_flag_repo.go
@@ -90,13 +90,8 @@ func (f FeatureFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) e
 
 // Remove removes the feature entry from the cache
 func (f FeatureFlagRepo) Remove(ctx context.Context, identifier string) error {
-
-	// remove featureConfigs entry
 	fcKey := domain.NewFeatureConfigsKey(identifier)
-	if err := f.cache.Delete(ctx, string(fcKey)); err != nil {
-		return err
-	}
-	return nil
+	return f.cache.Delete(ctx, string(fcKey))
 }
 
 // RemoveAllFeaturesForEnvironment removes all feature entries for given environment id

--- a/repository/feature_flag_repo.go
+++ b/repository/feature_flag_repo.go
@@ -88,10 +88,21 @@ func (f FeatureFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) e
 	return nil
 }
 
-// Remove removes all feature entries for given environment id
-func (f FeatureFlagRepo) Remove(ctx context.Context, id string) error {
+// Remove removes the feature entry from the cache
+func (f FeatureFlagRepo) Remove(ctx context.Context, identifier string) error {
 
-	//get all the feature for given key
+	// remove featureConfigs entry
+	fcKey := domain.NewFeatureConfigsKey(identifier)
+	if err := f.cache.Delete(ctx, string(fcKey)); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RemoveAllFeaturesForEnvironment removes all feature entries for given environment id
+func (f FeatureFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error {
+
+	// get all the feature for given key
 	flags, err := f.Get(ctx, id)
 	if err != nil {
 		return err

--- a/repository/feature_flag_repo_test.go
+++ b/repository/feature_flag_repo_test.go
@@ -298,7 +298,7 @@ func TestFeatureFlagRepo_Remove(t *testing.T) {
 
 			} else {
 				assert.Nil(t, repo.Add(ctx, tc.repoConfig...))
-				assert.Nil(t, repo.Remove(ctx, "123"))
+				assert.Nil(t, repo.Remove(ctx, "123", "12345"))
 				flags, err := repo.Get(ctx, "123")
 				assert.Equal(t, flags, []domain.FeatureFlag{})
 				assert.Error(t, err)

--- a/repository/feature_flag_repo_test.go
+++ b/repository/feature_flag_repo_test.go
@@ -298,7 +298,7 @@ func TestFeatureFlagRepo_Remove(t *testing.T) {
 
 			} else {
 				assert.Nil(t, repo.Add(ctx, tc.repoConfig...))
-				assert.Nil(t, repo.Remove(ctx, "123", "12345"))
+				assert.Nil(t, repo.RemoveAllFeaturesForEnvironment(ctx, "123"))
 				flags, err := repo.Get(ctx, "123")
 				assert.Equal(t, flags, []domain.FeatureFlag{})
 				assert.Error(t, err)

--- a/repository/feature_flag_repo_test.go
+++ b/repository/feature_flag_repo_test.go
@@ -294,7 +294,7 @@ func TestFeatureFlagRepo_Remove(t *testing.T) {
 			repo := NewFeatureFlagRepo(tc.cache)
 
 			if tc.shouldErr {
-				assert.Error(t, repo.Remove(ctx, "123"))
+				assert.Error(t, repo.RemoveAllFeaturesForEnvironment(ctx, "123"))
 
 			} else {
 				assert.Nil(t, repo.Add(ctx, tc.repoConfig...))


### PR DESCRIPTION
```
[FFM-9609] :Refresh Features
 ### What: 
When we get an SSE event telling us there’s been a change to features, we should refresh the feature config that we’ve stored in our cache.
 ### Why:
Proxy to stay up to date with the Saas.
 ### Testing:
Locally
```

[FFM-9609]: https://harness.atlassian.net/browse/FFM-9609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ