### PR TITLE
[FFM:9610] : Refresh Segments

### DIFF
--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -221,6 +221,9 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		addFn: func(ctx context.Context, values ...domain.FlagConfig) error {
 			return nil
 		},
+		getFeatureConfigForEnvironmentFn: func(ctx context.Context, envID string) ([]domain.FeatureFlag, bool) {
+			return []domain.FeatureFlag{}, true
+		},
 	}
 	segmentRepo := mockSegmentRepo{
 
@@ -232,6 +235,9 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		},
 		removeAllSegmentsForEnvironmentFn: func(ctx context.Context, id string) error {
 			return nil
+		},
+		getSegmentsForEnvironmentFn: func(ctx context.Context, envID string) ([]domain.Segment, bool) {
+			return []domain.Segment{}, true
 		},
 	}
 	config := mockConfig{
@@ -505,6 +511,11 @@ type mockFlagRepo struct {
 	addFn                             func(ctx context.Context, values ...domain.FlagConfig) error
 	removeFn                          func(ctx context.Context, env, id string) error
 	removeAllFeaturesForEnvironmentFn func(ctx context.Context, id string) error
+	getFeatureConfigForEnvironmentFn  func(ctx context.Context, envID string) ([]domain.FeatureFlag, bool)
+}
+
+func (m mockFlagRepo) GetFeatureConfigForEnvironment(ctx context.Context, envID string) ([]domain.FeatureFlag, bool) {
+	return m.getFeatureConfigForEnvironmentFn(ctx, envID)
 }
 
 func (m mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error {
@@ -521,7 +532,12 @@ func (m mockFlagRepo) Add(ctx context.Context, values ...domain.FlagConfig) erro
 type mockSegmentRepo struct {
 	addFn                             func(ctx context.Context, values ...domain.SegmentConfig) error
 	removeFn                          func(ctx context.Context, env, id string) error
-	removeAllSegmentsForEnvironmentFn func(ctx context.Context, id string) error
+	removeAllSegmentsForEnvironmentFn func(ctx context.Context, envID string) error
+	getSegmentsForEnvironmentFn       func(ctx context.Context, envID string) ([]domain.Segment, bool)
+}
+
+func (m mockSegmentRepo) GetSegmentsForEnvironment(ctx context.Context, envID string) ([]domain.Segment, bool) {
+	return m.getSegmentsForEnvironmentFn(ctx, envID)
 }
 
 func (m mockSegmentRepo) Remove(ctx context.Context, envID, id string) error {

--- a/clients/client_service/client.go
+++ b/clients/client_service/client.go
@@ -237,3 +237,24 @@ func (c Client) FetchFeatureConfigForEnvironment(ctx context.Context, authToken,
 
 	return *resp.JSON200, nil
 }
+
+func (c Client) FetchSegmentConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.Segment, error) {
+
+	resp, err := c.client.GetAllSegmentsWithResponse(ctx, envID, &clientgen.GetAllSegmentsParams{}, func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+		return nil
+	})
+	if err != nil {
+		return []clientgen.Segment{}, fmt.Errorf("%w: %s", ErrInternal, err)
+	}
+
+	if resp.JSON200 == nil {
+		err, ok := statusCodeToErr[resp.StatusCode()]
+		if !ok {
+			return []clientgen.Segment{}, ErrInternal
+		}
+		return []clientgen.Segment{}, err
+	}
+
+	return *resp.JSON200, nil
+}

--- a/config/local/config_test.go
+++ b/config/local/config_test.go
@@ -63,6 +63,12 @@ type mockSegmentRepo struct {
 	add                               func(ctx context.Context, config ...domain.SegmentConfig) error
 	removeFn                          func(ctx context.Context, env, id string) error
 	removeAllSegmentsForEnvironmentFn func(ctx context.Context, id string) error
+	getSegmentsForEnvironmentFn       func(ctx context.Context, envID string) ([]domain.Segment, bool)
+}
+
+func (m *mockSegmentRepo) GetSegmentsForEnvironment(ctx context.Context, envID string) ([]domain.Segment, bool) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m *mockSegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error {
@@ -82,8 +88,13 @@ func (m *mockSegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfi
 }
 
 type mockFlagRepo struct {
-	config []domain.FlagConfig
-	add    func(ctx context.Context, config ...domain.FlagConfig) error
+	config                           []domain.FlagConfig
+	add                              func(ctx context.Context, config ...domain.FlagConfig) error
+	getFeatureConfigForEnvironmentFn func(ctx context.Context, envID string) ([]domain.FeatureFlag, bool)
+}
+
+func (m *mockFlagRepo) GetFeatureConfigForEnvironment(ctx context.Context, envID string) ([]domain.FeatureFlag, bool) {
+	return m.getFeatureConfigForEnvironmentFn(ctx, envID)
 }
 
 func (m *mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error {

--- a/config/local/config_test.go
+++ b/config/local/config_test.go
@@ -60,12 +60,17 @@ func (m *mockAuthRepo) Add(ctx context.Context, config ...domain.AuthConfig) err
 type mockSegmentRepo struct {
 	config []domain.SegmentConfig
 
-	add func(ctx context.Context, config ...domain.SegmentConfig) error
+	add                               func(ctx context.Context, config ...domain.SegmentConfig) error
+	removeFn                          func(ctx context.Context, env, id string) error
+	removeAllSegmentsForEnvironmentFn func(ctx context.Context, id string) error
 }
 
-func (m *mockSegmentRepo) Remove(ctx context.Context, id string) error {
-	//TODO implement me
-	panic("implement me")
+func (m *mockSegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error {
+	return m.removeAllSegmentsForEnvironmentFn(ctx, id)
+}
+
+func (m *mockSegmentRepo) Remove(ctx context.Context, env, id string) error {
+	return m.removeFn(ctx, env, id)
 }
 
 func (m *mockSegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfig) error {

--- a/config/remote/config.go
+++ b/config/remote/config.go
@@ -33,6 +33,9 @@ func (c *Config) Token() string {
 
 // ClusterIdentifier returns the identifier of the cluster that the Config authenticated against
 func (c *Config) ClusterIdentifier() string {
+	if c.clusterIdentifier == "" {
+		return "1"
+	}
 	return c.clusterIdentifier
 }
 

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -49,12 +49,17 @@ func (m *mockAuthRepo) Add(ctx context.Context, config ...domain.AuthConfig) err
 type mockSegmentRepo struct {
 	config []domain.SegmentConfig
 
-	add func(ctx context.Context, config ...domain.SegmentConfig) error
+	add                               func(ctx context.Context, config ...domain.SegmentConfig) error
+	removeFn                          func(ctx context.Context, env, id string) error
+	removeAllSegmentsForEnvironmentFn func(ctx context.Context, id string) error
 }
 
-func (m *mockSegmentRepo) Remove(ctx context.Context, id string) error {
-	//TODO implement me
-	panic("implement me")
+func (m *mockSegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error {
+	return m.removeAllSegmentsForEnvironmentFn(ctx, id)
+}
+
+func (m *mockSegmentRepo) Remove(ctx context.Context, env, id string) error {
+	return m.removeFn(ctx, env, id)
 }
 
 func (m *mockSegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfig) error {
@@ -94,6 +99,11 @@ func (m *mockFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) err
 type mockClientService struct {
 	authProxyKey    func() (domain.AuthenticateProxyKeyResponse, error)
 	pageProxyConfig func() ([]domain.ProxyConfig, error)
+}
+
+func (m mockClientService) FetchSegmentConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.Segment, error) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m mockClientService) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.FeatureConfig, error) {

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -52,6 +52,11 @@ type mockSegmentRepo struct {
 	add                               func(ctx context.Context, config ...domain.SegmentConfig) error
 	removeFn                          func(ctx context.Context, env, id string) error
 	removeAllSegmentsForEnvironmentFn func(ctx context.Context, id string) error
+	getSegmentsForEnvironmentFn       func(ctx context.Context, envID string) ([]domain.Segment, bool)
+}
+
+func (m *mockSegmentRepo) GetSegmentsForEnvironment(ctx context.Context, envID string) ([]domain.Segment, bool) {
+	return m.getSegmentsForEnvironmentFn(ctx, envID)
 }
 
 func (m *mockSegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error {
@@ -76,16 +81,19 @@ type mockFlagRepo struct {
 	addFn                             func(ctx context.Context, config ...domain.FlagConfig) error
 	removeFn                          func(ctx context.Context, env, id string) error
 	removeAllFeaturesForEnvironmentFn func(ctx context.Context, id string) error
+	getFeatureConfigForEnvironmentFn  func(ctx context.Context, envID string) ([]domain.FeatureFlag, bool)
+}
+
+func (m *mockFlagRepo) GetFeatureConfigForEnvironment(ctx context.Context, envID string) ([]domain.FeatureFlag, bool) {
+	return m.getFeatureConfigForEnvironmentFn(ctx, envID)
 }
 
 func (m *mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error {
-	//TODO implement me
-	panic("implement me")
+	return m.removeAllFeaturesForEnvironmentFn(ctx, id)
 }
 
 func (m *mockFlagRepo) Remove(ctx context.Context, env, id string) error {
-	//TODO implement me
-	panic("implement me")
+	return m.removeFn(ctx, env, id)
 }
 
 func (m *mockFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) error {

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -21,5 +21,6 @@ type FlagRepo interface {
 // SegmentRepo is the interface for the SegmentRepository
 type SegmentRepo interface {
 	Add(ctx context.Context, config ...SegmentConfig) error
-	Remove(ctx context.Context, id string) error
+	Remove(ctx context.Context, envID, id string) error
+	RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error
 }

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -16,6 +16,7 @@ type FlagRepo interface {
 	Add(ctx context.Context, config ...FlagConfig) error
 	Remove(ctx context.Context, envID, id string) error
 	RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error
+	GetFeatureConfigForEnvironment(ctx context.Context, envID string) ([]FeatureFlag, bool)
 }
 
 // SegmentRepo is the interface for the SegmentRepository
@@ -23,4 +24,5 @@ type SegmentRepo interface {
 	Add(ctx context.Context, config ...SegmentConfig) error
 	Remove(ctx context.Context, envID, id string) error
 	RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error
+	GetSegmentsForEnvironment(ctx context.Context, envID string) ([]Segment, bool)
 }

--- a/domain/services.go
+++ b/domain/services.go
@@ -11,4 +11,5 @@ type ClientService interface {
 	AuthenticateProxyKey(ctx context.Context, key string) (AuthenticateProxyKeyResponse, error)
 	PageProxyConfig(ctx context.Context, input GetProxyConfigInput) ([]ProxyConfig, error)
 	FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.FeatureConfig, error)
+	FetchSegmentConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.Segment, error)
 }

--- a/repository/feature_flag_repo.go
+++ b/repository/feature_flag_repo.go
@@ -88,6 +88,17 @@ func (f FeatureFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) e
 	return nil
 }
 
+// GetFeatureConfigForEnvironment gets the feature config for environment from cache.
+func (f FeatureFlagRepo) GetFeatureConfigForEnvironment(ctx context.Context, envID string) ([]domain.FeatureFlag, bool) {
+	var features []domain.FeatureFlag
+	key := domain.NewFeatureConfigsKey(envID)
+	if err := f.cache.Get(ctx, string(key), &features); err != nil {
+		return features, false
+	}
+
+	return features, true
+}
+
 // Remove removes the feature entry from the cache
 func (f FeatureFlagRepo) Remove(ctx context.Context, env, identifier string) error {
 	fcKey := domain.NewFeatureConfigKey(env, identifier)

--- a/repository/segment_repo.go
+++ b/repository/segment_repo.go
@@ -79,6 +79,16 @@ func (s SegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfig) er
 	return nil
 }
 
+// GetSegmentsForEnvironment gets all the segments associated with environment id
+func (s SegmentRepo) GetSegmentsForEnvironment(ctx context.Context, envID string) ([]domain.Segment, bool) {
+	var segments []domain.Segment
+	key := domain.NewSegmentsKey(envID)
+	if err := s.cache.Get(ctx, string(key), &segments); err != nil {
+		return segments, false
+	}
+	return segments, true
+}
+
 // RemoveAllSegmentsForEnvironment removes all segments entries for given environment id
 func (s SegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error {
 	//get all the segments for given key

--- a/repository/segment_repo.go
+++ b/repository/segment_repo.go
@@ -103,7 +103,7 @@ func (s SegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id str
 }
 
 // Remove removes the Segment entry from the cache
-func (f SegmentRepo) Remove(ctx context.Context, env, identifier string) error {
+func (s SegmentRepo) Remove(ctx context.Context, env, identifier string) error {
 	sKey := domain.NewSegmentKey(env, identifier)
-	return f.cache.Delete(ctx, string(sKey))
+	return s.cache.Delete(ctx, string(sKey))
 }

--- a/repository/segment_repo.go
+++ b/repository/segment_repo.go
@@ -79,9 +79,8 @@ func (s SegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfig) er
 	return nil
 }
 
-// Remove removes all segment entries for given environment id
-func (s SegmentRepo) Remove(ctx context.Context, id string) error {
-
+// RemoveAllSegmentsForEnvironment removes all segments entries for given environment id
+func (s SegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error {
 	//get all the segments for given key
 	segments, err := s.Get(ctx, id)
 	if err != nil {
@@ -101,4 +100,10 @@ func (s SegmentRepo) Remove(ctx context.Context, id string) error {
 		}
 	}
 	return nil
+}
+
+// Remove removes the Segment entry from the cache
+func (f SegmentRepo) Remove(ctx context.Context, env, identifier string) error {
+	sKey := domain.NewSegmentKey(env, identifier)
+	return f.cache.Delete(ctx, string(sKey))
 }

--- a/repository/segment_repo_test.go
+++ b/repository/segment_repo_test.go
@@ -195,11 +195,11 @@ func TestSegmentRepo_Remove(t *testing.T) {
 			repo := NewSegmentRepo(tc.cache)
 
 			if tc.shouldErr {
-				assert.Error(t, repo.Remove(ctx, "123"))
+				assert.Error(t, repo.RemoveAllSegmentsForEnvironment(ctx, "123"))
 
 			} else {
 				assert.Nil(t, repo.Add(ctx, tc.repoConfig...))
-				assert.Nil(t, repo.Remove(ctx, "123"))
+				assert.Nil(t, repo.RemoveAllSegmentsForEnvironment(ctx, "123"))
 				flags, err := repo.Get(ctx, "123")
 				assert.Equal(t, flags, []domain.Segment{})
 				assert.Error(t, err)


### PR DESCRIPTION
```
[FFM-9610] : Refresh Segments
### What:
 When we get an SSE event telling us there’s been a change to segments, we should refresh the feature config that we’ve stored in our cache.
### Why:
Proxy to stay up to date with the Saas.
### Testing:
Locally
```

[FFM-9609]: https://harness.atlassian.net/browse/FFM-9609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FFM-9610]: https://harness.atlassian.net/browse/FFM-9610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ