### PR TITLE
[FFM-9787]: Cache cleanup on startup

### DIFF
--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -441,7 +441,7 @@ func TestRefresher_handleRemoveEnvironmentEvent(t *testing.T) {
 }
 
 type mockConfig struct {
-	fetchAndPopulate func(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error
+	fetchAndPopulate func(ctx context.Context, inventoryRepo domain.InventoryRepo, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error
 
 	populate func(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error
 	// Key returns proxyKey
@@ -457,8 +457,17 @@ type mockConfig struct {
 	setProxyConfigFn func(proxyConfig []domain.ProxyConfig)
 }
 
-func (m mockConfig) FetchAndPopulate(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error {
-	return m.fetchAndPopulate(ctx, authRepo, flagRepo, segmentRepo)
+type mockInventoryRepo struct {
+	addFn                      func(ctx context.Context, key string, assets map[string]string) error
+	removeFn                   func(ctx context.Context, key string) error
+	getFn                      func(ctx context.Context, key string) (map[string]string, error)
+	patchFn                    func(ctx context.Context, key string, assets []string) error
+	buildAssetListFromConfigFn func(config []domain.ProxyConfig) (map[string]string, error)
+	cleanupFn                  func(ctx context.Context, key string, config []domain.ProxyConfig) error
+}
+
+func (m mockConfig) FetchAndPopulate(ctx context.Context, inventory domain.InventoryRepo, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error {
+	return m.fetchAndPopulate(ctx, inventory, authRepo, flagRepo, segmentRepo)
 }
 
 func (m mockConfig) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error {

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -299,6 +299,7 @@ func main() {
 	flagRepo := repository.NewFeatureFlagRepo(sdkCache)
 	segmentRepo := repository.NewSegmentRepo(sdkCache)
 	authRepo := repository.NewAuthRepo(sdkCache)
+	inventoryRepo := repository.NewInventoryRepo(sdkCache)
 
 	// Create config that we'll use to populate our repos
 	conf, err := config.NewConfig(offline, configDir, proxyKey, clientSvc)
@@ -309,7 +310,7 @@ func main() {
 
 	// Read replicas don't need to care about populating the repos with config
 	if !readReplica {
-		if err := conf.FetchAndPopulate(ctx, authRepo, flagRepo, segmentRepo); err != nil {
+		if err := conf.FetchAndPopulate(ctx, inventoryRepo, authRepo, flagRepo, segmentRepo); err != nil {
 			logger.Error("failed to populate repos with config", "err", err)
 			os.Exit(1)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ import (
 // Config defines the interface for populating repositories with configuration data
 type Config interface {
 	// FetchAndPopulate authenticates, fetches and populates the config.
-	FetchAndPopulate(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error
+	FetchAndPopulate(ctx context.Context, inventoryRepo domain.InventoryRepo, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error
 
 	// Populate populates the repos with the config
 	Populate(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error

--- a/config/local/config.go
+++ b/config/local/config.go
@@ -62,7 +62,7 @@ func (c Config) SetProxyConfig(_ []domain.ProxyConfig) {
 
 }
 
-func (c Config) FetchAndPopulate(_ context.Context, _ domain.AuthRepo, _ domain.FlagRepo, _ domain.SegmentRepo) error {
+func (c Config) FetchAndPopulate(_ context.Context, _ domain.InventoryRepo, _ domain.AuthRepo, _ domain.FlagRepo, _ domain.SegmentRepo) error {
 	return nil
 }
 

--- a/config/remote/config.go
+++ b/config/remote/config.go
@@ -73,6 +73,8 @@ func (c *Config) FetchAndPopulate(ctx context.Context, inventory domain.Inventor
 }
 
 // Populate populates repositories with the config
+//
+//nolint:gocognit,cyclop
 func (c *Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error {
 	for _, cfg := range c.proxyConfig {
 		for _, env := range cfg.Environments {
@@ -103,7 +105,6 @@ func (c *Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRep
 					return fmt.Errorf("failed to add auth config to cache: %s", err)
 				}
 			}
-
 			if len(env.FeatureConfigs) > 0 {
 				if err := flagRepo.Add(ctx, domain.FlagConfig{
 					EnvironmentID:  env.ID.String(),

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -17,7 +17,7 @@ type mockInventoryRepo struct {
 	addFn                      func(ctx context.Context, key string, assets map[string]string) error
 	removeFn                   func(ctx context.Context, key string) error
 	getFn                      func(ctx context.Context, key string) (map[string]string, error)
-	patchFn                    func(ctx context.Context, key string, assets []string) error
+	patchFn                    func(ctx context.Context, key string, assets map[string]string) error
 	buildAssetListFromConfigFn func(config []domain.ProxyConfig) (map[string]string, error)
 	cleanupFn                  func(ctx context.Context, key string, config []domain.ProxyConfig) error
 }
@@ -34,7 +34,7 @@ func (m mockInventoryRepo) Get(ctx context.Context, key string) (map[string]stri
 	return m.getFn(ctx, key)
 }
 
-func (m mockInventoryRepo) Patch(ctx context.Context, key string, assets []string) error {
+func (m mockInventoryRepo) Patch(ctx context.Context, key string, assets map[string]string) error {
 	return m.patchFn(ctx, key, assets)
 }
 
@@ -464,7 +464,7 @@ func TestConfig_Populate(t *testing.T) {
 		getFn: func(ctx context.Context, key string) (map[string]string, error) {
 			return map[string]string{}, nil
 		},
-		patchFn: func(ctx context.Context, key string, assets []string) error {
+		patchFn: func(ctx context.Context, key string, assets map[string]string) error {
 			return nil
 		},
 		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]string, error) {

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -13,6 +13,39 @@ import (
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 )
 
+type mockInventoryRepo struct {
+	addFn                      func(ctx context.Context, key string, assets map[string]string) error
+	removeFn                   func(ctx context.Context, key string) error
+	getFn                      func(ctx context.Context, key string) (map[string]string, error)
+	patchFn                    func(ctx context.Context, key string, assets []string) error
+	buildAssetListFromConfigFn func(config []domain.ProxyConfig) (map[string]string, error)
+	cleanupFn                  func(ctx context.Context, key string, config []domain.ProxyConfig) error
+}
+
+func (m mockInventoryRepo) Add(ctx context.Context, key string, assets map[string]string) error {
+	return m.addFn(ctx, key, assets)
+}
+
+func (m mockInventoryRepo) Remove(ctx context.Context, key string) error {
+	return m.removeFn(ctx, key)
+}
+
+func (m mockInventoryRepo) Get(ctx context.Context, key string) (map[string]string, error) {
+	return m.getFn(ctx, key)
+}
+
+func (m mockInventoryRepo) Patch(ctx context.Context, key string, assets []string) error {
+	return m.patchFn(ctx, key, assets)
+}
+
+func (m mockInventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]string, error) {
+	return m.buildAssetListFromConfigFn(config)
+}
+
+func (m mockInventoryRepo) Cleanup(ctx context.Context, key string, config []domain.ProxyConfig) error {
+	return m.cleanupFn(ctx, key, config)
+}
+
 type mockAuthRepo struct {
 	config []domain.AuthConfig
 
@@ -20,15 +53,35 @@ type mockAuthRepo struct {
 	addAPIConfigsForEnvironmentFn func(ctx context.Context, envID string, apiKeys []string) error
 }
 
-func (m mockAuthRepo) AddAPIConfigsForEnvironment(ctx context.Context, envID string, apiKeys []string) error {
-	return m.addAPIConfigsForEnvironmentFn(ctx, envID, apiKeys)
-}
-func (m *mockAuthRepo) PatchAPIConfigForEnvironment(ctx context.Context, envID, apikey, action string) error {
+func (m mockAuthRepo) Remove(ctx context.Context, id []string) error {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m *mockAuthRepo) Remove(ctx context.Context, id []string) error {
+func (m mockAuthRepo) Get(ctx context.Context, key string) (map[string]string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthRepo) Patch(ctx context.Context, key string, assets []string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]string, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthRepo) Cleanup(ctx context.Context, key string, config []domain.ProxyConfig) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m mockAuthRepo) AddAPIConfigsForEnvironment(ctx context.Context, envID string, apiKeys []string) error {
+	return m.addAPIConfigsForEnvironmentFn(ctx, envID, apiKeys)
+}
+func (m *mockAuthRepo) PatchAPIConfigForEnvironment(ctx context.Context, envID, apikey, action string) error {
 	//TODO implement me
 	panic("implement me")
 }
@@ -53,6 +106,16 @@ type mockSegmentRepo struct {
 	removeFn                          func(ctx context.Context, env, id string) error
 	removeAllSegmentsForEnvironmentFn func(ctx context.Context, id string) error
 	getSegmentsForEnvironmentFn       func(ctx context.Context, envID string) ([]domain.Segment, bool)
+}
+
+func (m *mockSegmentRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockSegmentRepo) GetFeatureConfigForEnvironment(ctx context.Context, envID string) ([]domain.FeatureFlag, bool) {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (m *mockSegmentRepo) GetSegmentsForEnvironment(ctx context.Context, envID string) ([]domain.Segment, bool) {
@@ -323,6 +386,7 @@ func TestConfig_Populate(t *testing.T) {
 						return proxyConfig, nil
 					},
 				},
+
 				authRepo: &mockAuthRepo{
 					add: func(ctx context.Context, config ...domain.AuthConfig) error {
 						return nil
@@ -390,6 +454,27 @@ func TestConfig_Populate(t *testing.T) {
 		},
 	}
 
+	inventoryRepo := mockInventoryRepo{
+		addFn: func(ctx context.Context, key string, assets map[string]string) error {
+			return nil
+		},
+		removeFn: func(ctx context.Context, key string) error {
+			return nil
+		},
+		getFn: func(ctx context.Context, key string) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+		patchFn: func(ctx context.Context, key string, assets []string) error {
+			return nil
+		},
+		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]string, error) {
+			return map[string]string{}, nil
+		},
+		cleanupFn: func(ctx context.Context, key string, config []domain.ProxyConfig) error {
+			return nil
+		},
+	}
+
 	for desc, tc := range testCases {
 		desc := desc
 		tc := tc
@@ -397,7 +482,7 @@ func TestConfig_Populate(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			c := NewConfig(tc.args.key, tc.mocks.clientService)
 
-			err := c.FetchAndPopulate(context.Background(), tc.mocks.authRepo, tc.mocks.flagRepo, tc.mocks.segmentRepo)
+			err := c.FetchAndPopulate(context.Background(), inventoryRepo, tc.mocks.authRepo, tc.mocks.flagRepo, tc.mocks.segmentRepo)
 			if tc.shouldErr {
 				assert.NotNil(t, err)
 			} else {

--- a/domain/inventory.go
+++ b/domain/inventory.go
@@ -1,0 +1,13 @@
+package domain
+
+import (
+	"fmt"
+)
+
+// KeyInventory maps all assets associated with for proxy key.
+type KeyInventory string
+
+// NewKeyInventory creates a key inventory entry for the proxy key. This key contains all the entries associated with the proxy key.
+func NewKeyInventory(key string) KeyInventory {
+	return KeyInventory(fmt.Sprintf("key-%s-inventory", key))
+}

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -2,6 +2,16 @@ package domain
 
 import "context"
 
+// KeyRepo the interface for keyRepository.
+type InventoryRepo interface {
+	Add(ctx context.Context, key string, assets map[string]string) error
+	Remove(ctx context.Context, key string) error
+	Get(ctx context.Context, key string) (map[string]string, error)
+	Patch(ctx context.Context, key string, assets []string) error
+	BuildAssetListFromConfig(config []ProxyConfig) (map[string]string, error)
+	Cleanup(ctx context.Context, key string, config []ProxyConfig) error
+}
+
 // AuthRepo is the interface for the AuthRepository
 type AuthRepo interface {
 	Add(ctx context.Context, config ...AuthConfig) error

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -7,7 +7,7 @@ type InventoryRepo interface {
 	Add(ctx context.Context, key string, assets map[string]string) error
 	Remove(ctx context.Context, key string) error
 	Get(ctx context.Context, key string) (map[string]string, error)
-	Patch(ctx context.Context, key string, assets []string) error
+	Patch(ctx context.Context, key string, assets map[string]string) error
 	BuildAssetListFromConfig(config []ProxyConfig) (map[string]string, error)
 	Cleanup(ctx context.Context, key string, config []ProxyConfig) error
 }

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -1,0 +1,108 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/harness/ff-proxy/v2/cache"
+	"github.com/harness/ff-proxy/v2/domain"
+)
+
+// InventoryRepo is a repository that stores all references to all assets for the key.
+type InventoryRepo struct {
+	cache cache.Cache
+}
+
+// NewInventoryRepo creates new instance of inventory
+func NewInventoryRepo(c cache.Cache) InventoryRepo {
+	return InventoryRepo{
+		cache: c,
+	}
+}
+
+// Add sets the inventory for proxy config - list of assets for the key.
+func (i InventoryRepo) Add(ctx context.Context, key string, assets map[string]string) error {
+	return i.cache.Set(ctx, string(domain.NewProxyConfigsKey(key)), assets)
+}
+
+func (i InventoryRepo) Remove(_ context.Context, key string) error {
+	return nil
+}
+func (i InventoryRepo) Get(ctx context.Context, key string) (map[string]string, error) {
+	var inventory map[string]string
+	err := i.cache.Get(ctx, string(domain.NewProxyConfigsKey(key)), &inventory)
+	if err != nil && !errors.Is(err, domain.ErrCacheNotFound) {
+		return inventory, err
+	}
+	return inventory, nil
+}
+func (i InventoryRepo) Patch(_ context.Context, key string, assets []string) error {
+	return nil
+}
+
+// Cleanup removes all entries for the key which are in the old config but not in the new one
+func (i InventoryRepo) Cleanup(ctx context.Context, key string, config []domain.ProxyConfig) error {
+
+	oldAssets, err := i.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	newAssets, err := i.BuildAssetListFromConfig(config)
+	if err != nil {
+		return err
+	}
+
+	// work out assets to delete
+	for k, _ := range oldAssets {
+		// if the key exists in the new assets we don't want to delete it.
+		if _, ok := newAssets[k]; ok {
+			delete(oldAssets, k)
+		}
+	}
+
+	// what's left of old values. we want to delete.
+	for key, _ := range oldAssets {
+		err := i.cache.Delete(ctx, key)
+		if err != nil {
+			return err
+		}
+	}
+	// set new inventory.
+	return i.Add(ctx, key, newAssets)
+}
+
+// BuildAssetListFromConfig returns the list of keys for all assets associated with this proxyKey
+func (i InventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]string, error) {
+
+	empty := ""
+	inventory := make(map[string]string)
+
+	for _, cfg := range config {
+		for _, env := range cfg.Environments {
+			environment := env.ID.String()
+			if len(env.APIKeys) > 0 {
+				inventory[string(domain.NewAPIConfigsKey(environment))] = empty
+				for _, apiKey := range env.APIKeys {
+					inventory[string(domain.NewAuthAPIKey(apiKey))] = empty
+				}
+			}
+			if len(env.FeatureConfigs) > 0 {
+				inventory[string(domain.NewFeatureConfigsKey(environment))] = empty
+				for _, f := range env.FeatureConfigs {
+					inventory[string(domain.NewFeatureConfigKey(environment, f.Feature))] = empty
+				}
+			}
+
+			if len(env.Segments) > 0 {
+				//append segments
+				inventory[string(domain.NewFeatureConfigsKey(environment))] = empty
+				for _, f := range env.FeatureConfigs {
+					inventory[string(domain.NewFeatureConfigKey(environment, f.Feature))] = empty
+				}
+			}
+		}
+	}
+
+	return inventory, nil
+}

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -25,7 +25,7 @@ func (i InventoryRepo) Add(ctx context.Context, key string, assets map[string]st
 	return i.cache.Set(ctx, string(domain.NewKeyInventory(key)), assets)
 }
 
-func (i InventoryRepo) Remove(_ context.Context, key string) error {
+func (i InventoryRepo) Remove(_ context.Context, _ string) error {
 	return nil
 }
 func (i InventoryRepo) Get(ctx context.Context, key string) (map[string]string, error) {
@@ -36,7 +36,7 @@ func (i InventoryRepo) Get(ctx context.Context, key string) (map[string]string, 
 	}
 	return inventory, nil
 }
-func (i InventoryRepo) Patch(_ context.Context, key string, assets []string) error {
+func (i InventoryRepo) Patch(_ context.Context, _ string, _ map[string]string) error {
 	return nil
 }
 
@@ -54,7 +54,7 @@ func (i InventoryRepo) Cleanup(ctx context.Context, key string, config []domain.
 	}
 
 	// work out assets to delete
-	for k, _ := range oldAssets {
+	for k := range oldAssets {
 		// if the key exists in the new assets we don't want to delete it.
 		if _, ok := newAssets[k]; ok {
 			delete(oldAssets, k)
@@ -62,7 +62,7 @@ func (i InventoryRepo) Cleanup(ctx context.Context, key string, config []domain.
 	}
 
 	// what's left of old values. we want to delete.
-	for key, _ := range oldAssets {
+	for key := range oldAssets {
 		err := i.cache.Delete(ctx, key)
 		if err != nil {
 			return err

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -22,7 +22,7 @@ func NewInventoryRepo(c cache.Cache) InventoryRepo {
 
 // Add sets the inventory for proxy config - list of assets for the key.
 func (i InventoryRepo) Add(ctx context.Context, key string, assets map[string]string) error {
-	return i.cache.Set(ctx, string(domain.NewProxyConfigsKey(key)), assets)
+	return i.cache.Set(ctx, string(domain.NewKeyInventory(key)), assets)
 }
 
 func (i InventoryRepo) Remove(_ context.Context, key string) error {
@@ -30,7 +30,7 @@ func (i InventoryRepo) Remove(_ context.Context, key string) error {
 }
 func (i InventoryRepo) Get(ctx context.Context, key string) (map[string]string, error) {
 	var inventory map[string]string
-	err := i.cache.Get(ctx, string(domain.NewProxyConfigsKey(key)), &inventory)
+	err := i.cache.Get(ctx, string(domain.NewKeyInventory(key)), &inventory)
 	if err != nil && !errors.Is(err, domain.ErrCacheNotFound) {
 		return inventory, err
 	}


### PR DESCRIPTION
```
[FFM-9787]: Cache cleanup on startup
 ### What: 
- Keep track of all the inventory for the proxy key
- Delete all entries not in fresh config, during the startup.
- Patch inventory will be a separate function due to the PR size.
 ### Why:
To ensure we clean all cache entries which are no longer featured in SAAS.
Keep proxy/cache in sync with SAAS at all times.
 ### Testing:
Locally + unit tests
```

[FFM-9787]: https://harness.atlassian.net/browse/FFM-9787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ