### PR TITLE
[FFM-9780]: Update key inventory on event, APIKeys/Features/Segments

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -18,4 +18,7 @@ type Cache interface {
 
 	// HealthCheck checks cache health
 	HealthCheck(ctx context.Context) error
+
+	// Scan all the keys for given key
+	Scan(ctx context.Context, key string) (map[string]string, error)
 }

--- a/cache/in_mem.go
+++ b/cache/in_mem.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/harness/ff-proxy/v2/domain"
 	jsoniter "github.com/json-iterator/go"
+
+	"github.com/harness/ff-proxy/v2/domain"
 )
 
 // MemCache is an in memory cache that stores a map of keys to a map of fields
@@ -16,6 +17,12 @@ import (
 type MemCache struct {
 	*sync.RWMutex
 	data map[string][]byte
+}
+
+// Scan all the keys for given key
+func (m MemCache) Scan(_ context.Context, _ string) (map[string]string, error) {
+	//TODO implement equivalent.
+	return map[string]string{}, nil
 }
 
 // NewMemCache creates an initialised MemCache

--- a/cache/key_value_cache.go
+++ b/cache/key_value_cache.go
@@ -127,7 +127,6 @@ func (k *KeyValCache) Scan(ctx context.Context, key string) (map[string]string, 
 	scan := make(map[string]string)
 	iter := k.redisClient.Scan(ctx, 0, "*"+key+"*", 0).Iterator()
 	for iter.Next(ctx) {
-		//fmt.Println("keys", iter.Val())
 		scan[iter.Val()] = ""
 	}
 	if err := iter.Err(); err != nil {

--- a/cache/key_value_cache.go
+++ b/cache/key_value_cache.go
@@ -130,7 +130,7 @@ func (k *KeyValCache) Scan(ctx context.Context, key string) (map[string]string, 
 		scan[iter.Val()] = ""
 	}
 	if err := iter.Err(); err != nil {
-		panic(err)
+		return scan, fmt.Errorf("%w: KeyValCache.Scan failed to iterate over keset for key %q", err, key)
 	}
 	return scan, nil
 }

--- a/cache/key_value_cache.go
+++ b/cache/key_value_cache.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/go-redis/cache/v8"
 	"github.com/go-redis/redis/v8"
-	"github.com/harness/ff-proxy/v2/domain"
 	jsoniter "github.com/json-iterator/go"
+
+	"github.com/harness/ff-proxy/v2/domain"
 )
 
 // DoFn returns the item to be cached
@@ -119,4 +120,18 @@ func (k *KeyValCache) Keys(ctx context.Context, key string) ([]string, error) {
 // HealthCheck pings the underlying redis cache
 func (k *KeyValCache) HealthCheck(ctx context.Context) error {
 	return k.redisClient.Ping(ctx).Err()
+}
+
+// Scan returns a map of keys that match the pattern
+func (k *KeyValCache) Scan(ctx context.Context, key string) (map[string]string, error) {
+	scan := make(map[string]string)
+	iter := k.redisClient.Scan(ctx, 0, "*"+key+"*", 0).Iterator()
+	for iter.Next(ctx) {
+		//fmt.Println("keys", iter.Val())
+		scan[iter.Val()] = ""
+	}
+	if err := iter.Err(); err != nil {
+		panic(err)
+	}
+	return scan, nil
 }

--- a/cache/memoize_cache.go
+++ b/cache/memoize_cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"crypto/md5" //#nosec G501
 	"fmt"
 	"reflect"
@@ -54,6 +55,12 @@ func NewMemoizeCache(rc redis.UniversalClient, defaultExpiration, cleanupInterva
 	)
 
 	return mc
+}
+
+// Scan all the keys for given key
+func (m memoizeCache) Scan(cxt context.Context, key string) (map[string]string, error) {
+	//TODO
+	return m.Cache.Scan(cxt, key)
 }
 
 func (m memoizeCache) makeMarshalFunc(ffCache internalCache) func(interface{}) ([]byte, error) {

--- a/cache/memoize_cache.go
+++ b/cache/memoize_cache.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"context"
 	"crypto/md5" //#nosec G501
 	"fmt"
 	"reflect"
@@ -55,12 +54,6 @@ func NewMemoizeCache(rc redis.UniversalClient, defaultExpiration, cleanupInterva
 	)
 
 	return mc
-}
-
-// Scan all the keys for given key
-func (m memoizeCache) Scan(cxt context.Context, key string) (map[string]string, error) {
-	//TODO
-	return m.Cache.Scan(cxt, key)
 }
 
 func (m memoizeCache) makeMarshalFunc(ffCache internalCache) func(interface{}) ([]byte, error) {

--- a/cache/metrics.go
+++ b/cache/metrics.go
@@ -40,7 +40,7 @@ type MetricsCache struct {
 func (c MetricsCache) Scan(ctx context.Context, key string) (m map[string]string, err error) {
 	start := time.Now()
 	defer func() {
-		trackHistogram(start, c.scanDuration)
+		trackHistogram(start, c.scanDuration, key)
 		trackCounter(c.scanCount, key, getErrorLabel(err))
 	}()
 	return c.next.Scan(ctx, key)

--- a/cache/metrics.go
+++ b/cache/metrics.go
@@ -110,9 +110,11 @@ func NewMetricsCache(label string, reg prometheus.Registerer, next Cache) Metric
 		c.writeDuration,
 		c.readDuration,
 		c.deleteDuration,
+		c.scanDuration,
 		c.writeCount,
 		c.readCount,
 		c.deleteCount,
+		c.scanCount,
 	)
 	return c
 }

--- a/cache/metrics.go
+++ b/cache/metrics.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/harness/ff-proxy/v2/domain"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/harness/ff-proxy/v2/domain"
 )
 
 type counter interface {
@@ -32,6 +33,10 @@ type MetricsCache struct {
 	writeCount  counter
 	readCount   counter
 	deleteCount counter
+}
+
+func (c MetricsCache) Scan(ctx context.Context, key string) (map[string]string, error) {
+	return c.next.Scan(ctx, key)
 }
 
 // NewMetricsCache creates a MetricsCache

--- a/cache/metrics_test.go
+++ b/cache/metrics_test.go
@@ -13,6 +13,11 @@ type mockCache struct {
 	set    func() error
 	get    func() error
 	delete func() error
+	scan   func() (map[string]string, error)
+}
+
+func (m mockCache) Scan(ctx context.Context, key string) (map[string]string, error) {
+	return m.scan()
 }
 
 func (m mockCache) Set(ctx context.Context, key string, value interface{}) error {

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -305,13 +305,10 @@ func (s Refresher) updateFeatureConfigsEntry(ctx context.Context, env string, id
 			updatedFeatures = append(updatedFeatures, f)
 		}
 	}
-	if err := s.flagRepo.Add(ctx, domain.FlagConfig{
+	return s.flagRepo.Add(ctx, domain.FlagConfig{
 		EnvironmentID:  env,
 		FeatureConfigs: updatedFeatures,
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func (s Refresher) handleFetchSegmentEvent(ctx context.Context, env, id string) error {
@@ -386,13 +383,10 @@ func (s Refresher) updateSegmentConfigsEntry(ctx context.Context, env string, id
 			updatedSegment = append(updatedSegment, s)
 		}
 	}
-	if err := s.segmentRepo.Add(ctx, domain.SegmentConfig{
+	return s.segmentRepo.Add(ctx, domain.SegmentConfig{
 		EnvironmentID: env,
 		Segments:      updatedSegment,
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }
 
 func (s Refresher) addItems(assets map[string]string, configKey, configsKey string) (map[string]string, error) {

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -351,7 +351,7 @@ func (s Refresher) handleDeleteSegmentEvent(ctx context.Context, env, identifier
 		}
 	}
 
-	// remove deleted flag entry.
+	// remove deleted segment entry.
 	if err := s.segmentRepo.Remove(ctx, identifier); err != nil {
 		return err
 	}

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -27,15 +27,16 @@ type Refresher struct {
 	clientService     domain.ClientService
 	config            config.Config
 	proxyConfig       []domain.ProxyConfig
+	inventory         domain.InventoryRepo
 	authRepo          domain.AuthRepo
 	flagRepo          domain.FlagRepo
 	segmentRepo       domain.SegmentRepo
 }
 
 // NewRefresher creates a Refresher
-func NewRefresher(l log.Logger, config config.Config, client domain.ClientService, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) Refresher {
+func NewRefresher(l log.Logger, config config.Config, client domain.ClientService, inventory domain.InventoryRepo, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) Refresher {
 	l = l.With("component", "Refresher")
-	return Refresher{log: l, config: config, clientService: client, authRepo: authRepo, flagRepo: flagRepo, segmentRepo: segmentRepo}
+	return Refresher{log: l, config: config, clientService: client, inventory: inventory, authRepo: authRepo, flagRepo: flagRepo, segmentRepo: segmentRepo}
 }
 
 // HandleMessage makes Refresher implement the MessageHandler interface

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -375,7 +375,7 @@ func main() {
 		//
 		// Layering them in this order means that the first thing we'll do when we receive an SSE message
 		// is attempt to refresh the cache, then if that's successful we'll forward the event on to Redis and Pushpin
-		cacheRefresher := cache.NewRefresher(logger, conf, clientSvc, authRepo, flagRepo, segmentRepo)
+		cacheRefresher := cache.NewRefresher(logger, conf, clientSvc, inventoryRepo, authRepo, flagRepo, segmentRepo)
 		redisForwarder := stream.NewForwarder(logger, redisStream, cacheRefresher, stream.WithStreamName(sseStreamTopic))
 		messageHandler = stream.NewForwarder(logger, pushpinStream, redisForwarder)
 	}

--- a/config/local/config_test.go
+++ b/config/local/config_test.go
@@ -61,7 +61,7 @@ type mockSegmentRepo struct {
 	config []domain.SegmentConfig
 
 	add                               func(ctx context.Context, config ...domain.SegmentConfig) error
-	removeFn                          func(ctx context.Context, env, id string) error
+	removeFn                          func(ctx context.Context, id string) error
 	removeAllSegmentsForEnvironmentFn func(ctx context.Context, id string) error
 	getSegmentsForEnvironmentFn       func(ctx context.Context, envID string) ([]domain.Segment, bool)
 }
@@ -75,8 +75,8 @@ func (m *mockSegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, i
 	return m.removeAllSegmentsForEnvironmentFn(ctx, id)
 }
 
-func (m *mockSegmentRepo) Remove(ctx context.Context, env, id string) error {
-	return m.removeFn(ctx, env, id)
+func (m *mockSegmentRepo) Remove(ctx context.Context, id string) error {
+	return m.removeFn(ctx, id)
 }
 
 func (m *mockSegmentRepo) Add(ctx context.Context, config ...domain.SegmentConfig) error {
@@ -102,9 +102,8 @@ func (m *mockFlagRepo) RemoveAllFeaturesForEnvironment(ctx context.Context, id s
 	panic("implement me")
 }
 
-func (m *mockFlagRepo) Remove(ctx context.Context, env, id string) error {
-	//TODO implement me
-	panic("implement me")
+func (m *mockFlagRepo) Remove(ctx context.Context, id string) error {
+	return m.Remove(ctx, id)
 }
 
 func (m *mockFlagRepo) Add(ctx context.Context, config ...domain.FlagConfig) error {

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -7,9 +7,11 @@ type InventoryRepo interface {
 	Add(ctx context.Context, key string, assets map[string]string) error
 	Remove(ctx context.Context, key string) error
 	Get(ctx context.Context, key string) (map[string]string, error)
-	Patch(ctx context.Context, key string, assets map[string]string) error
+	Patch(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error
 	BuildAssetListFromConfig(config []ProxyConfig) (map[string]string, error)
 	Cleanup(ctx context.Context, key string, config []ProxyConfig) error
+	KeyExists(ctx context.Context, key string) bool
+	GetKeysForEnvironment(ctx context.Context, env string) (map[string]string, error)
 }
 
 // AuthRepo is the interface for the AuthRepository

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -26,7 +26,7 @@ type AuthRepo interface {
 // FlagRepo is the interface for the FlagRepository
 type FlagRepo interface {
 	Add(ctx context.Context, config ...FlagConfig) error
-	Remove(ctx context.Context, envID, id string) error
+	Remove(ctx context.Context, key string) error
 	RemoveAllFeaturesForEnvironment(ctx context.Context, id string) error
 	GetFeatureConfigForEnvironment(ctx context.Context, envID string) ([]FeatureFlag, bool)
 }
@@ -34,7 +34,7 @@ type FlagRepo interface {
 // SegmentRepo is the interface for the SegmentRepository
 type SegmentRepo interface {
 	Add(ctx context.Context, config ...SegmentConfig) error
-	Remove(ctx context.Context, envID, id string) error
+	Remove(ctx context.Context, identifier string) error
 	RemoveAllSegmentsForEnvironment(ctx context.Context, id string) error
 	GetSegmentsForEnvironment(ctx context.Context, envID string) ([]Segment, bool)
 }

--- a/repository/feature_flag_repo.go
+++ b/repository/feature_flag_repo.go
@@ -100,9 +100,8 @@ func (f FeatureFlagRepo) GetFeatureConfigForEnvironment(ctx context.Context, env
 }
 
 // Remove removes the feature entry from the cache
-func (f FeatureFlagRepo) Remove(ctx context.Context, env, identifier string) error {
-	fcKey := domain.NewFeatureConfigKey(env, identifier)
-	return f.cache.Delete(ctx, string(fcKey))
+func (f FeatureFlagRepo) Remove(ctx context.Context, identifier string) error {
+	return f.cache.Delete(ctx, identifier)
 }
 
 // RemoveAllFeaturesForEnvironment removes all feature entries for given environment id

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -120,7 +120,7 @@ func (i InventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (ma
 // KeyExists check if the given key exists in cache.
 func (i InventoryRepo) KeyExists(ctx context.Context, key string) bool {
 	var val interface{}
-	err := i.cache.Get(ctx, key, val)
+	err := i.cache.Get(ctx, key, &val)
 	if err != nil && errors.Is(err, domain.ErrCacheNotFound) {
 		return false
 	}

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -36,8 +36,18 @@ func (i InventoryRepo) Get(ctx context.Context, key string) (map[string]string, 
 	}
 	return inventory, nil
 }
-func (i InventoryRepo) Patch(_ context.Context, _ string, _ map[string]string) error {
-	return nil
+
+func (i InventoryRepo) Patch(ctx context.Context, key string, updateInventory func(assets map[string]string) (map[string]string, error)) error {
+	oldAssets, err := i.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+	//logic is different for every case.
+	newAssets, err := updateInventory(oldAssets)
+	if err != nil {
+		return err
+	}
+	return i.Add(ctx, key, newAssets)
 }
 
 // Cleanup removes all entries for the key which are in the old config but not in the new one
@@ -105,4 +115,23 @@ func (i InventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (ma
 	}
 
 	return inventory, nil
+}
+
+// KeyExists check if the given key exists in cache.
+func (i InventoryRepo) KeyExists(ctx context.Context, key string) bool {
+	var val interface{}
+	err := i.cache.Get(ctx, key, val)
+	if err != nil && errors.Is(err, domain.ErrCacheNotFound) {
+		return false
+	}
+	return true
+}
+
+// GetKeysForEnvironment get the map of keys for environment
+func (i InventoryRepo) GetKeysForEnvironment(ctx context.Context, env string) (map[string]string, error) {
+	scan, err := i.cache.Scan(ctx, env)
+	if err != nil {
+		return scan, err
+	}
+	return scan, nil
 }

--- a/repository/segment_repo.go
+++ b/repository/segment_repo.go
@@ -114,5 +114,5 @@ func (s SegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id str
 
 // Remove removes the Segment entry from the cache
 func (s SegmentRepo) Remove(ctx context.Context, identifier string) error {
-	return s.cache.Delete(ctx, string(identifier))
+	return s.cache.Delete(ctx, identifier)
 }

--- a/repository/segment_repo.go
+++ b/repository/segment_repo.go
@@ -113,7 +113,6 @@ func (s SegmentRepo) RemoveAllSegmentsForEnvironment(ctx context.Context, id str
 }
 
 // Remove removes the Segment entry from the cache
-func (s SegmentRepo) Remove(ctx context.Context, env, identifier string) error {
-	sKey := domain.NewSegmentKey(env, identifier)
-	return s.cache.Delete(ctx, string(sKey))
+func (s SegmentRepo) Remove(ctx context.Context, identifier string) error {
+	return s.cache.Delete(ctx, string(identifier))
 }


### PR DESCRIPTION
```
FFM-9780]: Update key inventory on event, APIKeys/Features/Segments
 ### What: 
- Keep track of all the inventory for the proxy key
- Update accordingly where state of the cache is changing. 
- due to the size of PR scope is only for APIKeys/Feature/Segments
 ### Why:
Keeping track of the key assets is important to ensure appropriate cache cleanup on the restart.
 ### Testing:
Locally + unit tests
```

[FFM-9780]: https://harness.atlassian.net/browse/FFM-9780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ