### PR TITLE
[FFM-9815]: Update key inventory on event - env add/remove

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -332,7 +332,7 @@ func main() {
 
 		gpc = gripcontrol.NewGripPubControl([]map[string]interface{}{
 			{
-				"control_uri": "http://localhost:5565",
+				"control_uri": "http://localhost:5561",
 			},
 		})
 		pushpinStream    = stream.NewPushpin(gpc)

--- a/config/local/config_test.go
+++ b/config/local/config_test.go
@@ -28,6 +28,11 @@ type mockAuthRepo struct {
 
 	add                           func(ctx context.Context, config ...domain.AuthConfig) error
 	addAPIConfigsForEnvironmentFn func(ctx context.Context, envID string, apiKeys []string) error
+	getKeysForEnvironmentFn       func(ctx context.Context, envID string) ([]string, bool)
+}
+
+func (m mockAuthRepo) GetKeysForEnvironment(ctx context.Context, envID string) ([]string, bool) {
+	return m.getKeysForEnvironmentFn(ctx, envID)
 }
 
 func (m mockAuthRepo) AddAPIConfigsForEnvironment(ctx context.Context, envID string, apiKeys []string) error {

--- a/config/remote/config.go
+++ b/config/remote/config.go
@@ -68,6 +68,7 @@ func (c *Config) FetchAndPopulate(ctx context.Context, inventory domain.Inventor
 	if err := inventory.Cleanup(ctx, c.key, proxyConfig); err != nil {
 		return err
 	}
+
 	c.proxyConfig = proxyConfig
 	return c.Populate(ctx, authRepo, flagRepo, segmentRepo)
 }

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -61,8 +61,12 @@ type mockAuthRepo struct {
 
 	add                           func(ctx context.Context, config ...domain.AuthConfig) error
 	addAPIConfigsForEnvironmentFn func(ctx context.Context, envID string, apiKeys []string) error
+	getKeysForEnvironmentFn       func(ctx context.Context, envID string) ([]string, bool)
 }
 
+func (m mockAuthRepo) GetKeysForEnvironment(ctx context.Context, envID string) ([]string, bool) {
+	return m.getKeysForEnvironmentFn(ctx, envID)
+}
 func (m mockAuthRepo) Remove(ctx context.Context, id []string) error {
 	//TODO implement me
 	panic("implement me")

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -20,6 +20,7 @@ type AuthRepo interface {
 	AddAPIConfigsForEnvironment(ctx context.Context, envID string, apiKeys []string) error
 	Remove(ctx context.Context, id []string) error
 	RemoveAllKeysForEnvironment(ctx context.Context, envID string) error
+	GetKeysForEnvironment(ctx context.Context, envID string) ([]string, bool)
 	PatchAPIConfigForEnvironment(ctx context.Context, envID, apikey, action string) error
 }
 


### PR DESCRIPTION
```
[FFM-9815]: Update key inventory on event - env add/remove
 ### What: 
- Keep track of all the inventory for the proxy key
- Update accordingly where state of the cache is changing. 
 ### Why:
Keeping track of the key assets is important to ensure appropriate cache cleanup on the restart.
 ### Testing:
Locally + unit tests
```

[FFM-9815]: https://harness.atlassian.net/browse/FFM-9815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ