### PR TITLE
[FFM-9816]: Update key inventory on event, deletedProxyKey

### DIFF
--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -181,6 +181,16 @@ func TestRefresher_HandleMessage(t *testing.T) {
 			expected:  expected{err: nil},
 			shouldErr: false,
 		},
+		"Given I have an SSEMessage with the domain 'proxy' event 'deleteProxyKey'": {
+			args: args{
+				message: domain.SSEMessage{
+					Domain: domain.MsgDomainProxy,
+					Event:  domain.EventProxyKeyDeleted,
+				},
+			},
+			expected:  expected{err: nil},
+			shouldErr: false,
+		},
 	}
 
 	mockClient := mockClientService{


### PR DESCRIPTION
```
FFM-9780]: Update key inventory on event, deletedProxyKey
 ### What: 
- Keep track of all the inventory for the proxy key
- All key assets are deleted when proxyKey is deleted.
 ### Why:
Keeping track of the key assets is important to ensure appropriate cache cleanup on the restart.
 ### Testing:
Locally + unit tests

```