### PR TITLE
FFM-9889 Fix config fetching on stream disconnect

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -344,7 +344,7 @@ func main() {
 		}
 
 		reloadConfig = func() error {
-			return conf.Populate(ctx, authRepo, flagRepo, segmentRepo)
+			return conf.FetchAndPopulate(ctx, inventoryRepo, authRepo, flagRepo, segmentRepo)
 		}
 
 		redisStream = stream.NewRedisStream(redisClient)


### PR DESCRIPTION
**What**

- Uses `FetchAndPopulate` over `Populate` in the config reload function. Populate used to do fetching but made a change to have FetchAndPopulate and Populate methods and just missed updating this line which meant we broke polling for changes on stream disconnects.

**Why**

- When the Proxy disconnects from the saas stream we need to be able to poll for changes. The reload function gets called on stream disconnects and when the stream fails to reconnect so this handles polling and cache refreshing for us