### PR TITLE
FFM-9888 Update Health response

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 )
@@ -47,16 +48,28 @@ func (a *EnvironmentID) UnmarshalBinary(b []byte) error {
 	return jsoniter.Unmarshal(b, a)
 }
 
-// EnvironmentHealth contains the health info for an environment
-type EnvironmentHealth struct {
-	ID           string       `json:"id"`
-	StreamStatus StreamStatus `json:"streamStatus"`
-}
-
 // StreamStatus contains a streams state
 type StreamStatus struct {
 	State StreamState `json:"state"`
 	Since int64       `json:"since"`
+}
+
+// NewStreamStatus creates a StreamStatus
+func NewStreamStatus() StreamStatus {
+	return StreamStatus{
+		State: StreamStateInitializing,
+		Since: time.Now().UnixMilli(),
+	}
+}
+
+// MarshalBinary makes StreamStatus implement the BinaryMarshaler interface
+func (s *StreamStatus) MarshalBinary() ([]byte, error) {
+	return jsoniter.Marshal(s)
+}
+
+// UnmarshalBinary makes StreamStatus implement the BinaryUnmarshaler interface
+func (s *StreamStatus) UnmarshalBinary(b []byte) error {
+	return jsoniter.Unmarshal(b, s)
 }
 
 // ToPtr is a helper func for converting any type to a pointer

--- a/domain/requests.go
+++ b/domain/requests.go
@@ -74,8 +74,8 @@ func (m *MetricsRequest) MarshalBinary() (data []byte, err error) {
 
 // HealthResponse contains the fields returned in a healthcheck response
 type HealthResponse struct {
-	Environments []EnvironmentHealth `json:"environments"`
-	CacheStatus  string              `json:"cacheStatus"`
+	StreamStatus StreamStatus `json:"streamStatus"`
+	CacheStatus  string       `json:"cacheStatus"`
 }
 
 type GetProxyConfigInput struct {

--- a/stream/health.go
+++ b/stream/health.go
@@ -2,36 +2,97 @@ package stream
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/harness/ff-proxy/v2/cache"
+	"github.com/harness/ff-proxy/v2/domain"
 )
 
 // Health maintains the health/status of a stream in a cache
 type Health struct {
-	c   cache.Cache
-	key string
+	c      cache.Cache
+	key    string
+	status domain.StreamStatus
 }
 
+// NewHealth creates a Health
 func NewHealth(k string, c cache.Cache) Health {
-	return Health{
-		key: k,
-		c:   c,
+	h := Health{
+		key:    k,
+		c:      c,
+		status: domain.NewStreamStatus(),
 	}
+
+	defaultStreamStatus := domain.StreamStatus{
+		State: domain.StreamStateInitializing,
+		Since: time.Now().UnixMilli(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// It's fine for us to ignore this error, if we fail to set the status
+	// to initialising we'll end up setting it as Connected or Disconnected
+	// in our OnConnect/OnDisconnect handlers when we attempt to stream
+	_ = h.c.Set(ctx, h.key, defaultStreamStatus)
+
+	return h
 }
 
+// SetHealthy sets the stream status as CONNECTED in the cache.
+// If the stream status is already CONNECTED it does nothing.
 func (h Health) SetHealthy(ctx context.Context) error {
-	return h.c.Set(ctx, h.key, true)
-}
-
-func (h Health) SetUnhealthy(ctx context.Context) error {
-	return h.c.Set(ctx, h.key, false)
-}
-
-func (h Health) StreamHealthy(ctx context.Context) (bool, error) {
-	var b bool
-	if err := h.c.Get(ctx, h.key, &b); err != nil {
-		return b, err
+	var streamStatus domain.StreamStatus
+	if err := h.c.Get(ctx, h.key, &streamStatus); err != nil {
+		// Ignore NotFound errors for this key because if the key doesn't
+		// exist we'll end up setting it at the end of this function
+		if !errors.Is(err, domain.ErrCacheNotFound) {
+			return err
+		}
 	}
 
-	return b, nil
+	// If current status is healthy then don't do anything
+	if streamStatus.State == domain.StreamStateConnected {
+		return nil
+	}
+
+	streamStatus.State = domain.StreamStateConnected
+	streamStatus.Since = time.Now().UnixMilli()
+
+	return h.c.Set(ctx, h.key, streamStatus)
+}
+
+// SetUnhealthy sets the stream status as DISCONNECTED in the cache.
+// If the stream status is already DISCONNECTED it does nothing.
+func (h Health) SetUnhealthy(ctx context.Context) error {
+	var streamStatus domain.StreamStatus
+	if err := h.c.Get(ctx, h.key, &streamStatus); err != nil {
+		// Ignore NotFound errors for this key because if the key doesn't
+		// exist we'll end up setting it at the end of this function
+		if !errors.Is(err, domain.ErrCacheNotFound) {
+			return err
+		}
+	}
+
+	// If current status is disconnected then we don't need to do anything
+	if streamStatus.State == domain.StreamStateDisconnected {
+		return nil
+	}
+
+	// Otherwise we update the state and since to be now
+	streamStatus.State = domain.StreamStateDisconnected
+	streamStatus.Since = time.Now().UnixMilli()
+
+	return h.c.Set(ctx, h.key, streamStatus)
+}
+
+// StreamStatus returns the StreamStatus from the cache
+func (h Health) StreamStatus(ctx context.Context) (domain.StreamStatus, error) {
+	var s domain.StreamStatus
+	if err := h.c.Get(ctx, h.key, &s); err != nil {
+		return domain.StreamStatus{}, err
+	}
+
+	return s, nil
 }


### PR DESCRIPTION
**What**

- Updates the health response so that it makes sense in the context of ProxyV2
- Added an extra poll for Config in the OnConnect handler for the Saas Stream. This will only happen if the previous stream state was disconnected

**Why**

- The current health response was ProxyV1 focused
- We poll for changes when the stream disconnects but there could be a minute between a disconnect an reconnect. If any changes were made in that minute we wouldn't have pulled them down when we reconnected

**Testing**

- Tested manually locally
- Update /health handler unit tests
- Found a /stream unit test that we could uncomment now that streaming is implemented