### PR TITLE
FFM-9893 Refresh Token before fetching new env config

### DIFF
--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -505,6 +505,8 @@ type mockConfig struct {
 	// Token returns the authToken that the Config uses to communicate with Harness SaaS
 	token func() string
 
+	refreshToken func() (string, error)
+
 	// ClusterIdentifier returns the identifier of the cluster that the Config authenticated against
 	clusterIdentifier func() string
 
@@ -561,6 +563,13 @@ func (m mockConfig) FetchAndPopulate(ctx context.Context, inventory domain.Inven
 
 func (m mockConfig) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRepo domain.FlagRepo, segmentRepo domain.SegmentRepo) error {
 	return m.populate(ctx, authRepo, flagRepo, segmentRepo)
+}
+
+func (m mockConfig) RefreshToken() (string, error) {
+	if m.refreshToken == nil {
+		return "", nil
+	}
+	return m.refreshToken()
 }
 
 func (m mockConfig) Key() string {

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,9 @@ type Config interface {
 	// Token returns the authToken that the Config uses to communicate with Harness SaaS
 	Token() string
 
+	// RefreshToken refreshes the auth token that the Config uses for fetching env config
+	RefreshToken() (string, error)
+
 	// ClusterIdentifier returns the identifier of the cluster that the Config authenticated against
 	ClusterIdentifier() string
 

--- a/config/local/config.go
+++ b/config/local/config.go
@@ -46,6 +46,12 @@ func (c Config) Token() string {
 	return ""
 }
 
+// RefreshToken returns an empty token and a nil error. Local config reads from a file rather than communicating with
+// saas so there is no token to refresh
+func (c Config) RefreshToken() (string, error) {
+	return "", nil
+}
+
 // ClusterIdentifier returns an empty string rather than a clusterIdentifier because local config
 // loads config from a file and doesn't make any requests to Harness SaaS
 func (c Config) ClusterIdentifier() string {

--- a/config/remote/config.go
+++ b/config/remote/config.go
@@ -31,6 +31,16 @@ func (c *Config) Token() string {
 	return c.token
 }
 
+func (c *Config) RefreshToken() (string, error) {
+	authResp, err := authenticate(c.key, c.ClientService)
+	if err != nil {
+		return "", err
+	}
+
+	c.token = authResp.Token
+	return c.token, nil
+}
+
 // ClusterIdentifier returns the identifier of the cluster that the Config authenticated against
 func (c *Config) ClusterIdentifier() string {
 	if c.clusterIdentifier == "" {


### PR DESCRIPTION
**What**

- Forces the Proxy to refresh the auth token it uses to fetch env config

**Why**

- When the Proxy starts up it authenticates and stores an auth token that it uses for future requests. The issue with this though is the auth token is only authorised for use with environments that existed when the Proxy started up. When we add a new environment and the Proxy tries to fetch this config it gets an unauthorised error because the toekn its using doesn't have access to the environmnet. To fix this we refresh the auth token which means the new one will have access to the newly created environment

**Testing**

- Tested manually locally