### PR TITLE
FFM-9930 Fix 403 when posting metrics for new env

### DIFF
--- a/clients/metrics_service/client_test.go
+++ b/clients/metrics_service/client_test.go
@@ -275,16 +275,20 @@ func TestMetricService_StoreMetrics(t *testing.T) {
 }
 
 func TestMetricService_SendMetrics(t *testing.T) {
+	tokenFn := func() string {
+		return defaultToken
+	}
+
 	postMetricsCount := 0
 	testCases := map[string]struct {
 		metrics              map[string]domain.MetricsRequest
-		token                string
+		token                func() string
 		expectedMetricsCount int
 		postMetricsWithResp  func(environment string) (*clientgen.PostMetricsResponse, error)
 	}{
 		"Given I send one environments metrics successfully": {
 			metrics:              map[string]domain.MetricsRequest{"123": env123MetricsFlag1},
-			token:                defaultToken,
+			token:                tokenFn,
 			expectedMetricsCount: 1,
 			postMetricsWithResp: func(environment string) (*clientgen.PostMetricsResponse, error) {
 				postMetricsCount++
@@ -295,7 +299,7 @@ func TestMetricService_SendMetrics(t *testing.T) {
 		},
 		"Given I have an error sending metrics for one env": {
 			metrics:              map[string]domain.MetricsRequest{"123": env123MetricsFlag1},
-			token:                defaultToken,
+			token:                tokenFn,
 			expectedMetricsCount: 1,
 			postMetricsWithResp: func(environment string) (*clientgen.PostMetricsResponse, error) {
 				postMetricsCount++
@@ -304,7 +308,7 @@ func TestMetricService_SendMetrics(t *testing.T) {
 		},
 		"Given I have 2 environments and the first errors we still send metrics for second env": {
 			metrics:              map[string]domain.MetricsRequest{"123": env123MetricsFlag1, "456": env456MetricsFlag1},
-			token:                defaultToken,
+			token:                tokenFn,
 			expectedMetricsCount: 2,
 			postMetricsWithResp: func(environment string) (*clientgen.PostMetricsResponse, error) {
 				postMetricsCount++
@@ -316,7 +320,7 @@ func TestMetricService_SendMetrics(t *testing.T) {
 		},
 		"Given I have 2 environments and the first returns non 200 we still send metrics for second env": {
 			metrics:              map[string]domain.MetricsRequest{"123": env123MetricsFlag1, "456": env456MetricsFlag1},
-			token:                defaultToken,
+			token:                tokenFn,
 			expectedMetricsCount: 2,
 			postMetricsWithResp: func(environment string) (*clientgen.PostMetricsResponse, error) {
 				postMetricsCount++

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -480,7 +480,7 @@ func createMetricsService(ctx context.Context, logger log.Logger, conf config.Co
 	}
 
 	metricsEnabled := metricPostDuration != 0 && !offline
-	ms, err := metricsservice.NewClient(logger, metricService, conf.Token(), metricsEnabled, promReg, redisStream)
+	ms, err := metricsservice.NewClient(logger, metricService, conf.Token, metricsEnabled, promReg, redisStream)
 	if err != nil {
 		logger.Error("failed to create client for the feature flags metric service", "err", err)
 		os.Exit(1)


### PR DESCRIPTION
**What**

- Fixes a bug where we'd get a 403 if we created a new environment while the Proxy was running and the Proxy tried to forward metrics for that environment to Saas.

**Why**

- When a new env gets created we refresh the auth token that the proxy uses to commuincate with Saas so that it has the new env in the claims. However in the metrics service we were still using the old token that was fetched on startup which meant the metrics request for the new env would get a 403 from Saas.

**Testing**

- Manually tested locally