### PR TITLE
FFM-9931 Cleanup logging 

### DIFF
--- a/config/local/config_test.go
+++ b/config/local/config_test.go
@@ -28,10 +28,10 @@ type mockAuthRepo struct {
 
 	add                           func(ctx context.Context, config ...domain.AuthConfig) error
 	addAPIConfigsForEnvironmentFn func(ctx context.Context, envID string, apiKeys []string) error
-	getKeysForEnvironmentFn       func(ctx context.Context, envID string) ([]string, bool)
+	getKeysForEnvironmentFn       func(ctx context.Context, envID string) ([]string, error)
 }
 
-func (m mockAuthRepo) GetKeysForEnvironment(ctx context.Context, envID string) ([]string, bool) {
+func (m mockAuthRepo) GetKeysForEnvironment(ctx context.Context, envID string) ([]string, error) {
 	return m.getKeysForEnvironmentFn(ctx, envID)
 }
 

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -61,10 +61,10 @@ type mockAuthRepo struct {
 
 	add                           func(ctx context.Context, config ...domain.AuthConfig) error
 	addAPIConfigsForEnvironmentFn func(ctx context.Context, envID string, apiKeys []string) error
-	getKeysForEnvironmentFn       func(ctx context.Context, envID string) ([]string, bool)
+	getKeysForEnvironmentFn       func(ctx context.Context, envID string) ([]string, error)
 }
 
-func (m mockAuthRepo) GetKeysForEnvironment(ctx context.Context, envID string) ([]string, bool) {
+func (m mockAuthRepo) GetKeysForEnvironment(ctx context.Context, envID string) ([]string, error) {
 	return m.getKeysForEnvironmentFn(ctx, envID)
 }
 func (m mockAuthRepo) Remove(ctx context.Context, id []string) error {

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -20,7 +20,7 @@ type AuthRepo interface {
 	AddAPIConfigsForEnvironment(ctx context.Context, envID string, apiKeys []string) error
 	Remove(ctx context.Context, id []string) error
 	RemoveAllKeysForEnvironment(ctx context.Context, envID string) error
-	GetKeysForEnvironment(ctx context.Context, envID string) ([]string, bool)
+	GetKeysForEnvironment(ctx context.Context, envID string) ([]string, error)
 	PatchAPIConfigForEnvironment(ctx context.Context, envID, apikey, action string) error
 }
 


### PR DESCRIPTION
**What**

- Fixes a logging typo where we were logging `failed to handle
  addEnvironmentEvent` when we should have been logging `failed to
handle removeEnvironmentEvent`

- Bubbles up the domain.ErrCacheNotFound error to the cache refresher
  and ignores logging/returning the error if we try to remove assets and
the key doesn't exist.

**Why**

- If I created an environment that had no segments and deleted it the
  removeEnvironmentHandler would error out with this message because no
segments existed in the cache for it to remove. We probably don't want
to be logging this as a warning/error because it's valid for an
environment to exist with no segments,
```{"level":"warn","ts":"2023-11-15T09:40:03Z","caller":"stream/sse.go:52","msg":"failed to handle message","err":"failed to remove segment config from cache for environment 67ad9739-276f-4bcd-aa3e-1ba8cbdf35c0 with error cache: not found: KeyValCache.Get key env-67ad9739-276f-4bcd-aa3e-1ba8cbdf35c0-segments doesn't exist in cache: redis: nil"}```
- Similarly I think there was a situation where if I created an environment with no SDK keys and
  deleted it, we would error out of the handler before we attempted to
remove the Flags or Segments

**Testing**

- Manual testing locally
- Added a unit test