### PR TITLE
FFM-9957 Add cluster identifier to client service requests

### DIFF
--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -313,7 +313,7 @@ func (s Refresher) handleRemoveAPIKeyEvent(ctx context.Context, env, apiKey stri
 func (s Refresher) handleFetchFeatureEvent(ctx context.Context, env, id string) error {
 	s.log.Debug("updating featureConfig entry", "environment", env, "identifier", id)
 
-	featureConfigs, err := s.clientService.FetchFeatureConfigForEnvironment(ctx, s.config.Token(), env)
+	featureConfigs, err := s.clientService.FetchFeatureConfigForEnvironment(ctx, s.config.Token(), s.config.ClusterIdentifier(), env)
 	if err != nil {
 		return err
 	}
@@ -394,7 +394,7 @@ func (s Refresher) updateFeatureConfigsEntry(ctx context.Context, env string, id
 func (s Refresher) handleFetchSegmentEvent(ctx context.Context, env, id string) error {
 	s.log.Debug("updating featureConfig entry", "environment", env, "identifier", id)
 
-	segmentConfig, err := s.clientService.FetchSegmentConfigForEnvironment(ctx, s.config.Token(), env)
+	segmentConfig, err := s.clientService.FetchSegmentConfigForEnvironment(ctx, s.config.Token(), s.config.ClusterIdentifier(), env)
 	if err != nil {
 		return err
 	}

--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -736,11 +736,11 @@ type mockClientService struct {
 	FetchSegmentConfigForEnvironmentFn func(ctx context.Context, authToken, envId string) ([]clientgen.Segment, error)
 }
 
-func (c mockClientService) FetchSegmentConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.Segment, error) {
+func (c mockClientService) FetchSegmentConfigForEnvironment(ctx context.Context, authToken, cluster, envId string) ([]clientgen.Segment, error) {
 	return c.FetchSegmentConfigForEnvironmentFn(ctx, authToken, envId)
 }
 
-func (c mockClientService) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.FeatureConfig, error) {
+func (c mockClientService) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, cluster, envId string) ([]clientgen.FeatureConfig, error) {
 	return c.FetchFeatureConfigForEnvironmentFn(ctx, authToken, envId)
 }
 

--- a/clients/client_service/client.go
+++ b/clients/client_service/client.go
@@ -218,8 +218,8 @@ func (c Client) getProxyConfig(ctx context.Context, input domain.GetProxyConfigI
 	return *resp.JSON200, nil
 }
 
-func (c Client) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.FeatureConfig, error) {
-	resp, err := c.client.GetFeatureConfigWithResponse(ctx, envID, &clientgen.GetFeatureConfigParams{}, func(ctx context.Context, req *http.Request) error {
+func (c Client) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, cluster, envID string) ([]clientgen.FeatureConfig, error) {
+	resp, err := c.client.GetFeatureConfigWithResponse(ctx, envID, &clientgen.GetFeatureConfigParams{Cluster: &cluster}, func(ctx context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 		return nil
 	})
@@ -238,9 +238,9 @@ func (c Client) FetchFeatureConfigForEnvironment(ctx context.Context, authToken,
 	return *resp.JSON200, nil
 }
 
-func (c Client) FetchSegmentConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.Segment, error) {
+func (c Client) FetchSegmentConfigForEnvironment(ctx context.Context, authToken, cluster, envID string) ([]clientgen.Segment, error) {
 
-	resp, err := c.client.GetAllSegmentsWithResponse(ctx, envID, &clientgen.GetAllSegmentsParams{}, func(ctx context.Context, req *http.Request) error {
+	resp, err := c.client.GetAllSegmentsWithResponse(ctx, envID, &clientgen.GetAllSegmentsParams{Cluster: &cluster}, func(ctx context.Context, req *http.Request) error {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 		return nil
 	})

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -398,7 +398,7 @@ func main() {
 		redisForwarder := stream.NewForwarder(logger, redisStream, cacheRefresher, stream.WithStreamName(sseStreamTopic))
 		messageHandler = stream.NewForwarder(logger, pushpinStream, redisForwarder)
 
-		streamURL := fmt.Sprintf("%s/stream", clientService)
+		streamURL := fmt.Sprintf("%s/stream?cluster=%s", clientService, conf.ClusterIdentifier())
 		sseClient := stream.NewSSEClient(logger, streamURL, proxyKey, conf.Token())
 
 		saasStream := stream.NewStream(

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -186,12 +186,12 @@ type mockClientService struct {
 	pageProxyConfig func() ([]domain.ProxyConfig, error)
 }
 
-func (m mockClientService) FetchSegmentConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.Segment, error) {
+func (m mockClientService) FetchSegmentConfigForEnvironment(ctx context.Context, authToken, cluster, envID string) ([]clientgen.Segment, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (m mockClientService) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envId string) ([]clientgen.FeatureConfig, error) {
+func (m mockClientService) FetchFeatureConfigForEnvironment(ctx context.Context, authToken, cluster, envId string) ([]clientgen.FeatureConfig, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/domain/services.go
+++ b/domain/services.go
@@ -10,6 +10,6 @@ import (
 type ClientService interface {
 	AuthenticateProxyKey(ctx context.Context, key string) (AuthenticateProxyKeyResponse, error)
 	PageProxyConfig(ctx context.Context, input GetProxyConfigInput) ([]ProxyConfig, error)
-	FetchFeatureConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.FeatureConfig, error)
-	FetchSegmentConfigForEnvironment(ctx context.Context, authToken, envID string) ([]clientgen.Segment, error)
+	FetchFeatureConfigForEnvironment(ctx context.Context, authToken, cluster string, envID string) ([]clientgen.FeatureConfig, error)
+	FetchSegmentConfigForEnvironment(ctx context.Context, authToken, cluster string, envID string) ([]clientgen.Segment, error)
 }


### PR DESCRIPTION
**What**

- Adds the cluster identifier to all requests that hit the ff client service

**Why**

- We should have had this in but missed it and got away with some stuff working because the routing on the LB was setup to always default to a certain cluster which meant we missed it until we tried doing tests against Prod1 & Prod2 which showed up some bugs