### PR TITLE
FFM-10052 Add CreateSDKKey E2E tests

### DIFF
--- a/tests/e2e/sdk_key_refreshing_test.go
+++ b/tests/e2e/sdk_key_refreshing_test.go
@@ -1,0 +1,117 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/harness/ff-proxy/v2/gen/client"
+	"github.com/harness/ff-proxy/v2/tests/e2e/testhelpers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSDKKeyCreated(t *testing.T) {
+	var (
+		org          = GetOrgIdentifier()
+		project      = GetProjectIdentifier()
+		defaultEnv   = testhelpers.GetDefaultEnvironment()
+		secondaryEnv = testhelpers.GetSecondaryEnvironment()
+	)
+
+	type args struct {
+		sdkKeyIdentifier string
+		environment      string
+	}
+
+	type mocks struct {
+	}
+
+	type expected struct {
+		statusCode int
+	}
+
+	createSDKKey := func(identifier string, env string, t *testing.T) string {
+		body := testhelpers.GetAddAPIKeyBody(identifier, "Server", identifier, "", "")
+		resp, err := testhelpers.AddAPIKey(org, body, project, env)
+		assert.Nil(t, err)
+		assert.NotNil(t, resp.JSON201)
+
+		return resp.JSON201.ApiKey
+	}
+
+	deleteSDKKey := func(identifier string, env string, t *testing.T) {
+		_, err := testhelpers.DeleteSDKKey(org, project, env, identifier)
+		if err != nil {
+			t.Logf("failed to cleanup sdk key at the end of test: %s", err)
+		}
+	}
+
+	testCases := map[string]struct {
+		args          args
+		mocks         mocks
+		createSDKKey  func(identifier string, env string, t *testing.T) string
+		cleanupSDKKey func(identifier string, env string, t *testing.T)
+		expected      expected
+	}{
+		"Given I create a new SDK key in an environment that is associated with my ProxyKey": {
+			args: args{
+				sdkKeyIdentifier: "CreateSDKKeyTest_HappyPath",
+				environment:      defaultEnv,
+			},
+			createSDKKey:  createSDKKey,
+			cleanupSDKKey: deleteSDKKey,
+			expected:      expected{statusCode: http.StatusOK},
+		},
+		"Given I create a new SDK key in an environment that is NOT associated with my ProxyKey": {
+			args: args{
+				sdkKeyIdentifier: "CreateSDKKeyTest_SadPath",
+				environment:      secondaryEnv,
+			},
+			createSDKKey:  createSDKKey,
+			cleanupSDKKey: deleteSDKKey,
+			expected:      expected{statusCode: http.StatusUnauthorized},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			defer func() {
+				tc.cleanupSDKKey(tc.args.sdkKeyIdentifier, tc.args.environment, t)
+			}()
+			sdkKey := tc.createSDKKey(tc.args.sdkKeyIdentifier, tc.args.environment, t)
+
+			proxyClient := testhelpers.DefaultEvaluationClient(GetStreamURL())
+
+			var resp *http.Response
+			err := retry.Do(func() error {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+
+				r, err := proxyClient.Authenticate(ctx, client.AuthenticateJSONRequestBody{
+					ApiKey: sdkKey,
+				})
+				if err != nil {
+					return err
+				}
+				resp = r
+
+				if resp.StatusCode != tc.expected.statusCode {
+					return errors.New("blah")
+				}
+
+				return nil
+			},
+				retry.Attempts(5), retry.Delay(1000*time.Millisecond),
+			)
+
+			assert.Nil(t, err)
+			assert.Equal(t, tc.expected.statusCode, resp.StatusCode)
+		})
+	}
+}

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/harness/ff-proxy/v2/tests/e2e/testhelpers"
 	"github.com/joho/godotenv"
 	log "github.com/sirupsen/logrus"
 )
@@ -36,6 +37,7 @@ func Setup() {
 		log.Infof("%s", x)
 	}
 
+	testhelpers.SetAuthToken(testhelpers.GetUserAccessToken())
 	// wait for service to be healthy
 
 }

--- a/tests/e2e/testhelpers/admin.go
+++ b/tests/e2e/testhelpers/admin.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/harness/ff-proxy/v2/domain"
 	"github.com/harness/ff-proxy/v2/gen/admin"
 )
 
@@ -153,7 +154,8 @@ func CreateProxyKeyForMultipleOrgs(ctx context.Context, keyIdentifier, account, 
 					Projects: &admin.ProjectDictionary_Projects{
 						AdditionalProperties: map[string]admin.ProxyKeyProject{
 							project1: {
-								Scope: "all",
+								Scope:        "selected",
+								Environments: domain.ToPtr([]string{GetDefaultEnvironment()}),
 							},
 							emptyProject: {
 								Scope: "all",
@@ -173,7 +175,7 @@ func CreateProxyKeyForMultipleOrgs(ctx context.Context, keyIdentifier, account, 
 			},
 		},
 	}
-	
+
 	resp, err := c.CreateProxyKey(ctx, params, body, AddAuthToken)
 	if err != nil {
 		return "", err

--- a/tests/e2e/testhelpers/apikey.go
+++ b/tests/e2e/testhelpers/apikey.go
@@ -42,3 +42,19 @@ func GetAddAPIKeyBody(identifier string, apiKeyType string, name string, descrip
 		Type:        admin.ApiKeyRequestType(apiKeyType),
 	}
 }
+
+func DeleteSDKKey(org, project, env, identifier string) (*admin.DeleteAPIKeyResponse, error) {
+	client := DefaultClient()
+
+	resp, err := client.DeleteAPIKey(context.Background(), admin.Identifier(identifier), &admin.DeleteAPIKeyParams{
+		ProjectIdentifier:     admin.ProjectQueryParam(project),
+		EnvironmentIdentifier: admin.EnvironmentQueryParam(env),
+		AccountIdentifier:     admin.AccountQueryParam(GetDefaultAccount()),
+		OrgIdentifier:         admin.OrgQueryParam(org),
+	}, AddAuthToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return admin.ParseDeleteAPIKeyResponse(resp)
+}

--- a/tests/e2e/testhelpers/platform.go
+++ b/tests/e2e/testhelpers/platform.go
@@ -50,6 +50,11 @@ func GetDefaultEnvironment() string {
 	return os.Getenv("DEFAULT_ENVIRONMENT")
 }
 
+// GetSecondaryEnvironment ...
+func GetSecondaryEnvironment() string {
+	return os.Getenv("SECONDARY_ENVIRONMENT")
+}
+
 // GetClientURL ...
 func GetClientURL() string {
 	return os.Getenv("CLIENT_URL")

--- a/tests/e2e/testhelpers/project.go
+++ b/tests/e2e/testhelpers/project.go
@@ -27,11 +27,12 @@ const (
 
 // TestProject represents a project that we will create during tests
 type TestProject struct {
-	Account           string
-	Organization      string
-	ProjectIdentifier string
-	Environment       Environment
-	Flags             map[string]v1.FeatureFlagRequest
+	Account              string
+	Organization         string
+	ProjectIdentifier    string
+	DefaultEnvironment   Environment
+	SecondaryEnvironment Environment
+	Flags                map[string]v1.FeatureFlagRequest
 }
 
 // Environment contains entities that we will use to drive test data
@@ -88,6 +89,12 @@ func SetupTestProject(org string) (TestProject, error) {
 		return TestProject{}, err
 	}
 
+	// Create a second environment that won't be associated with our Proxy key for use in tests
+	env2, err := setupEnvironment(org, projectIdentifier, GetSecondaryEnvironment())
+	if err != nil {
+		return TestProject{}, err
+	}
+
 	// create bool flag
 	var flags = make(map[string]v1.FeatureFlagRequest)
 	boolflag := GenerateBooleanFeatureFlagBody(projectIdentifier, 1)
@@ -112,11 +119,12 @@ func SetupTestProject(org string) (TestProject, error) {
 	}
 
 	return TestProject{
-		Account:           GetDefaultAccount(),
-		Organization:      org,
-		ProjectIdentifier: projectIdentifier,
-		Environment:       env1,
-		Flags:             flags,
+		Account:              GetDefaultAccount(),
+		Organization:         org,
+		ProjectIdentifier:    projectIdentifier,
+		DefaultEnvironment:   env1,
+		SecondaryEnvironment: env2,
+		Flags:                flags,
 	}, nil
 }
 
@@ -137,10 +145,10 @@ func SetupTestEmptyProject(org string) (TestProject, error) {
 	}
 
 	return TestProject{
-		Account:           GetDefaultAccount(),
-		Organization:      org,
-		ProjectIdentifier: projectIdentifier,
-		Environment:       env1,
+		Account:            GetDefaultAccount(),
+		Organization:       org,
+		ProjectIdentifier:  projectIdentifier,
+		DefaultEnvironment: env1,
 	}, nil
 }
 

--- a/tests/e2e/testhelpers/setup/.env.setup
+++ b/tests/e2e/testhelpers/setup/.env.setup
@@ -1,6 +1,7 @@
 DEFAULT_ACCOUNT       = ""
 DEFAULT_ORG           = "default"
 DEFAULT_ENVIRONMENT   = "default"
+SECONDARY_ENVIRONMENT = "secondEnv"
 ADMIN_URL            = "https://app.harness.io/gateway/cf"
 CLIENT_URL = "https://config.ff.harness.io/api/1.0"
 SECONDARY_ORG         = "FF"

--- a/tests/e2e/testhelpers/setup/main.go
+++ b/tests/e2e/testhelpers/setup/main.go
@@ -41,7 +41,13 @@ CLIENT_URL=https://app.harness.io/gateway/cf
 PROXY_KEY=%s
 PROXY_AUTH_KEY=%s
 SERVER_API_KEY=%s
-EMPTY_PROJECT_API_KEY=%s`
+EMPTY_PROJECT_API_KEY=%s
+PLATFORM_BASE_URL=https://app.harness.io/gateway/ng/api
+DEFAULT_ENVIRONMENT=%s
+SECONDARY_ENVIRONMENT=%s
+DEFAULT_ACCOUNT=%s
+USER_ACCESS_TOKEN=%s
+ADMIN_URL=https://app.harness.io/gateway/cf`
 
 // var onlineProxyInMemTemplate = `ACCOUNT_IDENTIFIER=%s
 // ORG_IDENTIFIER=%s
@@ -143,7 +149,25 @@ func main() {
 		log.Fatalf("failed to open %s: %s", onlineTestFileName, err)
 	}
 
-	_, err = io.WriteString(onlineTestFile, fmt.Sprintf(onlineTestTemplate, testhelpers.GetAdminURL(), projects[0].Account, projects[0].Organization, projects[1].Organization, projects[0].ProjectIdentifier, projects[1].ProjectIdentifier, projects[0].Environment.Identifier, proxyKey, proxyAuthToken, project.Environment.Keys[0].ApiKey, empty.Environment.Keys[0].ApiKey))
+	_, err = io.WriteString(onlineTestFile, fmt.Sprintf(
+		onlineTestTemplate,
+		testhelpers.GetAdminURL(),
+		projects[0].Account,
+		projects[0].Organization,
+		projects[1].Organization,
+		projects[0].ProjectIdentifier,
+		projects[1].ProjectIdentifier,
+		projects[0].DefaultEnvironment.Identifier,
+		proxyKey,
+		proxyAuthToken,
+		project.DefaultEnvironment.Keys[0].ApiKey,
+		empty.DefaultEnvironment.Keys[0].ApiKey,
+		projects[0].DefaultEnvironment.Identifier,
+		projects[0].SecondaryEnvironment.Identifier,
+		testhelpers.GetDefaultAccount(),
+		testhelpers.GetUserAccessToken(),
+	),
+	)
 	if err != nil {
 		log.Fatalf("failed to write to %s: %s", onlineTestFileName, err)
 	}

--- a/tests/e2e/testhelpers/setup/main.go
+++ b/tests/e2e/testhelpers/setup/main.go
@@ -193,7 +193,7 @@ func main() {
 		log.Fatalf("failed to open %s: %s", onlineRedisProxy, err)
 	}
 
-	_, err = io.WriteString(onlineProxyRedisFile, fmt.Sprintf(onlineProxyRedisTemplate, testhelpers.GetDefaultAccount(), projects[0].Organization, projects[1].Organization, proxyKey, proxyAuthToken, project.Environment.Keys[0].ApiKey, empty.Environment.Keys[0].ApiKey))
+	_, err = io.WriteString(onlineProxyRedisFile, fmt.Sprintf(onlineProxyRedisTemplate, testhelpers.GetDefaultAccount(), projects[0].Organization, projects[1].Organization, proxyKey, proxyAuthToken, project.DefaultEnvironment.Keys[0].ApiKey, empty.DefaultEnvironment.Keys[0].ApiKey))
 	if err != nil {
 		log.Fatalf("failed to write to %s: %s", onlineRedisProxy, err)
 	}
@@ -207,7 +207,7 @@ func main() {
 	//	log.Fatalf("failed to open %s: %s", generateOfflineConfig, err)
 	//}
 	//
-	//_, err = io.WriteString(generateOfflineFile, fmt.Sprintf(generateOfflineConfigTemplate, testhelpers.GetDefaultAccount(), testhelpers.GetDefaultOrg(), testhelpers.GetUserAccessToken(), project.Environment.Keys[0].ApiKey))
+	//_, err = io.WriteString(generateOfflineFile, fmt.Sprintf(generateOfflineConfigTemplate, testhelpers.GetDefaultAccount(), testhelpers.GetDefaultOrg(), testhelpers.GetUserAccessToken(), project.DefaultEnvironment.Keys[0].ApiKey))
 	//if err != nil {
 	//	log.Fatalf("failed to write to %s: %s", generateOfflineConfig, err)
 	//}


### PR DESCRIPTION
**What**

- Adds e2e tests to test that when we create SDK keys in Saas they get pushed down to the Proxy and can be used against the Proxy