### PR TITLE
FFM-9943 Add prometheus metrics to client service requests

### DIFF
--- a/clients/client_service/client_test.go
+++ b/clients/client_service/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/harness/ff-proxy/v2/log"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/harness/ff-proxy/v2/domain"
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
@@ -105,7 +106,7 @@ func TestClientService_Authenticate(t *testing.T) {
 		tc := tc
 		t.Run(desc, func(t *testing.T) {
 			logger, _ := log.NewStructuredLogger("DEBUG")
-			clientService, _ := NewClient(logger, "localhost:8000")
+			clientService, _ := NewClient(logger, "localhost:8000", prometheus.NewRegistry())
 			clientService.client = &tc.mockService
 
 			actual, err := clientService.Authenticate(context.Background(), "", domain.Target{})

--- a/clients/client_service/prometheus.go
+++ b/clients/client_service/prometheus.go
@@ -1,0 +1,91 @@
+package clientservice
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// prometheusClient is used to decorating an ffClientService implementation that tracks prometheus metrics
+type prometheusClient struct {
+	requestCount    *prometheus.CounterVec
+	requestDuration *prometheus.HistogramVec
+
+	next ffClientService
+}
+
+func newPrometheusClient(next ffClientService, reg *prometheus.Registry) prometheusClient {
+	p := prometheusClient{
+		requestCount: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "ff_proxy_to_client_service_requests",
+			Help: "Tracks the number of requests that the Proxy makes to the ff-client-service in Harness Saas",
+		},
+			[]string{"url", "envID", "code"},
+		),
+		requestDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "ff_proxy_to_ff_client_service_requests_duration",
+			Help:    "Tracks the request duration for requests made from the ff-proxy to the ff-client service",
+			Buckets: []float64{0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1},
+		},
+			[]string{"url", "envID"},
+		),
+		next: next,
+	}
+
+	reg.MustRegister(p.requestCount, p.requestDuration)
+
+	return p
+}
+
+func (p prometheusClient) AuthenticateWithResponse(ctx context.Context, body clientgen.AuthenticateJSONRequestBody, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.AuthenticateResponse, err error) {
+	start := time.Now()
+	defer func() {
+		p.requestCount.WithLabelValues("/client/auth", "", strconv.Itoa(resp.StatusCode())).Inc()
+		p.requestDuration.WithLabelValues("/client/auth", "").Observe(time.Since(start).Seconds())
+	}()
+
+	return p.next.AuthenticateWithResponse(ctx, body, reqEditors...)
+}
+
+func (p prometheusClient) AuthenticateProxyKeyWithResponse(ctx context.Context, body clientgen.AuthenticateProxyKeyJSONRequestBody, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.AuthenticateProxyKeyResponse, err error) {
+	start := time.Now()
+	defer func() {
+		p.requestCount.WithLabelValues("/proxy/auth", "", strconv.Itoa(resp.StatusCode())).Inc()
+		p.requestDuration.WithLabelValues("/proxy/auth", "").Observe(time.Since(start).Seconds())
+	}()
+
+	return p.next.AuthenticateProxyKeyWithResponse(ctx, body, reqEditors...)
+}
+
+func (p prometheusClient) GetProxyConfigWithResponse(ctx context.Context, params *clientgen.GetProxyConfigParams, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.GetProxyConfigResponse, err error) {
+	start := time.Now()
+	defer func() {
+		p.requestCount.WithLabelValues("/proxy/config", "", strconv.Itoa(resp.StatusCode())).Inc()
+		p.requestDuration.WithLabelValues("/proxy/config", "").Observe(time.Since(start).Seconds())
+	}()
+
+	return p.next.GetProxyConfigWithResponse(ctx, params, reqEditors...)
+}
+
+func (p prometheusClient) GetAllSegmentsWithResponse(ctx context.Context, environmentUUID string, params *clientgen.GetAllSegmentsParams, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.GetAllSegmentsResponse, err error) {
+	start := time.Now()
+	defer func() {
+		p.requestCount.WithLabelValues("/client/env/:env/target-segments", environmentUUID, strconv.Itoa(resp.StatusCode())).Inc()
+		p.requestDuration.WithLabelValues("/client/env/:env/target-segments", environmentUUID).Observe(time.Since(start).Seconds())
+	}()
+
+	return p.next.GetAllSegmentsWithResponse(ctx, environmentUUID, params, reqEditors...)
+}
+
+func (p prometheusClient) GetFeatureConfigWithResponse(ctx context.Context, environmentUUID string, params *clientgen.GetFeatureConfigParams, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.GetFeatureConfigResponse, err error) {
+	start := time.Now()
+	defer func() {
+		p.requestCount.WithLabelValues("/client/env/:env/feature-configs", environmentUUID, strconv.Itoa(resp.StatusCode())).Inc()
+		p.requestDuration.WithLabelValues("/client/env/:env/feature-configs", environmentUUID).Observe(time.Since(start).Seconds())
+	}()
+
+	return p.next.GetFeatureConfigWithResponse(ctx, environmentUUID, params, reqEditors...)
+}

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -286,7 +286,7 @@ func main() {
 		sdkCache = cache.NewMetricsCache("in_mem", promReg, cache.NewMemCache())
 	}
 
-	clientSvc, err := clientservice.NewClient(logger, clientService)
+	clientSvc, err := clientservice.NewClient(logger, clientService, promReg)
 	if err != nil {
 		logger.Error("failed to create client for the feature flags client service", "err", err)
 		os.Exit(1)


### PR DESCRIPTION
**What**

- Decoartes the generated ClientService implementation with a type that tracks the number of requests made to the client service and their duration
- Adds a subscription counter to the Stream Prometheus decorator. We can use this to graph /stream requests made from the Primary to Harness Saas

**Why**

- This is useful information to have to see if your Proxy is functioning Properly
- We can build dashboards off of this that we can share with customers to help them gain insight into how their Proxy is functioning

**Testing**

- Built a few panels for these new metrics locally and they seem to be working as expected
<img width="1767" alt="Screenshot 2023-11-28 at 17 04 36" src="https://github.com/harness/ff-proxy/assets/16992818/9744acdd-43dc-4d0a-8454-89a7d988fba9">

