### PR TITLE
FFM-10278 Return a 500 from the auth endpoint if we're unable to hit

### DIFF
--- a/domain/errors.go
+++ b/domain/errors.go
@@ -11,4 +11,7 @@ var (
 
 	// ErrCacheInternal is the error returned by a cache when there is an unexpected error
 	ErrCacheInternal = errors.New("cache: internal error")
+
+	// ErrConnRefused is the error returned by a cache when we can't connect to it
+	ErrConnRefused = errors.New("cache: connection refused")
 )

--- a/repository/auth_repo.go
+++ b/repository/auth_repo.go
@@ -82,21 +82,21 @@ func (a AuthRepo) Add(ctx context.Context, values ...domain.AuthConfig) error {
 
 // Get gets the environmentID for the passed api key hash
 // if the auth repo has been configured with approved envs only return keys that belong to those envs
-func (a AuthRepo) Get(ctx context.Context, key domain.AuthAPIKey) (string, bool) {
+func (a AuthRepo) Get(ctx context.Context, key domain.AuthAPIKey) (string, error) {
 	var environment domain.EnvironmentID
 
 	if err := a.cache.Get(ctx, string(key), &environment); err != nil {
-		return "", false
+		return "", err
 	}
 
 	// if we're filtering by env then check result belongs to approved env
 	if len(a.approvedEnvironments) > 0 {
 		if _, exists := a.approvedEnvironments[string(environment)]; !exists {
-			return "", false
+			return "", fmt.Errorf("%w: unapproved env", domain.ErrCacheInternal)
 		}
 	}
 
-	return string(environment), true
+	return string(environment), nil
 }
 
 // getAll gets all values from auth repo

--- a/token/token_source.go
+++ b/token/token_source.go
@@ -11,7 +11,7 @@ import (
 )
 
 type authRepo interface {
-	Get(context context.Context, key domain.AuthAPIKey) (string, bool)
+	Get(context context.Context, key domain.AuthAPIKey) (string, error)
 }
 
 type hasher interface {
@@ -38,9 +38,9 @@ func (a TokenSource) GenerateToken(key string) (domain.Token, error) {
 
 	k := domain.NewAuthAPIKey(h)
 
-	env, ok := a.repo.Get(context.Background(), k)
-	if !ok {
-		return domain.Token{}, fmt.Errorf("key %q not found", key)
+	env, err := a.repo.Get(context.Background(), k)
+	if err != nil {
+		return domain.Token{}, fmt.Errorf("%w: key not found", err)
 	}
 
 	t := time.Now().Unix()

--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -80,6 +80,10 @@ func codeFrom(err error) int {
 		return http.StatusServiceUnavailable
 	}
 
+	if errors.Is(err, proxyservice.ErrCacheUnavailable) {
+		return http.StatusInternalServerError
+	}
+
 	return http.StatusInternalServerError
 }
 


### PR DESCRIPTION
**What**

- If redis is down we now return a 500 status code for any /auth requests made to the Proxy

**Why**

- If redis is down we currently return a 401 from the auth handler. It turns out not all SDKs retry if they get a 401 but they should all retry if they get a 500. This resolves an issue where an SDK could fail to authenticate because redis was down and it received a 401 from the Proxy and never retried

**Testing**

- Manually tested locally
- Updated tests