### PR TITLE
[FFM-10406] : Improve performance of the populate()

### DIFF
--- a/config/remote/config.go
+++ b/config/remote/config.go
@@ -109,8 +109,8 @@ func (c *Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRep
 	for _, cfg := range c.proxyConfig {
 		for _, env := range cfg.Environments {
 			wg.Add(1)
-			go func(group *sync.WaitGroup) {
-				defer group.Done()
+			go func() {
+				defer wg.Done()
 				//this will go multi
 				authConfig := make([]domain.AuthConfig, 0, len(env.APIKeys))
 				apiKeys := make([]string, 0, len(env.APIKeys))
@@ -125,7 +125,7 @@ func (c *Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRep
 				}
 				err := populate(ctx, authRepo, flagRepo, segmentRepo, apiKeys, authConfig, env)
 				errchan <- err
-			}(&wg)
+			}()
 		}
 	}
 

--- a/config/remote/config.go
+++ b/config/remote/config.go
@@ -107,11 +107,11 @@ func (c *Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRep
 	var wg sync.WaitGroup
 	errchan := make(chan error)
 	for _, cfg := range c.proxyConfig {
-		for _, env := range cfg.Environments {
+		for _, targetEnv := range cfg.Environments {
 			wg.Add(1)
-			go func() {
+			go func(env domain.Environments) {
 				defer wg.Done()
-				//this will go multi
+
 				authConfig := make([]domain.AuthConfig, 0, len(env.APIKeys))
 				apiKeys := make([]string, 0, len(env.APIKeys))
 
@@ -125,7 +125,7 @@ func (c *Config) Populate(ctx context.Context, authRepo domain.AuthRepo, flagRep
 				}
 				err := populate(ctx, authRepo, flagRepo, segmentRepo, apiKeys, authConfig, env)
 				errchan <- err
-			}()
+			}(targetEnv)
 		}
 	}
 


### PR DESCRIPTION
```
[FFM-10406] : Improve performance of the populate()
 ### What: 
Take advantage of parallel processing
 ### Why:
Improve performance on large config files.
 ### Testing:
Before vs after in sec 

100 envs 30 flags	0.4	0.1
200 envs 30 flags	0.8	0.2
300 envs 30 flags	1.3	0.3
500 envs 30 flags	2	0.6
1000 envs 30 flags	4.2	1.2
In all cases we se performance quadrupled.
```

[FFM-10406]: https://harness.atlassian.net/browse/FFM-10406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ