### PR TITLE
[FFM-10439]: Segment entries tracked properly in asset inventory

### DIFF
--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -90,6 +90,7 @@ func (i InventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (ma
 
 	for _, cfg := range config {
 		for _, env := range cfg.Environments {
+			//inventory := make(map[string]string)
 			environment := env.ID.String()
 			if len(env.APIKeys) > 0 {
 				inventory[string(domain.NewAPIConfigsKey(environment))] = empty
@@ -105,10 +106,9 @@ func (i InventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (ma
 			}
 
 			if len(env.Segments) > 0 {
-				//append segments
-				inventory[string(domain.NewFeatureConfigsKey(environment))] = empty
-				for _, f := range env.FeatureConfigs {
-					inventory[string(domain.NewFeatureConfigKey(environment, f.Feature))] = empty
+				inventory[string(domain.NewSegmentsKey(environment))] = empty
+				for _, s := range env.Segments {
+					inventory[string(domain.NewSegmentKey(environment, s.Name))] = empty
 				}
 			}
 		}

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -90,7 +90,6 @@ func (i InventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (ma
 
 	for _, cfg := range config {
 		for _, env := range cfg.Environments {
-			//inventory := make(map[string]string)
 			environment := env.ID.String()
 			if len(env.APIKeys) > 0 {
 				inventory[string(domain.NewAPIConfigsKey(environment))] = empty


### PR DESCRIPTION
```
[FFM-10439]: Segment entries tracked properly in asset inventory
 ### What: 
Fixed bug where segment is not populated properly to the inventory.
 ### Why:
---
 ### Testing:
Locally
```

[FFM-10439]: https://harness.atlassian.net/browse/FFM-10439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ