### PR TITLE
[FFM-10484]: Optimise cleanup on proxy startup

### DIFF
--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -102,15 +102,14 @@ func (i InventoryRepo) Cleanup(ctx context.Context, key string, config []domain.
 	// what's left of old values. we want to delete.
 	for key := range oldAssets {
 		wg.Add(1)
-		go func() {
+		go func(k string) {
 			defer func() {
 				wg.Done()
 				<-semaphore
 			}()
 			semaphore <- struct{}{}
-			errChan <- i.cache.Delete(ctx, key)
-
-		}()
+			errChan <- i.cache.Delete(ctx, k)
+		}(key)
 	}
 
 	go func() {


### PR DESCRIPTION
```
[FFM-10484]: Optimise cleanup on proxy startup
 ### What: 
Delete keys from redis concurrently 
 ### Why:
Improve time it takes to clean up old keys from redis and speed up startup.
 ### Testing:
Locally
```


[FFM-10484]: https://harness.atlassian.net/browse/FFM-10484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ