### PR TITLE
[FFM-10498]: Don't allow Proxy to fail to start if key is misconfigured

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -395,14 +395,14 @@ func main() {
 	}
 
 	reloadConfig := func() error {
-		return conf.FetchAndPopulate(ctx, inventoryRepo, authRepo, flagRepo, segmentRepo) //ASZ
+		return conf.FetchAndPopulate(ctx, inventoryRepo, authRepo, flagRepo, segmentRepo)
 	}
 
 	// If we're running as a Primary we'll need to fetch the config and populate the cache
 	var configStatus domain.ConfigStatus
 	if !readReplica {
 		if err := conf.FetchAndPopulate(ctx, inventoryRepo, authRepo, flagRepo, segmentRepo); err != nil {
-			logger.Error("failed to populate repos with config", "err", err) //ASZ
+			logger.Error("failed to populate repos with config", "err", err)
 			configStatus = domain.NewConfigStatus(domain.ConfigStateFailedToSync)
 		} else {
 			configStatus = domain.NewConfigStatus(domain.ConfigStateSynced)
@@ -476,8 +476,7 @@ func main() {
 
 	apiKeyHasher := hash.NewSha256()
 	tokenSource := token.NewSource(logger, authRepo, apiKeyHasher, []byte(authSecret))
-
-	proxyHealth := health.NewProxyHealth(logger, configStatus, saasStreamHealth.StreamStatus, cacheHealthCheck) //ASZ
+	proxyHealth := health.NewProxyHealth(logger, configStatus, saasStreamHealth.StreamStatus, cacheHealthCheck)
 
 	// Setup service and middleware
 	service := proxyservice.NewService(proxyservice.Config{

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -10,8 +10,13 @@ import (
 
 // StreamState is the connection state for a stream
 type StreamState string
+type ConfigState string
 
 const (
+	// ConfigStateSynced is the status for when proxy has synced successfully
+	ConfigStateSynced ConfigState = "SYNCED"
+	// ConfigStateFailedToSync is the status for when proxy has failed to perform sync. Indicative of misconfigured key
+	ConfigStateFailedToSync ConfigState = "FAILED_TO_SYNC"
 	// StreamStateConnected is the status for when a stream is connected
 	StreamStateConnected StreamState = "CONNECTED"
 	// StreamStateDisconnected is the status for when a stream is disconnected
@@ -58,6 +63,20 @@ type StreamStatus struct {
 func NewStreamStatus() StreamStatus {
 	return StreamStatus{
 		State: StreamStateInitializing,
+		Since: time.Now().UnixMilli(),
+	}
+}
+
+// ConfigStatus contains a config state
+type ConfigStatus struct {
+	State ConfigState `json:"state"`
+	Since int64       `json:"since"`
+}
+
+// NewConfigStatus creates a ConfigStatus for proxy
+func NewConfigStatus(status ConfigState) ConfigStatus {
+	return ConfigStatus{
+		State: status,
 		Since: time.Now().UnixMilli(),
 	}
 }

--- a/domain/requests.go
+++ b/domain/requests.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 	jsoniter "github.com/json-iterator/go"
+
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 )
 
 // AuthRequest contains the fields sent in an authentication request
@@ -76,6 +77,7 @@ func (m *MetricsRequest) MarshalBinary() (data []byte, err error) {
 
 // HealthResponse contains the fields returned in a healthcheck response
 type HealthResponse struct {
+	ConfigStatus ConfigStatus `json:"configStatus"`
 	StreamStatus StreamStatus `json:"streamStatus"`
 	CacheStatus  string       `json:"cacheStatus"`
 }

--- a/proxy-service/service.go
+++ b/proxy-service/service.go
@@ -391,7 +391,11 @@ func (s Service) Metrics(ctx context.Context, req domain.MetricsRequest) error {
 func (s Service) Health(ctx context.Context) (domain.HealthResponse, error) {
 	s.logger.Debug(ctx, "got health request")
 
-	return s.health(ctx), nil
+	healthResp := s.health(ctx)
+	if healthResp.ConfigStatus.State == domain.ConfigStateFailedToSync {
+		return healthResp, ErrInternal
+	}
+	return healthResp, nil
 }
 
 func toString(variation rest.Variation, kind string) string {


### PR DESCRIPTION
```
[FFM-10498]: Don't allow Proxy to fail to start if key is misconfigured
 ### What: 
Added config sync status. 
 ### Why:
Prevent proxy from getting into the crash loop state if the key is misconfigured.
 ### Testing:
Locally
```

[FFM-10498]: https://harness.atlassian.net/browse/FFM-10498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ