### PR TITLE
FFM-10506 - Track SDK usage via prometheus metric

### DIFF
--- a/clients/metrics_service/client.go
+++ b/clients/metrics_service/client.go
@@ -88,6 +88,8 @@ func (c Client) PostMetrics(ctx context.Context, envID string, metric domain.Met
 			errLabel = "true"
 		}
 		c.metricsForwarded.WithLabelValues(envID, errLabel).Inc()
+
+		c.trackSDKUsage(metric)
 	}()
 
 	ctx = context.WithValue(ctx, tokenKey, c.token())


### PR DESCRIPTION
**What**

- Using an existing prometheus metric to track SDK usage via the metrics

**Why**

- This was accidentally undone during the metrics perf work