### PR TITLE
[FFM-10518]: ReadReplica shows invalid status

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -418,6 +418,7 @@ func main() {
 	//   - The replica subscribes to this stream and when it gets a stream disconnect message
 	//     it closes any open streams with SDKs to force them to poll for changes
 	if readReplica {
+		configStatus = domain.NewConfigStatus(domain.ConfigStateReadReplica)
 		primaryToReplicaControlStream.Subscribe(ctx)
 		readReplicaSSEStream.Subscribe(ctx)
 	} else {

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -17,6 +17,8 @@ const (
 	ConfigStateSynced ConfigState = "SYNCED"
 	// ConfigStateFailedToSync is the status for when proxy has failed to perform sync. Indicative of misconfigured key
 	ConfigStateFailedToSync ConfigState = "FAILED_TO_SYNC"
+	// ConfigStateReadReplica is the status for read replica
+	ConfigStateReadReplica ConfigState = "READ_REPLICA"
 	// StreamStateConnected is the status for when a stream is connected
 	StreamStateConnected StreamState = "CONNECTED"
 	// StreamStateDisconnected is the status for when a stream is disconnected


### PR DESCRIPTION
```
[FFM-10518]: ReadReplica shows invalid status 
 ### What: 
Added status for read replica
 ### Why:
To avoid invalid status
 ### Testing:
Locally
```

[FFM-10518]: https://harness.atlassian.net/browse/FFM-10518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ