### PR TITLE
FFM-10471 Add unit tests for new metrics code

### DIFF
--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -35,7 +35,11 @@ func (m *metricsMap) add(r domain.MetricsRequest) {
 		return
 	}
 
+	incrSize := false
+
 	if r.MetricsData != nil {
+		incrSize = true
+
 		if currentMetrics.MetricsData == nil {
 			currentMetrics.MetricsData = &[]clientgen.MetricsData{}
 		}
@@ -44,12 +48,20 @@ func (m *metricsMap) add(r domain.MetricsRequest) {
 	}
 
 	if r.TargetData != nil {
+		incrSize = true
+
 		if currentMetrics.TargetData == nil {
 			currentMetrics.TargetData = &[]clientgen.TargetData{}
 		}
 
 		newTargets := append(*currentMetrics.TargetData, *r.TargetData...)
 		currentMetrics.TargetData = &newTargets
+	}
+
+	// As well as aggregating the metrics & target data we need to
+	// 'merge' the size of the current aggregated object and the new one
+	if incrSize {
+		currentMetrics.Size += r.Size
 	}
 
 	m.metrics[r.EnvironmentID] = currentMetrics

--- a/clients/metrics_service/map_test.go
+++ b/clients/metrics_service/map_test.go
@@ -1,0 +1,287 @@
+package metricsservice
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMap_add(t *testing.T) {
+
+	mr123 := domain.MetricsRequest{
+		Size:          7,
+		EnvironmentID: "123",
+		Metrics: clientgen.Metrics{
+			MetricsData: &[]clientgen.MetricsData{
+				{
+					Attributes:  nil,
+					Count:       1,
+					MetricsType: "Server",
+					Timestamp:   111,
+				},
+			},
+			TargetData: &[]clientgen.TargetData{
+				{
+					Attributes: nil,
+					Identifier: "Foo",
+					Name:       "Bar",
+				},
+			},
+		},
+	}
+
+	mr123Again := domain.MetricsRequest{
+		Size:          2,
+		EnvironmentID: "123",
+		Metrics: clientgen.Metrics{
+			MetricsData: &[]clientgen.MetricsData{
+				{
+					Attributes:  nil,
+					Count:       1,
+					MetricsType: "Server",
+					Timestamp:   111,
+				},
+			},
+			TargetData: &[]clientgen.TargetData{
+				{
+					Attributes: nil,
+					Identifier: "Hello",
+					Name:       "World",
+				},
+			},
+		},
+	}
+
+	mr456 := domain.MetricsRequest{
+		Size:          8,
+		EnvironmentID: "456",
+		Metrics:       clientgen.Metrics{},
+	}
+
+	type args struct {
+		metricRequest domain.MetricsRequest
+	}
+
+	type expected struct {
+		data map[string]domain.MetricsRequest
+		size int
+	}
+
+	testCases := map[string]struct {
+		metricsMap *metricsMap
+		args       args
+		expected   expected
+	}{
+		"Given I add one element to an empty map": {
+			metricsMap: newMetricsMap(),
+			args: args{
+				metricRequest: mr123,
+			},
+			expected: expected{
+				data: map[string]domain.MetricsRequest{
+					"123": mr123,
+				},
+				size: 7,
+			},
+		},
+		"Given I add a second element for a different environment": {
+			metricsMap: &metricsMap{
+				RWMutex: &sync.RWMutex{},
+				metrics: map[string]domain.MetricsRequest{
+					"123": mr123,
+				},
+				currentSize: mr123.Size,
+			},
+			args: args{
+				metricRequest: mr456,
+			},
+			expected: expected{
+				data: map[string]domain.MetricsRequest{
+					"123": mr123,
+					"456": mr456,
+				},
+				size: 15,
+			},
+		},
+		"Given I add a second element for the same environment different environment": {
+			metricsMap: &metricsMap{
+				RWMutex: &sync.RWMutex{},
+				metrics: map[string]domain.MetricsRequest{
+					"123": mr123,
+				},
+				currentSize: mr123.Size,
+			},
+			args: args{
+				metricRequest: mr123Again,
+			},
+			expected: expected{
+				data: map[string]domain.MetricsRequest{
+					"123": domain.MetricsRequest{
+						Size:          9,
+						EnvironmentID: "123",
+						Metrics: clientgen.Metrics{
+							MetricsData: mergeSlices(*mr123.MetricsData, *mr123Again.MetricsData),
+							TargetData:  mergeSlices(*mr123.TargetData, *mr123Again.TargetData),
+						},
+					},
+				},
+				size: 9,
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			tc.metricsMap.add(tc.args.metricRequest)
+
+			assert.Equal(t, tc.expected.data, tc.metricsMap.metrics)
+			assert.Equal(t, tc.expected.size, tc.metricsMap.currentSize)
+		})
+	}
+}
+
+func mergeSlices[T any](s1, s2 []T) *[]T {
+	merged := make([]T, 0, len(s1)+len(s2))
+	merged = append(merged, s1...)
+	merged = append(merged, s2...)
+	return &merged
+}
+
+func TestMetricsMap_get(t *testing.T) {
+
+	type expected struct {
+		data map[string]domain.MetricsRequest
+	}
+
+	testCases := map[string]struct {
+		metricsMap *metricsMap
+		expected   expected
+	}{
+		"Given I have an empty metrics map": {
+			metricsMap: newMetricsMap(),
+			expected:   expected{data: make(map[string]domain.MetricsRequest)},
+		},
+		"Given I have a metrics map with one item in it": {
+			metricsMap: &metricsMap{
+				RWMutex: &sync.RWMutex{},
+				metrics: map[string]domain.MetricsRequest{
+					"123": domain.MetricsRequest{
+						Size:          5,
+						EnvironmentID: "123",
+						Metrics:       clientgen.Metrics{},
+					},
+				},
+				currentSize: 5,
+			},
+			expected: expected{
+				data: map[string]domain.MetricsRequest{
+					"123": domain.MetricsRequest{
+						Size:          5,
+						EnvironmentID: "123",
+						Metrics:       clientgen.Metrics{},
+					},
+				},
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			actual := tc.metricsMap.get()
+			assert.Equal(t, tc.expected.data, actual)
+
+		})
+	}
+}
+
+func TestMetricsMap_size(t *testing.T) {
+
+	type expected struct {
+		size int
+	}
+
+	testCases := map[string]struct {
+		metricsMap *metricsMap
+		expected   expected
+	}{
+		"Given I have an empty metrics map": {
+			metricsMap: newMetricsMap(),
+			expected:   expected{size: 0},
+		},
+		"Given I have a metrics map with a size of 11": {
+			metricsMap: &metricsMap{
+				RWMutex:     &sync.RWMutex{},
+				metrics:     nil,
+				currentSize: 11,
+			},
+			expected: expected{size: 11},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			actual := tc.metricsMap.size()
+			assert.Equal(t, tc.expected.size, actual)
+		})
+	}
+}
+
+func TestMetricsMap_flush(t *testing.T) {
+
+	type expected struct {
+		data map[string]domain.MetricsRequest
+		size int
+	}
+
+	testCases := map[string]struct {
+		metricsMap *metricsMap
+		expected   expected
+	}{
+		"Given I have an empty metrics map and I call flush": {
+			metricsMap: newMetricsMap(),
+			expected: expected{
+				data: make(map[string]domain.MetricsRequest),
+				size: 0,
+			},
+		},
+		"Given I have a populated metrics map and I call flush": {
+			metricsMap: &metricsMap{
+				RWMutex: &sync.RWMutex{},
+				metrics: map[string]domain.MetricsRequest{
+					"123": domain.MetricsRequest{},
+				},
+				currentSize: 3,
+			},
+			expected: expected{
+				data: make(map[string]domain.MetricsRequest),
+				size: 0,
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			tc.metricsMap.flush()
+
+			assert.Equal(t, tc.expected.data, tc.metricsMap.metrics)
+			assert.Equal(t, tc.expected.size, tc.metricsMap.currentSize)
+		})
+	}
+}

--- a/clients/metrics_service/queue.go
+++ b/clients/metrics_service/queue.go
@@ -85,10 +85,11 @@ func (q Queue) StoreMetrics(ctx context.Context, m domain.MetricsRequest) error 
 		return err
 	}
 
-	// We flushed because the max size was reached so reset the ticker
-	// so that we wait for the full duration again.
+	// Flush all the existing metrics because the max size has been reached,
+	// reset the ticker and add the new metric to the map
 	q.ticker.Reset(q.tickerDuration)
 	q.metrics.flush()
+	q.metrics.add(m)
 	return nil
 }
 

--- a/clients/metrics_service/queue_test.go
+++ b/clients/metrics_service/queue_test.go
@@ -1,0 +1,212 @@
+package metricsservice
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueue_StoreMetrics(t *testing.T) {
+	logger := log.NoOpLogger{}
+
+	mr123 := domain.MetricsRequest{
+		Size:          7,
+		EnvironmentID: "123",
+		Metrics: clientgen.Metrics{
+			MetricsData: &[]clientgen.MetricsData{
+				{
+					Attributes:  nil,
+					Count:       1,
+					MetricsType: "Server",
+					Timestamp:   111,
+				},
+			},
+			TargetData: &[]clientgen.TargetData{
+				{
+					Attributes: nil,
+					Identifier: "Foo",
+					Name:       "Bar",
+				},
+			},
+		},
+	}
+
+	mr456 := domain.MetricsRequest{
+		Size:          8,
+		EnvironmentID: "456",
+		Metrics:       clientgen.Metrics{},
+	}
+
+	type args struct {
+		metricRequest domain.MetricsRequest
+	}
+
+	type expected struct {
+		metrics map[string]domain.MetricsRequest
+	}
+
+	testCases := map[string]struct {
+		args     args
+		queue    Queue
+		expected expected
+	}{
+		"Given I call StoreMetrics and we've already exceeded the max queue size": {
+			args: args{
+				metricRequest: mr123,
+			},
+			queue: Queue{
+				log:   logger,
+				queue: make(chan map[string]domain.MetricsRequest, 1), // Buffer so we don't have to run the test concurrently
+				metrics: &metricsMap{
+					RWMutex: &sync.RWMutex{},
+					metrics: map[string]domain.MetricsRequest{
+						mr123.EnvironmentID: mr123,
+					},
+					currentSize: maxQueueSize * 2,
+				},
+				ticker:         time.NewTicker(30 * time.Second),
+				tickerDuration: 30 * time.Second,
+			},
+			expected: expected{metrics: map[string]domain.MetricsRequest{
+				mr123.EnvironmentID: mr123,
+			}},
+		},
+		"Given I call StoreMetrics and we haven't exceeded the max queue size": {
+			args: args{
+				metricRequest: mr456,
+			},
+			queue: Queue{
+				log:   logger,
+				queue: make(chan map[string]domain.MetricsRequest, 1), // Buffer so we don't have to run the test concurrently
+				metrics: &metricsMap{
+					RWMutex: &sync.RWMutex{},
+					metrics: map[string]domain.MetricsRequest{
+						mr123.EnvironmentID: mr123,
+					},
+					currentSize: 0,
+				},
+				ticker:         time.NewTicker(30 * time.Second),
+				tickerDuration: 30 * time.Second,
+			},
+			expected: expected{metrics: map[string]domain.MetricsRequest{
+				mr123.EnvironmentID: mr123,
+				mr456.EnvironmentID: mr456,
+			}},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			assert.Nil(t, tc.queue.StoreMetrics(ctx, tc.args.metricRequest))
+
+			assert.Equal(t, tc.expected.metrics, tc.queue.metrics.get())
+		})
+	}
+}
+
+func TestQueue_Listen(t *testing.T) {
+	logger := log.NewNoOpLogger()
+
+	mr123 := domain.MetricsRequest{
+		Size:          7,
+		EnvironmentID: "123",
+		Metrics: clientgen.Metrics{
+			MetricsData: &[]clientgen.MetricsData{
+				{
+					Attributes:  nil,
+					Count:       1,
+					MetricsType: "Server",
+					Timestamp:   111,
+				},
+			},
+			TargetData: &[]clientgen.TargetData{
+				{
+					Attributes: nil,
+					Identifier: "Foo",
+					Name:       "Bar",
+				},
+			},
+		},
+	}
+
+	mr456 := domain.MetricsRequest{
+		Size:          8,
+		EnvironmentID: "456",
+		Metrics:       clientgen.Metrics{},
+	}
+
+	type args struct {
+		metricsRequests []domain.MetricsRequest
+		flushDuration   time.Duration
+	}
+
+	type expected struct {
+		eventCount  int
+		metricsData map[string]domain.MetricsRequest
+	}
+
+	testCases := map[string]struct {
+		args     args
+		expected expected
+	}{
+		"Given I have a queue, I add metrics requests to it and the flush interval expires": {
+			args: args{
+				metricsRequests: []domain.MetricsRequest{mr123, mr456},
+				flushDuration:   5 * time.Second,
+			},
+			expected: expected{
+				metricsData: map[string]domain.MetricsRequest{
+					mr123.EnvironmentID: mr123,
+					mr456.EnvironmentID: mr456,
+				},
+				eventCount: 1,
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), tc.args.flushDuration*3)
+			defer cancel()
+
+			q := NewQueue(ctx, logger, tc.args.flushDuration)
+
+			go func() {
+				for _, mr := range tc.args.metricsRequests {
+					_ = q.StoreMetrics(ctx, mr)
+				}
+			}()
+
+			actual := map[string]domain.MetricsRequest{}
+			eventCount := 0
+
+			for mr := range q.Listen(ctx) {
+				eventCount++
+
+				for k, v := range mr {
+					actual[k] = v
+				}
+
+				if eventCount == tc.expected.eventCount {
+					cancel()
+				}
+			}
+
+			assert.Equal(t, tc.expected.metricsData, actual)
+		})
+	}
+}

--- a/clients/metrics_service/worker_test.go
+++ b/clients/metrics_service/worker_test.go
@@ -1,0 +1,501 @@
+package metricsservice
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	"github.com/harness/ff-proxy/v2/log"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockRedisStream struct {
+	*sync.RWMutex
+	idx    int
+	events []string
+}
+
+func newMockRedisStream(events ...string) *mockRedisStream {
+	return &mockRedisStream{
+		RWMutex: &sync.RWMutex{},
+		idx:     0,
+		events:  events,
+	}
+}
+
+func (m *mockRedisStream) Sub(ctx context.Context, channel string, id string, messageFn domain.HandleMessageFn) error {
+	m.Lock()
+	defer func() {
+		m.Unlock()
+		m.idx++
+	}()
+
+	if m.idx >= len(m.events) {
+		// Worker subscribe func will only exit if we return context.Canceled error
+		return context.Canceled
+	}
+
+	return messageFn(id, m.events[m.idx])
+}
+
+type mockMetricsService struct {
+	metrics chan domain.MetricsRequest
+}
+
+func (m *mockMetricsService) PostMetrics(ctx context.Context, envID string, r domain.MetricsRequest, clusterIdentifier string) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case m.metrics <- r:
+	}
+
+	return nil
+}
+
+func (m *mockMetricsService) listen() <-chan domain.MetricsRequest {
+	return m.metrics
+}
+
+func mustMarshalToString(mr ...domain.MetricsRequest) []string {
+	ss := []string{}
+
+	for _, m := range mr {
+		b, err := json.Marshal(m)
+		if err != nil {
+			panic(err)
+		}
+
+		ss = append(ss, string(b))
+	}
+
+	return ss
+}
+
+func TestWorker_Start(t *testing.T) {
+	mr123 := domain.MetricsRequest{
+		Size:          176,
+		EnvironmentID: "123",
+		Metrics: clientgen.Metrics{
+			MetricsData: &[]clientgen.MetricsData{
+				{
+					Attributes:  nil,
+					Count:       1,
+					MetricsType: "Server",
+					Timestamp:   111,
+				},
+			},
+			TargetData: &[]clientgen.TargetData{
+				{
+					Attributes: nil,
+					Identifier: "Foo",
+					Name:       "Bar",
+				},
+			},
+		},
+	}
+
+	mr456 := domain.MetricsRequest{
+		Size:          24,
+		EnvironmentID: "456",
+		Metrics:       clientgen.Metrics{},
+	}
+
+	type args struct {
+	}
+
+	type mocks struct {
+		redisStream   *mockRedisStream
+		metricService *mockMetricsService
+		store         Queue
+	}
+
+	type expected struct {
+		metrics []domain.MetricsRequest
+	}
+
+	testCases := map[string]struct {
+		args     args
+		mocks    mocks
+		expected expected
+	}{
+		"Given I have a redis stream with one metrics request on it": {
+			mocks: mocks{
+				redisStream: newMockRedisStream(mustMarshalToString(mr123)...),
+				metricService: &mockMetricsService{
+					metrics: make(chan domain.MetricsRequest),
+				},
+			},
+			expected: expected{metrics: []domain.MetricsRequest{mr123}},
+		},
+		"Given I have a redis stream with two metrics requests on it": {
+			mocks: mocks{
+				redisStream: newMockRedisStream(mustMarshalToString(mr123, mr456)...),
+				metricService: &mockMetricsService{
+					metrics: make(chan domain.MetricsRequest),
+				},
+			},
+			expected: expected{metrics: []domain.MetricsRequest{mr123, mr456}},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			defer cancel()
+
+			queue := NewQueue(ctx, log.NoOpLogger{}, 5*time.Second)
+			w := NewWorker(log.NoOpLogger{}, queue, tc.mocks.metricService, tc.mocks.redisStream, 1, "1")
+
+			w.Start(ctx)
+
+			actual := []domain.MetricsRequest{}
+
+			// Wait for metrics to be 'posted' to the metrics service
+			done := false
+			for !done {
+				m, ok := <-tc.mocks.metricService.listen()
+				if !ok {
+					done = true
+					continue
+				}
+
+				actual = append(actual, m)
+
+				if len(actual) == len(tc.expected.metrics) {
+					done = true
+				}
+			}
+
+			assert.Equal(t, tc.expected.metrics, actual)
+		})
+	}
+}
+
+// Benchmarking the handle metrics function reading from a channel vs just taking a raw bytes
+func Benchmark_Start(b *testing.B) {
+	benchmarks := []struct {
+		name          string
+		metricsEvents int
+		concurrency   int
+		startFn       func(n int, c int)
+	}{
+		{
+			name:          "StartOne- 10000 metrics, concurrency=1",
+			metricsEvents: 10000,
+			concurrency:   1,
+			startFn:       StartOne,
+		},
+		{
+			name:          "StartTwo - 10000 metrics, concurrency=1",
+			metricsEvents: 10000,
+			concurrency:   1,
+			startFn:       StartTwo,
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bm.startFn(bm.metricsEvents, bm.concurrency)
+			}
+		})
+	}
+}
+
+func StartTwo(n int, conc int) {
+	// Start a single thread that subscribes to the redis stream
+	metrics := metricsRequestStream(generateData(n)...)
+
+	// Start multiple threads to process events coming off the redis stream
+	sem := make(chan struct{}, conc)
+	for m := range metrics {
+		sem <- struct{}{}
+		go func(b []byte) {
+			defer func() {
+				<-sem
+			}()
+
+			handleMetrics(b)
+		}(m)
+	}
+}
+
+func StartOne(n int, conc int) {
+	wg := &sync.WaitGroup{}
+	wg.Add(conc)
+
+	// Start a single thread that subscribes to the redis stream
+	metrics := metricsRequestStream(generateData(n)...)
+
+	// Start multiple threads to process events coming off the redis stream
+	for i := 0; i < conc; i++ {
+		go func() {
+			defer wg.Done()
+		}()
+		handleMetricsReadFromChan(metrics)
+	}
+
+	wg.Wait()
+}
+
+// Benchmarking the handle metrics function reading from a channel vs just taking a raw bytes
+func Benchmark_HandleMetrics(b *testing.B) {
+	benchmarks := []struct {
+		name          string
+		metricsStream <-chan []byte
+		fn1           func(<-chan []byte)
+		fn2           func([]byte)
+	}{
+		{
+			name:          "handleMetrics- 1000 metrics",
+			metricsStream: metricsRequestStream(generateData(10000)...),
+			fn2:           handleMetrics,
+		},
+		{
+			name:          "handleMetricsFromChan - 1000 metrics",
+			metricsStream: metricsRequestStream(generateData(10000)...),
+			fn1:           handleMetricsReadFromChan,
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+
+				if bm.fn2 != nil {
+					for m := range bm.metricsStream {
+						bm.fn2(m)
+					}
+				} else if bm.fn1 != nil {
+					bm.fn1(bm.metricsStream)
+				}
+
+			}
+		})
+	}
+
+}
+
+func BenchmarkName(b *testing.B) {
+	benchmarks := []struct {
+		name          string
+		metricsStream <-chan []byte
+		fn            func(<-chan []byte)
+	}{
+		{
+			name:          "single thread - 1000 metrics",
+			metricsStream: metricsRequestStream(generateData(10000)...),
+			fn:            singleThread,
+		},
+		{
+			name:          "fanout - 1000 metrics",
+			metricsStream: metricsRequestStream(generateData(10000)...),
+			fn:            fanout,
+		},
+		{
+			name:          "semaphore - 1000 metrics",
+			metricsStream: metricsRequestStream(generateData(10000)...),
+			fn:            semaphore,
+		},
+		{
+			name:          "foo - 1000 metrics",
+			metricsStream: metricsRequestStream(generateData(10000)...),
+			fn:            foo,
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				bm.fn(bm.metricsStream)
+			}
+		})
+	}
+}
+
+func fanout(metrics <-chan []byte) {
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for m := range metrics {
+				handleMetrics(m)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func foo(metrics <-chan []byte) {
+	wg := &sync.WaitGroup{}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			handleMetricsReadFromChan(metrics)
+		}()
+	}
+}
+
+func semaphore(metrics <-chan []byte) {
+	sem := make(chan struct{}, 5)
+
+	for m := range metrics {
+		sem <- struct{}{}
+		go func() {
+			defer func() {
+				<-sem
+			}()
+			handleMetrics(m)
+		}()
+	}
+}
+
+func singleThread(metrics <-chan []byte) {
+	for m := range metrics {
+		handleMetrics(m)
+	}
+}
+
+func handleMetrics(b []byte) {
+	mr := domain.MetricsRequest{}
+
+	if err := jsoniter.Unmarshal(b, &mr); err != nil {
+		panic(err)
+	}
+}
+
+func handleMetricsReadFromChan(b <-chan []byte) {
+	for {
+		select {
+		case v, ok := <-b:
+			if !ok {
+				return
+			}
+
+			mr := domain.MetricsRequest{}
+			if err := jsoniter.Unmarshal(v, &mr); err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+func metricsRequestStream(metricsRequests ...domain.MetricsRequest) <-chan []byte {
+	out := make(chan []byte)
+
+	go func() {
+		defer close(out)
+
+		for _, mr := range metricsRequests {
+			b, err := jsoniter.Marshal(mr)
+			if err != nil {
+				panic(err)
+			}
+
+			out <- b
+		}
+	}()
+
+	return out
+}
+
+func generateData(size int) []domain.MetricsRequest {
+	data := make([]domain.MetricsRequest, 0)
+
+	for i := 0; i < size; i++ {
+		envID := 1
+		if i%2 == 0 {
+			envID = 2
+		}
+
+		data = append(data, domain.MetricsRequest{
+			EnvironmentID: fmt.Sprintf("env-%d", envID),
+			Metrics: clientgen.Metrics{
+				MetricsData: &[]clientgen.MetricsData{
+					{
+						Attributes: []clientgen.KeyValue{
+							{
+								Key:   "FOOOOOOOOOOOOOOOOOOOOOOOOOOOOO",
+								Value: "BAARRRRRRRRRRRRRRRRRRRRRRRRR",
+							},
+						},
+						Count:       2,
+						MetricsType: "Server",
+						Timestamp:   time.Now().UnixMilli(),
+					},
+					{
+						Attributes: []clientgen.KeyValue{
+							{
+								Key:   "FOOOOOOOOOOOOOOOOOOOOOOOOOOOOO",
+								Value: "BAARRRRRRRRRRRRRRRRRRRRRRRRR",
+							},
+						},
+						Count:       2,
+						MetricsType: "Server",
+						Timestamp:   time.Now().UnixMilli(),
+					},
+					{
+						Attributes: []clientgen.KeyValue{
+							{
+								Key:   "FOOOOOOOOOOOOOOOOOOOOOOOOOOOOO",
+								Value: "BAARRRRRRRRRRRRRRRRRRRRRRRRR",
+							},
+						},
+						Count:       2,
+						MetricsType: "Server",
+						Timestamp:   time.Now().UnixMilli(),
+					},
+				},
+				TargetData: &[]clientgen.TargetData{
+					{
+						Attributes: []clientgen.KeyValue{
+							{
+								Key:   "FOOOOOOOOOOOOOOOOOOOOOOOOOOOOO",
+								Value: "BAARRRRRRRRRRRRRRRRRRRRRRRRR",
+							},
+						},
+						Identifier: "HELOOOOOOOOO",
+						Name:       "WORLDDDDDDDDDDD",
+					},
+					{
+						Attributes: []clientgen.KeyValue{
+							{
+								Key:   "FOOOOOOOOOOOOOOOOOOOOOOOOOOOOO",
+								Value: "BAARRRRRRRRRRRRRRRRRRRRRRRRR",
+							},
+						},
+						Identifier: "HELOOOOOOOOO",
+						Name:       "WORLDDDDDDDDDDD",
+					},
+					{
+						Attributes: []clientgen.KeyValue{
+							{
+								Key:   "FOOOOOOOOOOOOOOOOOOOOOOOOOOOOO",
+								Value: "BAARRRRRRRRRRRRRRRRRRRRRRRRR",
+							},
+						},
+						Identifier: "HELOOOOOOOOO",
+						Name:       "WORLDDDDDDDDDDD",
+					},
+				},
+			},
+		})
+	}
+	return data
+}


### PR DESCRIPTION
**What**

- Adds unit tests for code that was added during the metric perf work
- Caught a bug where we weren't merging the size of aggregated objects
- Caught a bug where if the size of the current metric request put us over the limit we were dropping the current request instead of adding it to the map after flushing 