### PR TITLE
FFM-10697 Fix stuck in INITIALIZING stream STATE

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -329,7 +329,7 @@ func main() {
 				"control_uri": "http://localhost:5561",
 			},
 		})
-		saasStreamHealth = stream.NewHealth("ffproxy_saas_stream_health", sdkCache)
+		saasStreamHealth = stream.NewHealth("ffproxy_saas_stream_health", sdkCache, logger)
 		connectedStreams = domain.NewSafeMap()
 
 		getConnectedStreams = func() map[string]interface{} {
@@ -339,6 +339,9 @@ func main() {
 		pushpinStream domain.Stream = stream.NewPushpin(gpc)
 		redisStream   domain.Stream = stream.NewRedisStream(redisClient)
 	)
+
+	// Kick of routine that makes sure the cachedStreamStatus is up to date with the inMemoryStreamStatus
+	go saasStreamHealth.VerifyStreamStatus(ctx, 60*time.Second)
 
 	// Get the underlying type from the pushpinStream which is currently the
 	// Stream interface. We can now pass the underlying Pushpin type that has

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -10,6 +10,12 @@ import (
 
 // StreamState is the connection state for a stream
 type StreamState string
+
+// String makes StreamState implement the Stringer interface
+func (s StreamState) String() string {
+	return string(s)
+}
+
 type ConfigState string
 
 const (

--- a/domain/safe_stream_state.go
+++ b/domain/safe_stream_state.go
@@ -1,0 +1,33 @@
+package domain
+
+import "sync"
+
+// SafeStreamStatus is a StreamStatus that's safe for concurrent use
+type SafeStreamStatus struct {
+	*sync.RWMutex
+	value StreamStatus
+}
+
+// NewSafeStreamStatus creates a SafeStreamStatus
+func NewSafeStreamStatus(v StreamStatus) *SafeStreamStatus {
+	return &SafeStreamStatus{
+		RWMutex: &sync.RWMutex{},
+		value:   v,
+	}
+}
+
+// Set sets the StreamStatus
+func (s *SafeStreamStatus) Set(v StreamStatus) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.value = v
+}
+
+// Get gets the StreamStatus
+func (s *SafeStreamStatus) Get() StreamStatus {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.value
+}

--- a/domain/safe_stream_state_test.go
+++ b/domain/safe_stream_state_test.go
@@ -1,0 +1,19 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeStreamState(t *testing.T) {
+	s := NewSafeStreamStatus(NewStreamStatus())
+
+	expected := StreamStatus{State: StreamStateConnected, Since: time.Now().UnixMilli()}
+
+	s.Set(expected)
+
+	actual := s.Get()
+	assert.Equal(t, expected, actual)
+}

--- a/stream/health.go
+++ b/stream/health.go
@@ -7,26 +7,35 @@ import (
 
 	"github.com/harness/ff-proxy/v2/cache"
 	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
 )
 
 // Health maintains the health/status of a stream in a cache
 type Health struct {
-	c      cache.Cache
-	key    string
-	status domain.StreamStatus
+	log log.Logger
+	c   cache.Cache
+	key string
+
+	// Also keep a copy of the status in memory. This way we can
+	// recover if we failed to update the remote status in the cache
+	// due to a network error and avoid getting in a stuck state.
+	inMemStatus *domain.SafeStreamStatus
 }
 
 // NewHealth creates a Health
-func NewHealth(k string, c cache.Cache) Health {
-	h := Health{
-		key:    k,
-		c:      c,
-		status: domain.NewStreamStatus(),
-	}
+func NewHealth(k string, c cache.Cache, l log.Logger) Health {
+	l = l.With("component", "StreamHealth")
 
 	defaultStreamStatus := domain.StreamStatus{
 		State: domain.StreamStateInitializing,
 		Since: time.Now().UnixMilli(),
+	}
+
+	h := Health{
+		log:         l,
+		key:         k,
+		c:           c,
+		inMemStatus: domain.NewSafeStreamStatus(defaultStreamStatus),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -44,6 +53,11 @@ func NewHealth(k string, c cache.Cache) Health {
 // If the stream status is already CONNECTED it does nothing.
 func (h Health) SetHealthy(ctx context.Context) error {
 	var streamStatus domain.StreamStatus
+
+	defer func() {
+		h.inMemStatus.Set(streamStatus)
+	}()
+
 	if err := h.c.Get(ctx, h.key, &streamStatus); err != nil {
 		// Ignore NotFound errors for this key because if the key doesn't
 		// exist we'll end up setting it at the end of this function
@@ -67,6 +81,11 @@ func (h Health) SetHealthy(ctx context.Context) error {
 // If the stream status is already DISCONNECTED it does nothing.
 func (h Health) SetUnhealthy(ctx context.Context) error {
 	var streamStatus domain.StreamStatus
+
+	defer func() {
+		h.inMemStatus.Set(streamStatus)
+	}()
+
 	if err := h.c.Get(ctx, h.key, &streamStatus); err != nil {
 		// Ignore NotFound errors for this key because if the key doesn't
 		// exist we'll end up setting it at the end of this function
@@ -85,6 +104,43 @@ func (h Health) SetUnhealthy(ctx context.Context) error {
 	streamStatus.Since = time.Now().UnixMilli()
 
 	return h.c.Set(ctx, h.key, streamStatus)
+}
+
+// VerifyStreamStatus checks that the stream status recorded in the cache matches the stream status recorded in memory.
+// There was an issue where if we failed to update the stream status in the cache due to a network error that it could
+// be stuck as INITIALIZING until there was a disconnect between the Harness Saas stream and the Proxy. During this time
+// where the state was stuck as INITIALIZING any SDK stream requests would be rejected by replicas.
+//
+// This thread should resolve that issue because the stream status stored in memory isn't affected by network issues so
+// should always be up to date.
+func (h Health) VerifyStreamStatus(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.log.Info("context canceled, stopping thread that checks the cached stream status matches the in memory status")
+			return
+		case <-ticker.C:
+
+			var cachedStatus domain.StreamStatus
+			inMemStatus := h.inMemStatus.Get()
+
+			if err := h.c.Get(ctx, h.key, &cachedStatus); err != nil {
+				h.log.Error("failed to get stream status from cache", "err", err)
+			}
+
+			// The inMemState should always be accurate, if there's a difference between it and the
+			// cachedState then it's possible there was a network error when we tried to update the
+			// cachedState in SetHealthy or SetUnhealthy and we should try to update the cachedState again
+			if cachedStatus.State != inMemStatus.State {
+				if err := h.c.Set(ctx, h.key, inMemStatus); err != nil {
+					h.log.Error("failed to update cached stream state to match in memory stream state", "err", err)
+				}
+			}
+		}
+	}
 }
 
 // StreamStatus returns the StreamStatus from the cache

--- a/stream/health_test.go
+++ b/stream/health_test.go
@@ -1,0 +1,101 @@
+package stream
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/harness/ff-proxy/v2/cache"
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCache struct {
+	cache.Cache
+	getFn func(value interface{}) error
+
+	value interface{}
+}
+
+func (m *mockCache) Get(ctx context.Context, key string, value interface{}) error {
+	return m.getFn(value)
+}
+
+func (m *mockCache) Set(ctx context.Context, key string, value interface{}) error {
+	m.value = value
+	return nil
+}
+
+func TestHealth_VerifyStreamStatus(t *testing.T) {
+	type args struct {
+		interval    time.Duration
+		inMemStatus domain.StreamStatus
+	}
+
+	type mocks struct {
+		cache *mockCache
+	}
+
+	type expected struct {
+		streamStatus domain.StreamStatus
+	}
+
+	testCases := map[string]struct {
+		args     args
+		mocks    mocks
+		expected expected
+	}{
+		"Given the inMemoryStreamStatus is different from the cachedStreamStatus": {
+			args: args{
+				interval: 2 * time.Second,
+				inMemStatus: domain.StreamStatus{
+					State: domain.StreamStateConnected,
+					Since: 456,
+				},
+			},
+			mocks: mocks{
+				cache: &mockCache{
+					getFn: func(value interface{}) error {
+						value = domain.StreamStatus{
+							State: domain.StreamStateInitializing,
+							Since: 123,
+						}
+						return nil
+					},
+				},
+			},
+			expected: expected{
+				streamStatus: domain.StreamStatus{
+					State: domain.StreamStateConnected,
+					Since: 456,
+				},
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			h := Health{
+				log:         log.NoOpLogger{},
+				c:           tc.mocks.cache,
+				key:         "foo",
+				inMemStatus: domain.NewSafeStreamStatus(tc.args.inMemStatus),
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), tc.args.interval*2)
+			defer cancel()
+
+			h.VerifyStreamStatus(ctx, tc.args.interval)
+
+			actual := tc.mocks.cache.value
+
+			assert.Equal(t, tc.expected.streamStatus, actual)
+		})
+	}
+
+}


### PR DESCRIPTION
**What**

- Stores the StreamStatus in memory as well as in the redis cache. The in memory status can't be impacted by network issues with redis so should always be correct and up to date.
- Starts a goroutine that periodically checks the cached StreamStatus matches the in memory StreamStatus

**Why**

There was a bug where the Primary Proxy could start up, succesfully stream with Saas and fail to update the StreamState in redis from `INTIALIZING` to `CONNECTED` due to a network error. This would then lead to the StreamState being stuck at `INITIALIZING` which meant SDK /stream requests were rejected by the Replica Proxy's. The Proxy would then end up stuck in this state until there was a genuine disconnect and reconnect with the Saas stream which would then correct the StreamState in redis.

**Testing**

- I manually commented out the code that sets the stream state from `INITIALIZING` to `CONNECTED` at startup and saw that when the ticker in the Gorotuine expired the StreamStatus was corrected to match the in memory status.