### PR TITLE
FFM-10731  Fix bug where bad stream state could be recored with redis connection issues

### DIFF
--- a/stream/health_test.go
+++ b/stream/health_test.go
@@ -99,3 +99,161 @@ func TestHealth_VerifyStreamStatus(t *testing.T) {
 	}
 
 }
+
+func TestHealth_SetHealthy(t *testing.T) {
+
+	type args struct {
+	}
+
+	type mocks struct {
+		cache *mockCache
+	}
+
+	type expected struct {
+		inMemStatus domain.StreamStatus
+	}
+
+	testCases := map[string]struct {
+		args      args
+		mocks     mocks
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I call health but the cache errors getting the current status": {
+			mocks: mocks{cache: &mockCache{getFn: func(value interface{}) error {
+				return domain.ErrCacheInternal
+			}}},
+			expected: expected{
+				inMemStatus: domain.StreamStatus{
+					State: domain.StreamStateConnected,
+					Since: 123,
+				},
+			},
+			shouldErr: true,
+		},
+		"Given the status of the stream in the cache is DISCONNECTED": {
+			mocks: mocks{cache: &mockCache{getFn: func(value interface{}) error {
+				value = domain.StreamStatus{
+					State: domain.StreamStateDisconnected,
+					Since: 456,
+				}
+				return nil
+			}}},
+			expected: expected{
+				inMemStatus: domain.StreamStatus{
+					State: domain.StreamStateConnected,
+					Since: 123,
+				},
+			},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			h := Health{
+				log: log.NoOpLogger{},
+				c:   tc.mocks.cache,
+				key: "foo",
+				inMemStatus: domain.NewSafeStreamStatus(domain.StreamStatus{
+					State: domain.StreamStateConnected,
+					Since: 123,
+				}),
+			}
+
+			err := h.SetHealthy(context.Background())
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tc.expected.inMemStatus.State, h.inMemStatus.Get().State)
+		})
+	}
+}
+
+func TestHealth_SetUnHealthy(t *testing.T) {
+
+	type args struct {
+		startingState domain.StreamState
+	}
+
+	type mocks struct {
+		cache *mockCache
+	}
+
+	type expected struct {
+		inMemStatus domain.StreamStatus
+	}
+
+	testCases := map[string]struct {
+		args      args
+		mocks     mocks
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I call SetUnhealthy but the cache errors getting the current status": {
+			args: args{
+				startingState: domain.StreamStateConnected,
+			},
+			mocks: mocks{cache: &mockCache{getFn: func(value interface{}) error {
+				return domain.ErrCacheInternal
+			}}},
+			expected: expected{
+				inMemStatus: domain.StreamStatus{
+					State: domain.StreamStateConnected,
+					Since: 123,
+				},
+			},
+			shouldErr: true,
+		},
+		"Given the status of the stream in the cache is CONNECTED": {
+			mocks: mocks{cache: &mockCache{getFn: func(value interface{}) error {
+				value = domain.StreamStatus{
+					State: domain.StreamStateConnected,
+					Since: 456,
+				}
+				return nil
+			}}},
+			expected: expected{
+				inMemStatus: domain.StreamStatus{
+					State: domain.StreamStateDisconnected,
+					Since: 123,
+				},
+			},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			h := Health{
+				log: log.NoOpLogger{},
+				c:   tc.mocks.cache,
+				key: "foo",
+				inMemStatus: domain.NewSafeStreamStatus(domain.StreamStatus{
+					State: tc.args.startingState,
+					Since: 123,
+				}),
+			}
+
+			err := h.SetUnhealthy(context.Background())
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tc.expected.inMemStatus.State, h.inMemStatus.Get().State)
+		})
+	}
+}


### PR DESCRIPTION


**What**

- We only update the in memory stream status if we don't error fetching the cached status from redis

**Why**

- At the start of the SetHealthy & SetUnhealthy functions we decalre an empty StreamStatus. We then have a defer that sets that variable as the inMemoryStatus at the end of the function. However if we got an InternalError getting the cached value from redis which happened if there was a connection issue, then we'd end up
setting a default struct with empty fields as the in memory stream state.

This resulted in a bug where the stream state could be this in the health response
```
{"configStatus":{"state":"SYNCED","since":1708009070054},"streamStatus":{"state":"","since":0},"cacheStatus":"healthy"}
```

Instead of being `INITIALIZING`, `CONNECTED` or `DISCONNECTED`

**Testing**

- Added unit tests that mock out the redis connection error