### PR TITLE
[FFM-10769] : Aggregate Metics data for client SKDs

### DIFF
--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -1,6 +1,7 @@
 package metricsservice
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -75,10 +76,14 @@ func (m *metricsMap) add(r domain.MetricsRequest) {
 }
 
 // aggregate will convert and aggregate all the entries into the Metrics data and update new object.
-func (m *metricsMap) aggregate(r domain.MetricsRequest) []clientgen.MetricsData {
+func (m *metricsMap) aggregate(r domain.MetricsRequest) ([]clientgen.MetricsData, error) {
 
 	aggregatedMetricsMap := map[string]*clientgen.MetricsData{}
 	// dereference here
+	if r.MetricsData == nil {
+		return []clientgen.MetricsData{}, errors.New("metrics data is nil")
+	}
+	
 	metricsData := *r.MetricsData
 	for i := 0; i < len(metricsData); i++ {
 		keyName := getKeyEntry(r.EnvironmentID, &metricsData[i])
@@ -97,7 +102,7 @@ func (m *metricsMap) aggregate(r domain.MetricsRequest) []clientgen.MetricsData 
 		aggregatedMetricsData = append(aggregatedMetricsData, *v)
 	}
 	// assign new list.
-	return aggregatedMetricsData
+	return aggregatedMetricsData, nil
 }
 
 // getKeyEntry works out key entry for data item and updates the user.

--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -3,12 +3,14 @@ package metricsservice
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/harness/ff-proxy/v2/domain"
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 )
 
 const (
+	// TODO What should it be?
 	genericProxyTargetIdentifier = "generic_proxy_target"
 )
 
@@ -85,7 +87,8 @@ func (m *metricsMap) aggregate(r domain.MetricsRequest) []clientgen.MetricsData 
 		if _, ok := aggregatedMetricsMap[keyName]; ok {
 			aggregatedMetricsMap[keyName].Count += 1
 		} else {
-			// we create new map entry.
+			// update timestamp + create new map entry.
+			metricsData[i].Timestamp = time.Now().UnixMilli()
 			aggregatedMetricsMap[keyName] = &metricsData[i]
 		}
 	}

--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -83,7 +83,7 @@ func (m *metricsMap) aggregate(r domain.MetricsRequest) ([]clientgen.MetricsData
 	if r.MetricsData == nil {
 		return []clientgen.MetricsData{}, errors.New("metrics data is nil")
 	}
-	
+
 	metricsData := *r.MetricsData
 	for i := 0; i < len(metricsData); i++ {
 		keyName := getKeyEntry(r.EnvironmentID, &metricsData[i])

--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// TODO What should it be?
-	genericProxyTargetIdentifier = "generic_proxy_target"
+	genericProxyTargetIdentifier = "__global__cf_target"
 )
 
 // metricsMap is a type that stores metrics requests

--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -76,16 +76,15 @@ func (m *metricsMap) add(r domain.MetricsRequest) {
 
 // aggregate will convert and aggregate all the entries into the Metrics data and update new object.
 func (m *metricsMap) aggregate(r domain.MetricsRequest) []clientgen.MetricsData {
-	envId := r.EnvironmentID
-	aggregatedMetricsMap := map[string]*clientgen.MetricsData{}
 
+	aggregatedMetricsMap := map[string]*clientgen.MetricsData{}
 	// dereference here
 	metricsData := *r.MetricsData
 	for i := 0; i < len(metricsData); i++ {
-		keyName := getKeyEntry(envId, &metricsData[i])
+		keyName := getKeyEntry(r.EnvironmentID, &metricsData[i])
 		//if we have a key we want to increment
 		if _, ok := aggregatedMetricsMap[keyName]; ok {
-			aggregatedMetricsMap[keyName].Count += 1
+			aggregatedMetricsMap[keyName].Count++
 		} else {
 			// update timestamp + create new map entry.
 			metricsData[i].Timestamp = time.Now().UnixMilli()
@@ -102,7 +101,7 @@ func (m *metricsMap) aggregate(r domain.MetricsRequest) []clientgen.MetricsData 
 }
 
 // getKeyEntry works out key entry for data item and updates the user.
-func getKeyEntry(envId string, m *clientgen.MetricsData) string {
+func getKeyEntry(envID string, m *clientgen.MetricsData) string {
 	var featureIdentifier, variationIdentifier, sdkName, sdkLanguage, sdkType, sdkVersion string
 	// TODO is each of these items guaranteed ?
 	// loop through the list of attributes for each data item
@@ -126,7 +125,7 @@ func getKeyEntry(envId string, m *clientgen.MetricsData) string {
 			m.Attributes[i].Value = genericProxyTargetIdentifier
 		}
 	}
-	return fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s", envId, featureIdentifier, variationIdentifier, sdkName, sdkLanguage, sdkType, sdkVersion)
+	return fmt.Sprintf("%s-%s-%s-%s-%s-%s-%s", envID, featureIdentifier, variationIdentifier, sdkName, sdkLanguage, sdkType, sdkVersion)
 }
 
 func (m *metricsMap) get() map[string]domain.MetricsRequest {

--- a/clients/metrics_service/queue.go
+++ b/clients/metrics_service/queue.go
@@ -70,7 +70,11 @@ func (q Queue) flush(ctx context.Context) {
 // StoreMetrics adds a metrics request to the queue
 func (q Queue) StoreMetrics(ctx context.Context, m domain.MetricsRequest) error {
 	if q.metrics.size() < maxQueueSize {
-		aggregatedMetricsData := q.metrics.aggregate(m)
+		aggregatedMetricsData, err := q.metrics.aggregate(m)
+		if err != nil {
+			q.log.Error("unable to aggregate metrics data", "method", "StoreMetrics", "err", err)
+			return err
+		}
 		originalSize := len(*m.MetricsData)
 		aggregatedSize := len(aggregatedMetricsData)
 		// set aggregated data to be stored

--- a/clients/metrics_service/queue.go
+++ b/clients/metrics_service/queue.go
@@ -70,6 +70,13 @@ func (q Queue) flush(ctx context.Context) {
 // StoreMetrics adds a metrics request to the queue
 func (q Queue) StoreMetrics(ctx context.Context, m domain.MetricsRequest) error {
 	if q.metrics.size() < maxQueueSize {
+		aggregatedMetricsData := q.metrics.aggregate(m)
+		originalSize := len(*m.MetricsData)
+		aggregatedSize := len(aggregatedMetricsData)
+		// set aggregated data to be stored
+		m.MetricsData = &aggregatedMetricsData
+		// aggregate the list.
+		q.log.Debug("aggregated metrics data", "originalSize", originalSize, "aggregatedSize", aggregatedSize)
 		q.metrics.add(m)
 		return nil
 	}


### PR DESCRIPTION
```
[FFM-10769] : Aggregate Metics data for client SKDs
 ### What: 
- Filter through the Metrics data sent by sdks 
- Update target with generic identifier
- Increase count on duplicated
- Update timestamp  
 ### Why:
To reduce the number of metrics data we send to SAAS
 ### Testing:
Locally
```

[FFM-10769]: https://harness.atlassian.net/browse/FFM-10769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ