### PR TITLE
FFM-10855 Make Healthcheck use in-memory stream status

### DIFF
--- a/stream/health.go
+++ b/stream/health.go
@@ -150,15 +150,6 @@ func (h Health) VerifyStreamStatus(ctx context.Context, interval time.Duration) 
 }
 
 // StreamStatus returns the StreamStatus from the cache
-func (h Health) StreamStatus(ctx context.Context) (domain.StreamStatus, error) {
-	var s domain.StreamStatus
-	if err := h.c.Get(ctx, h.key, &s); err != nil {
-		h.log.Error("failed to get stream status from cache", "err", err)
-		return domain.StreamStatus{}, err
-	}
-
-	inMemStatus := h.inMemStatus.Get()
-	h.log.Info("StreamStatus for health endpoint", "cachedStatus.Since", s.Since, "cachedStatus.State", s.State, "inMemStatus.State", inMemStatus.State, "inMemStatus.Since", inMemStatus.Since)
-
-	return s, nil
+func (h Health) StreamStatus(_ context.Context) (domain.StreamStatus, error) {
+	return h.inMemStatus.Get(), nil
 }


### PR DESCRIPTION
**What**

- Rather than hitting redis each time the `/health` endpoint is called to get the stream status we now just return the in-memory stream status

**Why**

- This lightens the load on redis and we have a thread running once a minute that makes sure the in-memory status is up to date
- When we were load testing the Proxy and redis was under high load, this call to redis in the healthcheck could timeout, causing the healthcheck to fail and k8s to bounce the pod