### PR TITLE
FFM-10889 Fix bad assignement

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -336,7 +336,7 @@ func main() {
 				"control_uri": "http://localhost:5561",
 			},
 		})
-		saasStreamHealth = stream.NewHealth("ffproxy_saas_stream_health", sdkCache, logger)
+		saasStreamHealth = stream.NewHealth("ffproxy_saas_stream_health", cache.NewKeyValCache(redisClient), logger)
 		connectedStreams = domain.NewSafeMap()
 
 		getConnectedStreams = func() map[string]interface{} {

--- a/stream/health.go
+++ b/stream/health.go
@@ -89,7 +89,7 @@ func (h Health) SetUnhealthy(ctx context.Context) error {
 		Since: time.Now().UnixMilli(),
 	}
 
-	cachedStatus := &domain.StreamStatus{}
+	cachedStatus := domain.StreamStatus{}
 	if err := h.c.Get(ctx, h.key, &cachedStatus); err != nil {
 		// Ignore NotFound errors for this key because if the key doesn't
 		// exist we'll end up setting it at the end of this function


### PR DESCRIPTION
**What**

- Fixes a bug that could occur when setting the stream status
- The health check cache no longer uses the memoize cache

**Why**

- This bug happened in the reflection code in the memoize cache when we were trying to assign the value because we were passing a pointer to a pointer
- We probably don't need to use the memoize cache for the healcheck cache we can probably just hit redis directly

**Testing**

- Testing locally I waited for a stream disconnect and after the disconnect the panic doens't happen anymore