### PR TITLE
[FFM-10775]: Separate queues for TargetMetics and EvaluationMetics. Post them independently.

### DIFF
--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -11,22 +11,27 @@ import (
 )
 
 const (
-	// TODO What should it be?
 	genericProxyTargetIdentifier = "__global__cf_target"
+	metricsVariant               = "metrics"
+	targetVariant                = "target"
 )
 
 // metricsMap is a type that stores metrics requests
 // and aggregates them by environment
 type metricsMap struct {
 	*sync.RWMutex
-	metrics     map[string]domain.MetricsRequest
-	currentSize int
+	metrics        map[string]domain.MetricsRequest
+	currentSize    int
+	tickerDuration time.Duration
+	ticker         *time.Ticker
 }
 
-func newMetricsMap() *metricsMap {
+func newMetricsMap(duration time.Duration) *metricsMap {
 	return &metricsMap{
-		RWMutex: &sync.RWMutex{},
-		metrics: make(map[string]domain.MetricsRequest),
+		RWMutex:        &sync.RWMutex{},
+		metrics:        make(map[string]domain.MetricsRequest),
+		tickerDuration: duration,
+		ticker:         time.NewTicker(duration),
 	}
 }
 

--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -18,10 +18,8 @@ const (
 // and aggregates them by environment
 type metricsMap struct {
 	*sync.RWMutex
-	metrics        map[string]domain.MetricsRequest
-	currentSize    int
-	tickerDuration time.Duration
-	ticker         *time.Ticker
+	metrics     map[string]domain.MetricsRequest
+	currentSize int
 }
 
 func newMetricsMap() *metricsMap {

--- a/clients/metrics_service/map.go
+++ b/clients/metrics_service/map.go
@@ -12,8 +12,6 @@ import (
 
 const (
 	genericProxyTargetIdentifier = "__global__cf_target"
-	metricsVariant               = "metrics"
-	targetVariant                = "target"
 )
 
 // metricsMap is a type that stores metrics requests
@@ -26,12 +24,10 @@ type metricsMap struct {
 	ticker         *time.Ticker
 }
 
-func newMetricsMap(duration time.Duration) *metricsMap {
+func newMetricsMap() *metricsMap {
 	return &metricsMap{
-		RWMutex:        &sync.RWMutex{},
-		metrics:        make(map[string]domain.MetricsRequest),
-		tickerDuration: duration,
-		ticker:         time.NewTicker(duration),
+		RWMutex: &sync.RWMutex{},
+		metrics: make(map[string]domain.MetricsRequest),
 	}
 }
 

--- a/clients/metrics_service/map_test.go
+++ b/clients/metrics_service/map_test.go
@@ -12,6 +12,10 @@ import (
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 )
 
+const (
+	testDuration = 10 * time.Second
+)
+
 func TestMap_add(t *testing.T) {
 
 	mr123 := domain.MetricsRequest{
@@ -79,7 +83,7 @@ func TestMap_add(t *testing.T) {
 		expected   expected
 	}{
 		"Given I add one element to an empty map": {
-			metricsMap: newMetricsMap(),
+			metricsMap: newMetricsMap(testDuration),
 			args: args{
 				metricRequest: mr123,
 			},
@@ -167,7 +171,7 @@ func TestMetricsMap_get(t *testing.T) {
 		expected   expected
 	}{
 		"Given I have an empty metrics map": {
-			metricsMap: newMetricsMap(),
+			metricsMap: newMetricsMap(testDuration),
 			expected:   expected{data: make(map[string]domain.MetricsRequest)},
 		},
 		"Given I have a metrics map with one item in it": {
@@ -218,7 +222,7 @@ func TestMetricsMap_size(t *testing.T) {
 		expected   expected
 	}{
 		"Given I have an empty metrics map": {
-			metricsMap: newMetricsMap(),
+			metricsMap: newMetricsMap(testDuration),
 			expected:   expected{size: 0},
 		},
 		"Given I have a metrics map with a size of 11": {
@@ -255,7 +259,7 @@ func TestMetricsMap_flush(t *testing.T) {
 		expected   expected
 	}{
 		"Given I have an empty metrics map and I call flush": {
-			metricsMap: newMetricsMap(),
+			metricsMap: newMetricsMap(testDuration),
 			expected: expected{
 				data: make(map[string]domain.MetricsRequest),
 				size: 0,

--- a/clients/metrics_service/map_test.go
+++ b/clients/metrics_service/map_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	testDuration = 10 * time.Second
+	testDuration = 1 * time.Second
 )
 
 func TestMap_add(t *testing.T) {
@@ -83,7 +83,7 @@ func TestMap_add(t *testing.T) {
 		expected   expected
 	}{
 		"Given I add one element to an empty map": {
-			metricsMap: newMetricsMap(testDuration),
+			metricsMap: newMetricsMap(),
 			args: args{
 				metricRequest: mr123,
 			},
@@ -171,7 +171,7 @@ func TestMetricsMap_get(t *testing.T) {
 		expected   expected
 	}{
 		"Given I have an empty metrics map": {
-			metricsMap: newMetricsMap(testDuration),
+			metricsMap: newMetricsMap(),
 			expected:   expected{data: make(map[string]domain.MetricsRequest)},
 		},
 		"Given I have a metrics map with one item in it": {
@@ -222,7 +222,7 @@ func TestMetricsMap_size(t *testing.T) {
 		expected   expected
 	}{
 		"Given I have an empty metrics map": {
-			metricsMap: newMetricsMap(testDuration),
+			metricsMap: newMetricsMap(),
 			expected:   expected{size: 0},
 		},
 		"Given I have a metrics map with a size of 11": {
@@ -259,7 +259,7 @@ func TestMetricsMap_flush(t *testing.T) {
 		expected   expected
 	}{
 		"Given I have an empty metrics map and I call flush": {
-			metricsMap: newMetricsMap(testDuration),
+			metricsMap: newMetricsMap(),
 			expected: expected{
 				data: make(map[string]domain.MetricsRequest),
 				size: 0,

--- a/clients/metrics_service/queue.go
+++ b/clients/metrics_service/queue.go
@@ -36,15 +36,14 @@ type Queue struct {
 func NewQueue(ctx context.Context, l log.Logger, duration time.Duration) Queue {
 	l.With("component", "Queue")
 	q := Queue{
-		log:         l,
-		queue:       make(chan map[string]domain.MetricsRequest),
-		metricsData: newMetricsMap(),
-		targetData:  newMetricsMap(),
-
-		metricsTicker:   time.NewTicker(duration),
-		targetsTicker:   time.NewTicker(duration),
+		log:             l,
+		queue:           make(chan map[string]domain.MetricsRequest),
 		metricsDuration: duration,
 		targetsDuration: duration,
+		metricsTicker:   time.NewTicker(duration),
+		targetsTicker:   time.NewTicker(duration),
+		metricsData:     newMetricsMap(),
+		targetData:      newMetricsMap(),
 	}
 
 	// Start a routine that flushes the queue when the ticker expires

--- a/clients/metrics_service/queue.go
+++ b/clients/metrics_service/queue.go
@@ -24,8 +24,6 @@ type Queue struct {
 	queue       chan map[string]domain.MetricsRequest
 	metricsData *metricsMap
 	targetData  *metricsMap
-	//ticker         *time.Ticker
-	//tickerDuration time.Duration
 }
 
 // NewQueue creates a Queue //asz should really return both queues.

--- a/clients/metrics_service/worker_test.go
+++ b/clients/metrics_service/worker_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/harness/ff-proxy/v2/domain"
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
 	"github.com/harness/ff-proxy/v2/log"
-	jsoniter "github.com/json-iterator/go"
-	"github.com/stretchr/testify/assert"
 )
 
 type mockRedisStream struct {
@@ -106,6 +107,22 @@ func TestWorker_Start(t *testing.T) {
 		Metrics:       clientgen.Metrics{MetricsData: &[]clientgen.MetricsData{}},
 	}
 
+	mr123EvaluationMetricsExpected := domain.MetricsRequest{
+		Size:          176,
+		EnvironmentID: "123",
+		Metrics: clientgen.Metrics{
+			MetricsData: &[]clientgen.MetricsData{
+				{
+					Attributes:  nil,
+					Count:       1,
+					MetricsType: "Server",
+					Timestamp:   111,
+				},
+			},
+			TargetData: nil,
+		},
+	}
+
 	type args struct {
 	}
 
@@ -131,7 +148,7 @@ func TestWorker_Start(t *testing.T) {
 					metrics: make(chan domain.MetricsRequest),
 				},
 			},
-			expected: expected{metrics: []domain.MetricsRequest{mr123}},
+			expected: expected{metrics: []domain.MetricsRequest{mr123EvaluationMetricsExpected}},
 		},
 		"Given I have a redis stream with two metrics requests on it": {
 			mocks: mocks{
@@ -140,7 +157,7 @@ func TestWorker_Start(t *testing.T) {
 					metrics: make(chan domain.MetricsRequest),
 				},
 			},
-			expected: expected{metrics: []domain.MetricsRequest{mr123, mr456}},
+			expected: expected{metrics: []domain.MetricsRequest{mr123EvaluationMetricsExpected, mr456}},
 		},
 	}
 


### PR DESCRIPTION

```
[FFM-10775]: Separate queues for TargetMetics and EvaluationMetics. Post them independently
 ### What: 
Separate metics payload for the target and evaluation metrics.
 ### Why:
To be able to post both on different intervals if required
 ### Testing:
Locally
```


[FFM-10775]: https://harness.atlassian.net/browse/FFM-10775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ