### PR TITLE
FFM-10906 Use singleflight in HashCache

### DIFF
--- a/cache/hash_cache_test.go
+++ b/cache/hash_cache_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/harness/ff-proxy/v2/domain"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/singleflight"
 )
 
 type mCache struct {
@@ -176,8 +177,9 @@ func TestHashCache_Set(t *testing.T) {
 			ctx := context.Background()
 
 			hc := HashCache{
-				Cache:      tc.mocks.cache,
-				localCache: nil,
+				Cache:        tc.mocks.cache,
+				localCache:   nil,
+				requestGroup: &singleflight.Group{},
 			}
 
 			err := hc.Set(ctx, tc.args.key, tc.args.value)
@@ -279,8 +281,9 @@ func TestHashCache_Get(t *testing.T) {
 			ctx := context.Background()
 
 			hc := HashCache{
-				Cache:      tc.mocks.cache,
-				localCache: tc.mocks.localCache,
+				Cache:        tc.mocks.cache,
+				localCache:   tc.mocks.localCache,
+				requestGroup: &singleflight.Group{},
 			}
 
 			// Set key before we run Get test

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -309,7 +309,7 @@ func main() {
 		mcMetrics := cache.NewMemoizeMetrics("proxy", promReg)
 		mcCache := cache.NewMemoizeCache(redisClient, 1*time.Minute, 2*time.Minute, mcMetrics)
 		sdkCache = cache.NewMetricsCache("redis", promReg, mcCache)
-		hashCache = cache.NewHashCache(cache.NewKeyValCache(redisClient), 30*time.Minute, 10*time.Minute)
+		hashCache = cache.NewHashCache(cache.NewKeyValCache(redisClient), 10*time.Minute, 12*time.Minute)
 
 		err = sdkCache.HealthCheck(ctx)
 		if err != nil {


### PR DESCRIPTION
**What**

- Makes a change so that the HacheCache uses a singleflight pattern for requests

**Why**

- During load tests we were constantly maxing out the number of available redis connections. If we increased the number of connections that were available all that happened was we increased the number that we used.
- This singleflight pattern means that if we have multiple concurrent requests for the same key only one will be allowed to hit redis, the others will wait and be returned the response from the request that hit redis.

**Testing**

- Kicked off load tests again and can see a big reduction in the number of redis connections being used
![Screenshot 2024-03-12 at 11 30 55](https://github.com/harness/ff-proxy/assets/16992818/cd6f0f56-55a8-4464-823a-e71490fe25d7)

