### PR TITLE
FFM-10913 - Add HarnessXHeaders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ generate: ## Generates the client for the ff-servers client service
 
 PHONY+= build
 build: ## Builds the ff-proxy service binary
-	CGO_ENABLED=0 go build -ldflags="-X github.com/harness/ff-proxy/build.Version=${GIT_TAG}" -o ff-proxy ./cmd/ff-proxy/main.go
+	CGO_ENABLED=0 go build -ldflags="-X github.com/harness/ff-proxy/v2/build.Version=${GIT_TAG}" -o ff-proxy ./cmd/ff-proxy/main.go
 
 PHONY+= build-race
 build-race: generate ## Builds the ff-proxy service binary with the race detector enabled

--- a/clients/metrics_service/client_test.go
+++ b/clients/metrics_service/client_test.go
@@ -60,10 +60,9 @@ func TestMetricService_addAuthToken(t *testing.T) {
 
 			// create context and add token to it
 			ctx := context.Background()
-			ctx = context.WithValue(ctx, tokenKey, tc.token)
 
 			// check metrics are cleared after sending
-			err := addAuthToken(ctx, req)
+			err := addAuthToken(tc.token)(ctx, req)
 
 			// get auth header from updated request
 			assert.Equal(t, tc.expectedAuthHeader, req.Header.Get("Authorization"))

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,8 @@ type Config interface {
 
 	// SetProxyConfig sets the proxyConfig member
 	SetProxyConfig(proxyConfig []domain.ProxyConfig)
+
+	AccountID() string
 }
 
 // NewConfig creates either a local or remote config type that implements the Config interface

--- a/config/local/config.go
+++ b/config/local/config.go
@@ -63,6 +63,10 @@ func (c Config) Key() string {
 	return ""
 }
 
+func (c Config) AccountID() string {
+	return ""
+}
+
 // SetProxyConfig sets the proxyConfig member
 func (c Config) SetProxyConfig(_ []domain.ProxyConfig) {
 

--- a/domain/context_keys.go
+++ b/domain/context_keys.go
@@ -1,0 +1,7 @@
+package domain
+
+type ContextKey string
+
+const (
+	ContextKeyAccountID = ContextKey("accountID")
+)

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -1,8 +1,10 @@
 package domain
 
 import (
+	"reflect"
 	"testing"
 
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,4 +19,80 @@ func TestSafeMap(t *testing.T) {
 	actualM := m.Get()
 
 	assert.Equal(t, expectedM, actualM)
+}
+
+func TestStreamState_String(t *testing.T) {
+	assert.Equal(t, "CONNECTED", StreamStateConnected.String())
+	assert.Equal(t, "DISCONNECTED", StreamStateDisconnected.String())
+	assert.Equal(t, "INITIALIZING", StreamStateInitializing.String())
+}
+
+func TestNewAuthAPIKey(t *testing.T) {
+	expected := AuthAPIKey("auth-key-123")
+	actual := NewAuthAPIKey("123")
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestEnvironmentID_MarshalBinary(t *testing.T) {
+	envID := EnvironmentID("123")
+	expected, err := jsoniter.Marshal(envID)
+	assert.Nil(t, err)
+
+	actual, err := envID.MarshalBinary()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestEnvironmentID_UnmarshalBinary(t *testing.T) {
+	envID := EnvironmentID("123")
+	b, err := jsoniter.Marshal(envID)
+	assert.Nil(t, err)
+
+	var expected EnvironmentID
+	assert.Nil(t, jsoniter.Unmarshal(b, &expected))
+
+	var actual EnvironmentID
+	assert.Nil(t, actual.UnmarshalBinary(b))
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestNewConfigStatus(t *testing.T) {
+	expected := ConfigStatus{State: ConfigStateSynced}
+
+	actual := NewConfigStatus(ConfigStateSynced)
+
+	assert.Equal(t, expected.State, actual.State)
+	assert.NotEqual(t, int64(0), actual.Since)
+}
+
+func TestStreamStatus_MarshalBinary(t *testing.T) {
+	streamStatus := NewStreamStatus()
+	expected, err := jsoniter.Marshal(streamStatus)
+	assert.Nil(t, err)
+
+	actual, err := streamStatus.MarshalBinary()
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestStreamStatus_UnmarshalBinary(t *testing.T) {
+	streamStatus := NewStreamStatus()
+	b, err := jsoniter.Marshal(streamStatus)
+	assert.Nil(t, err)
+
+	var expected StreamStatus
+	assert.Nil(t, jsoniter.Unmarshal(b, &expected))
+
+	var actual StreamStatus
+	assert.Nil(t, actual.UnmarshalBinary(b))
+
+	assert.Equal(t, expected, actual)
+}
+
+func Test_ToPtr(t *testing.T) {
+	s := "foo"
+	actual := ToPtr(s)
+	assert.True(t, reflect.ValueOf(actual).Kind() == reflect.Ptr)
 }

--- a/domain/features_test.go
+++ b/domain/features_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,4 +43,29 @@ func Test_toSDKRules(t *testing.T) {
 
 	actual2 := toSDKRules(&rules2)
 	assert.NotNil(t, actual2[0].Serve.Distribution)
+}
+
+func TestNewFeatureConfigKey(t *testing.T) {
+	expected := FeatureFlagKey("env-123-feature-config-foo")
+	actual := NewFeatureConfigKey("123", "foo")
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestNewFeatureConfigsKey(t *testing.T) {
+	expected := FeatureFlagKey("env-123-feature-configs")
+	actual := NewFeatureConfigsKey("123")
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestFeatureFlag_MarshalBinary(t *testing.T) {
+	ff := FeatureFlag{Feature: "foo"}
+	expected, err := jsoniter.Marshal(ff)
+	assert.Nil(t, err)
+
+	actual, err := ff.MarshalBinary()
+	assert.Nil(t, err)
+
+	assert.Equal(t, expected, actual)
 }

--- a/domain/requests.go
+++ b/domain/requests.go
@@ -1,6 +1,11 @@
 package domain
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/harness/ff-proxy/v2/build"
 	jsoniter "github.com/json-iterator/go"
 
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
@@ -95,4 +100,15 @@ type GetProxyConfigInput struct {
 type AuthenticateProxyKeyResponse struct {
 	Token             string
 	ClusterIdentifier string
+}
+
+func AddHarnessXHeaders(envID string) func(ctx context.Context, req *http.Request) error {
+	return func(ctx context.Context, req *http.Request) error {
+		accountID := ctx.Value(ContextKeyAccountID).(string)
+
+		req.Header.Set("Harness-Accountid", accountID)
+		req.Header.Set("Harness-Environmentid", envID)
+		req.Header.Set("Harness-Sdk-Info", fmt.Sprintf("Proxy %s", build.Version))
+		return nil
+	}
 }

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/harness/ff-proxy/v2/build"
 	"github.com/r3labs/sse/v2"
 	"gopkg.in/cenkalti/backoff.v1"
 
@@ -23,11 +24,13 @@ type SSEClient struct {
 }
 
 // NewSSEClient creates an SSEClient
-func NewSSEClient(l log.Logger, url string, key string, token string) *SSEClient {
+func NewSSEClient(l log.Logger, url string, key string, token string, accountID string) *SSEClient {
 	c := sse.NewClient(url)
 	c.Headers = map[string]string{
-		"Authorization": fmt.Sprintf("Bearer %s", token),
-		"API-Key":       key,
+		"Authorization":     fmt.Sprintf("Bearer %s", token),
+		"API-Key":           key,
+		"Harness-Accountid": accountID,
+		"Harness-Sdk-Info":  fmt.Sprintf("Proxy %s", build.Version),
 	}
 
 	// don't use the default exponentialBackoff strategy - we'll have our own disconnect logic


### PR DESCRIPTION
**What**

- Adds HarnessXHeaders to the following requests the Proxy makes to Saas
  - /feature-configs/<identiifer>
  - /target-segments/<identifier>
  - /stream
  - /metrics/<envID>
 - Fixes build version tag, this was broken when we added `v2` to the import path

**Why**

- This will let us differentiate between Proxy & SDK traffic on these endpoints in our Saas metrics

**Testing**

- Tested locally with a reverse proxy that logged out the headers
- Added some unit tests for some unreleated domain package code