### PR TITLE
FFM-10913 Add Build arg and Env to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM golang:1.20 as builder
 
 WORKDIR /app
 
+ARG gitTag
+ENV GIT_TAG $gitTag
+
 # Fetch dependencies.
 COPY go.mod .
 COPY go.sum .

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ build-race: generate ## Builds the ff-proxy service binary with the race detecto
 
 image: ## Builds a docker image for the proxy called ff-proxy:latest
 	@echo "Building Feature Flag Proxy Image"
-	@docker build -t harness/ff-proxy:latest -f ./Dockerfile .
+	@docker build -t harness/ff-proxy:latest -f ./Dockerfile --build-arg gitTag=${GIT_TAG} .
 
 PHONY+= test
 test: ## Run the go tests (runs with race detector enabled)


### PR DESCRIPTION
**What**

- Adds a build arg and env to the dockerfile

**Why**

- We need these to set the embed the image version in the binary in our CI pipelines
