### PR TITLE
FFM-10979 Use harness-community/sse/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/google/uuid v1.4.0
+	github.com/harness-community/sse/v3 v3.1.0
 	github.com/harness/ff-golang-server-sdk v0.1.17
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/joho/godotenv v1.4.0
@@ -22,12 +23,11 @@ require (
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.11.1
-	github.com/r3labs/sse v0.0.0-20201126193848-34e640891548
-	github.com/r3labs/sse/v2 v2.10.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.19.1
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
+	golang.org/x/sync v0.4.0
 	gopkg.in/cenkalti/backoff.v1 v1.1.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -52,7 +52,6 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
-	github.com/harness-community/sse/v3 v3.1.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
@@ -86,7 +85,6 @@ require (
 	golang.org/x/crypto v0.16.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
-	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect

--- a/go.sum
+++ b/go.sum
@@ -358,10 +358,6 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/r3labs/sse v0.0.0-20201126193848-34e640891548 h1:ewzX4RiFeFXl8APBmMqXBXR5CZoF/jctB71BuLg7d3s=
-github.com/r3labs/sse v0.0.0-20201126193848-34e640891548/go.mod h1:S8xSOnV3CgpNrWd0GQ/OoQfMtlg2uPRSuTzcSGrzwK8=
-github.com/r3labs/sse/v2 v2.10.0 h1:hFEkLLFY4LDifoHdiCN/LlGBAdVJYsANaLqNYa1l/v0=
-github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktEmkNJ7I=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/harness-community/sse/v3"
 	"github.com/harness/ff-proxy/v2/build"
-	"github.com/r3labs/sse/v2"
 	"gopkg.in/cenkalti/backoff.v1"
 
 	"github.com/harness/ff-proxy/v2/domain"

--- a/stream/sse_test.go
+++ b/stream/sse_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/r3labs/sse/v2"
+	"github.com/harness-community/sse/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/stream/stream.go
+++ b/stream/stream.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/harness-community/sse/v3"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/r3labs/sse/v2"
 	"gopkg.in/cenkalti/backoff.v1"
 
 	"github.com/harness/ff-proxy/v2/domain"

--- a/stream/stream_test.go
+++ b/stream/stream_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/r3labs/sse/v2"
+	"github.com/harness-community/sse/v3"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/cenkalti/backoff.v1"
 

--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -35,7 +35,7 @@ func encodeStreamResponse(_ context.Context, w http.ResponseWriter, response int
 	w.Header().Add("Content-Type", "text/event-stream")
 	w.Header().Add("Grip-Hold", "stream")
 	w.Header().Add("Grip-Channel", r.GripChannel)
-	w.Header().Add("Grip-Keep-Alive", "\\n; format=cstring; timeout=15")
+	w.Header().Add("Grip-Keep-Alive", ":\\n\\n; format=cstring; timeout=15")
 	return nil
 }
 

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -15,9 +15,9 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis/v8"
+	"github.com/harness-community/sse/v3"
 	sdkstream "github.com/harness/ff-golang-server-sdk/stream"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/r3labs/sse"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/harness/ff-proxy/v2/cache"

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -1292,7 +1292,7 @@ func TestHTTPServer_Stream(t *testing.T) {
 				"Content-Type":    []string{"text/event-stream"},
 				"Grip-Hold":       []string{"stream"},
 				"Grip-Channel":    []string{envID},
-				"Grip-Keep-Alive": []string{"\\n; format=cstring; timeout=15"},
+				"Grip-Keep-Alive": []string{":\\n\\n; format=cstring; timeout=15"},
 			},
 		},
 


### PR DESCRIPTION
**What**

- Makes us use the `harness-community/sse/v3` fork of `r3labs/sse`
- Changes the keep alive format to match the Saas keepalive format https://github.com/wings-software/ff-server/pull/1948/files
- 
**Why**

- We swapped to using the fork on the server side and in the Go SDK so this keeps us in sync with those

**Testing**

- Manual testing streaming functionality locally with
  - `v0.1.17` Go SDK
  - `1.26.0` Javascript SDK
  - `1.5.0` Java SDK