### PR TITLE
FFM-10969 Add redis cluster support

### DIFF
--- a/cache/key_value_cache.go
+++ b/cache/key_value_cache.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/go-redis/cache/v8"
-	"github.com/go-redis/redis/v8"
 	jsoniter "github.com/json-iterator/go"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/harness/ff-proxy/v2/domain"
 )

--- a/cache/memoize_cache.go
+++ b/cache/memoize_cache.go
@@ -6,10 +6,10 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/go-redis/redis/v8"
 	jsoniter "github.com/json-iterator/go"
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
 )
 
 type memoizeMetrics interface {

--- a/cache/memoize_cache_test.go
+++ b/cache/memoize_cache_test.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/go-redis/redis/v8"
 	jsoniter "github.com/json-iterator/go"
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/clients/client_service/prometheus.go
+++ b/clients/client_service/prometheus.go
@@ -53,8 +53,10 @@ func (p prometheusClient) AuthenticateWithResponse(ctx context.Context, body cli
 func (p prometheusClient) AuthenticateProxyKeyWithResponse(ctx context.Context, body clientgen.AuthenticateProxyKeyJSONRequestBody, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.AuthenticateProxyKeyResponse, err error) {
 	start := time.Now()
 	defer func() {
-		p.requestCount.WithLabelValues("/proxy/auth", "", strconv.Itoa(resp.StatusCode())).Inc()
-		p.requestDuration.WithLabelValues("/proxy/auth", "").Observe(time.Since(start).Seconds())
+		if resp != nil {
+			p.requestCount.WithLabelValues("/proxy/auth", "", strconv.Itoa(resp.StatusCode())).Inc()
+			p.requestDuration.WithLabelValues("/proxy/auth", "").Observe(time.Since(start).Seconds())
+		}
 	}()
 
 	return p.next.AuthenticateProxyKeyWithResponse(ctx, body, reqEditors...)

--- a/clients/metrics_service/queue.go
+++ b/clients/metrics_service/queue.go
@@ -63,7 +63,7 @@ func (q Queue) flush(ctx context.Context) {
 			if len(metrics) == 0 {
 				continue
 			}
-			if err := send(context.Background(), q.queue, metrics); err != nil {
+			if err := send(ctx, q.queue, metrics); err != nil {
 				// The only possible error here is a context canceled or deadline exceeded
 				// but lets still log it anyway
 				q.log.Error("unable to flush metrics to channel", "method", "flush", "err", err)
@@ -74,7 +74,7 @@ func (q Queue) flush(ctx context.Context) {
 			if len(metrics) == 0 {
 				continue
 			}
-			if err := send(context.Background(), q.queue, metrics); err != nil {
+			if err := send(ctx, q.queue, metrics); err != nil {
 				// The only possible error here is a context canceled or deadline exceeded
 				// but lets still log it anyway
 				q.log.Error("unable to flush metrics to channel", "method", "flush", "err", err)

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -8,12 +8,16 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"time"
+
+	_ "net/http/pprof"
 
 	"gopkg.in/cenkalti/backoff.v1"
 
 	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/fanout/go-gripcontrol"
 
@@ -28,8 +32,6 @@ import (
 	"github.com/harness/ff-proxy/v2/token"
 
 	"cloud.google.com/go/profiler"
-
-	"github.com/go-redis/redis/v8"
 
 	"github.com/harness/ff-proxy/v2/cache"
 	"github.com/harness/ff-proxy/v2/config"
@@ -61,6 +63,7 @@ var (
 	redisAddress  string
 	redisPassword string
 	redisDB       int
+	redisPoolSize int
 
 	// Server Config
 	port       int
@@ -98,6 +101,7 @@ const (
 	redisAddrEnv     = "REDIS_ADDRESS"
 	redisPasswordEnv = "REDIS_PASSWORD"
 	redisDBEnv       = "REDIS_DB"
+	redisPoolSizeEnv = "REDIS_POOL_SIZE"
 
 	// Server Config
 	portEnv       = "PORT"
@@ -135,6 +139,7 @@ const (
 	redisAddressFlag  = "redis-address"
 	redisPasswordFlag = "redis-password"
 	redisDBFlag       = "redis-db"
+	redisPoolSizeFlag = "redis-pool-size"
 
 	// Server Config
 	portFlag       = "port"
@@ -172,6 +177,7 @@ func init() {
 	flag.StringVar(&redisAddress, redisAddressFlag, "", "Redis host:port address")
 	flag.StringVar(&redisPassword, redisPasswordFlag, "", "Optional. Redis password")
 	flag.IntVar(&redisDB, redisDBFlag, 0, "Database to be selected after connecting to the server.")
+	flag.IntVar(&redisPoolSize, redisPoolSizeFlag, 10, "sets the redi connection pool size, to this value multipled by the number of CPU available. E.g if this value is 10 and you've 2 CPU the connection pool size will be 20")
 
 	// Server Config
 	flag.IntVar(&port, portFlag, 8000, "port the relay proxy service is exposed on, default's to 8000")
@@ -199,6 +205,7 @@ func init() {
 		redisAddrEnv:                    redisAddressFlag,
 		redisPasswordEnv:                redisPasswordFlag,
 		redisDBEnv:                      redisDBFlag,
+		redisPoolSizeEnv:                redisPoolSizeFlag,
 		metricPostDurationEnv:           metricPostDurationFlag,
 		heartbeatIntervalEnv:            heartbeatIntervalFlag,
 		pprofEnabledEnv:                 pprofEnabledFlag,
@@ -286,30 +293,7 @@ func main() {
 	var hashCache *cache.HashCache
 
 	if redisAddress != "" && !generateOfflineConfig { //nolint:nestif
-		// if address does not start with redis:// or rediss:// then default to redis://
-		// if the connection string starts with rediss:// it means we'll connect with TLS enabled
-		redisConnectionString := redisAddress
-		if !strings.HasPrefix(redisAddress, "redis://") && !strings.HasPrefix(redisAddress, "rediss://") {
-			redisConnectionString = fmt.Sprintf("redis://%s", redisAddress)
-		}
-		parsed, err := redis.ParseURL(redisConnectionString)
-		if err != nil {
-			logger.Error("failed to parse redis address url", "connection string", redisConnectionString, "err", err)
-			os.Exit(1)
-		}
-		// TODO - going forward we can open up support for more of these query param connection string options e.g. max_retries etc
-		// we would first need to test the impact that these would have if unset vs current defaults
-		opts := redis.UniversalOptions{}
-		opts.DB = parsed.DB
-		opts.Addrs = []string{parsed.Addr}
-		opts.Username = parsed.Username
-		opts.Password = parsed.Password
-		opts.TLSConfig = parsed.TLSConfig
-		if redisPassword != "" {
-			opts.Password = redisPassword
-		}
-		redisClient = redis.NewUniversalClient(&opts)
-		logger.Info("connecting to redis", "address", redisAddress)
+		redisClient = newRedisClient(redisAddress, logger)
 
 		mcMetrics := cache.NewMemoizeMetrics("proxy", promReg)
 		mcCache := cache.NewMemoizeCache(redisClient, 1*time.Minute, 2*time.Minute, mcMetrics)
@@ -539,7 +523,7 @@ func main() {
 	server.Use(
 		middleware.NewEchoRequestIDMiddleware(),
 		middleware.NewEchoLoggingMiddleware(logger),
-		middleware.NewEchoAuthMiddleware(authRepo, []byte(authSecret), bypassAuth),
+		middleware.NewEchoAuthMiddleware(logger, authRepo, []byte(authSecret), bypassAuth),
 		middleware.NewPrometheusMiddleware(promReg),
 	)
 
@@ -621,4 +605,37 @@ func newMetricStore(ctx context.Context, logger log.Logger, readReplica bool, re
 	}
 
 	return metricsservice.NewQueue(ctx, logger, time.Duration(metricPostDuration)*time.Second)
+}
+
+func newRedisClient(addr string, logger log.Logger) redis.UniversalClient {
+	splitAddr := strings.Split(addr, ",")
+
+	// if address does not start with redis:// or rediss:// then default to redis://
+	// if the connection string starts with rediss:// it means we'll connect with TLS enabled
+	redisConnectionString := addr
+	if !strings.HasPrefix(redisAddress, "redis://") && !strings.HasPrefix(redisAddress, "rediss://") {
+		redisConnectionString = fmt.Sprintf("redis://%s", redisAddress)
+	}
+
+	parsed, err := redis.ParseURL(redisConnectionString)
+	if err != nil {
+		logger.Error("failed to parse redis address url", "connection string", redisConnectionString, "err", err)
+		os.Exit(1)
+	}
+
+	opts := redis.UniversalOptions{
+		Addrs:     splitAddr,
+		DB:        parsed.DB,
+		Username:  parsed.Username,
+		Password:  parsed.Password,
+		PoolSize:  redisPoolSize * runtime.NumCPU(),
+		TLSConfig: parsed.TLSConfig,
+	}
+
+	if redisPassword != "" {
+		opts.Password = redisPassword
+	}
+
+	logger.Info("connecting to redis", "address", redisAddress, "poolSize", opts.PoolSize)
+	return redis.NewUniversalClient(&opts)
 }

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	_ "net/http/pprof"
+	_ "net/http/pprof" //nolint:gosec
 
 	"gopkg.in/cenkalti/backoff.v1"
 

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/cenkalti/backoff.v1"
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.11.1
+	github.com/redis/go-redis/v9 v9.5.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,10 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -358,6 +362,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/redis/go-redis/v9 v9.5.1 h1:H1X4D3yHPaYrkL5X06Wh6xNVM/pX0Ft4RV0vMGvLBh8=
+github.com/redis/go-redis/v9 v9.5.1/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=

--- a/proxy-service/service.go
+++ b/proxy-service/service.go
@@ -382,7 +382,10 @@ func (s Service) Stream(ctx context.Context, req domain.StreamRequest) (domain.S
 	}
 
 	hashedAPIKey := s.hasher.Hash(req.APIKey)
-	envID, ok := s.authRepo.Get(ctx, domain.NewAuthAPIKey(hashedAPIKey))
+	envID, ok, err := s.authRepo.Get(ctx, domain.NewAuthAPIKey(hashedAPIKey))
+	if err != nil {
+		s.logger.Error(ctx, "stream handler failed to check if key exists in cache", "err", err)
+	}
 	if !ok {
 		return domain.StreamResponse{}, fmt.Errorf("%w: no environment found for apiKey %q", ErrNotFound, req.APIKey)
 	}

--- a/repository/auth_repo.go
+++ b/repository/auth_repo.go
@@ -50,21 +50,21 @@ func (a AuthRepo) AddAPIConfigsForEnvironment(ctx context.Context, envID string,
 
 // Get gets the environmentID for the passed api key hash
 // if the auth repo has been configured with approved envs only return keys that belong to those envs
-func (a AuthRepo) Get(ctx context.Context, key domain.AuthAPIKey) (string, bool) {
+func (a AuthRepo) Get(ctx context.Context, key domain.AuthAPIKey) (string, bool, error) {
 	var environment domain.EnvironmentID
 
 	if err := a.cache.Get(ctx, string(key), &environment); err != nil {
-		return "", false
+		return "", false, err
 	}
 
 	// if we're filtering by env then check result belongs to approved env
 	if len(a.approvedEnvironments) > 0 {
 		if _, exists := a.approvedEnvironments[string(environment)]; !exists {
-			return "", false
+			return "", false, nil
 		}
 	}
 
-	return string(environment), true
+	return string(environment), true, nil
 }
 
 // GetKeysForEnvironment gets all the apikey keys associated with environment id

--- a/repository/auth_repo_test.go
+++ b/repository/auth_repo_test.go
@@ -30,28 +30,32 @@ func TestAuthRepo_Get(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		cache    cache.Cache
-		data     []domain.AuthConfig
-		key      string
-		expected expected
+		cache     cache.Cache
+		data      []domain.AuthConfig
+		key       string
+		shouldErr bool
+		expected  expected
 	}{
 		"Given I have an empty AuthRepo": {
-			cache:    cache.NewMemCache(),
-			data:     unpopulated,
-			key:      "apikey-foo",
-			expected: expected{strVal: "", boolVal: false},
+			cache:     cache.NewMemCache(),
+			data:      unpopulated,
+			key:       "apikey-foo",
+			shouldErr: true,
+			expected:  expected{strVal: "", boolVal: false},
 		},
 		"Given I have a populated AuthRepo but try to get a key that doesn't exist": {
-			cache:    cache.NewMemCache(),
-			data:     populated,
-			key:      "foo",
-			expected: expected{strVal: "", boolVal: false},
+			cache:     cache.NewMemCache(),
+			data:      populated,
+			key:       "foo",
+			shouldErr: true,
+			expected:  expected{strVal: "", boolVal: false},
 		},
 		"Given I have a populated AuthRepo and try to get a key that does exist": {
-			cache:    cache.NewMemCache(),
-			data:     populated,
-			key:      "apikey-foo",
-			expected: expected{strVal: "env-approved", boolVal: true},
+			cache:     cache.NewMemCache(),
+			data:      populated,
+			key:       "apikey-foo",
+			shouldErr: false,
+			expected:  expected{strVal: "env-approved", boolVal: true},
 		},
 	}
 	for desc, tc := range testCases {
@@ -62,7 +66,12 @@ func TestAuthRepo_Get(t *testing.T) {
 
 			assert.Nil(t, repo.Add(ctx, tc.data...))
 
-			actual, ok := repo.Get(ctx, domain.AuthAPIKey(tc.key))
+			actual, ok, err := repo.Get(ctx, domain.AuthAPIKey(tc.key))
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
 
 			assert.Equal(t, tc.expected.boolVal, ok)
 			assert.Equal(t, tc.expected.strVal, actual)

--- a/stream/redis.go
+++ b/stream/redis.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/harness/ff-proxy/v2/domain"
 )

--- a/stream/redis_test.go
+++ b/stream/redis_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/go-redis/redis/v8"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/token/token_source.go
+++ b/token/token_source.go
@@ -12,7 +12,7 @@ import (
 )
 
 type authRepo interface {
-	Get(context context.Context, key domain.AuthAPIKey) (string, bool)
+	Get(context context.Context, key domain.AuthAPIKey) (string, bool, error)
 }
 
 type hasher interface {
@@ -39,7 +39,10 @@ func (a Source) GenerateToken(key string) (domain.Token, error) {
 
 	k := domain.NewAuthAPIKey(h)
 
-	env, ok := a.repo.Get(context.Background(), k)
+	env, ok, err := a.repo.Get(context.Background(), k)
+	if err != nil {
+		a.log.Error("failed to get auth key from cache to generate token", "err", err)
+	}
 	if !ok {
 		return domain.Token{}, fmt.Errorf("key %q not found", key)
 	}


### PR DESCRIPTION
**What**

- Calls `strings.Split` on the `REDIS_ADDRESS` environment variable. This allows us to handle single redis addresses e.g. `REDIS_ADDRESS=localhost:6379` or clustered redis addresses e.g `REDIS_ADDRESS=localhost:6379,localhost:6380,localhost:6381`
- Upgrades redis package, this was due to a bug with cluster mode when using redis 7.X with the go-redis/v8 package

Some other minor changes
- Makes redis pool size configurable
- Imports pprof package
- Fixes potential panic in `[clients/client_service/prometheus.go](https://github.com/harness/ff-proxy/compare/v2...FFM-10969?expand=1#diff-111f4c6c02c977121f554ec35ffdb0131c0f665fd4a52962d9207e06d061a17d)`
- Adds timeout to auth middleware code that does a key lookup in redis

**Why**

- So we can support receiving redis cluster addresses in the REDIS_ADDRESS environment variable

**Testing**

- Ran a local redis cluster locally as well as a single redis instance