### PR TITLE
FFM-11140 Prevent potential panic

### DIFF
--- a/clients/client_service/prometheus.go
+++ b/clients/client_service/prometheus.go
@@ -43,8 +43,10 @@ func newPrometheusClient(next ffClientService, reg *prometheus.Registry) prometh
 func (p prometheusClient) AuthenticateWithResponse(ctx context.Context, body clientgen.AuthenticateJSONRequestBody, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.AuthenticateResponse, err error) {
 	start := time.Now()
 	defer func() {
-		p.requestCount.WithLabelValues("/client/auth", "", strconv.Itoa(resp.StatusCode())).Inc()
-		p.requestDuration.WithLabelValues("/client/auth", "").Observe(time.Since(start).Seconds())
+		if resp != nil {
+			p.requestCount.WithLabelValues("/client/auth", "", strconv.Itoa(resp.StatusCode())).Inc()
+			p.requestDuration.WithLabelValues("/client/auth", "").Observe(time.Since(start).Seconds())
+		}
 	}()
 
 	return p.next.AuthenticateWithResponse(ctx, body, reqEditors...)
@@ -65,8 +67,10 @@ func (p prometheusClient) AuthenticateProxyKeyWithResponse(ctx context.Context, 
 func (p prometheusClient) GetProxyConfigWithResponse(ctx context.Context, params *clientgen.GetProxyConfigParams, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.GetProxyConfigResponse, err error) {
 	start := time.Now()
 	defer func() {
-		p.requestCount.WithLabelValues("/proxy/config", "", strconv.Itoa(resp.StatusCode())).Inc()
-		p.requestDuration.WithLabelValues("/proxy/config", "").Observe(time.Since(start).Seconds())
+		if resp != nil {
+			p.requestCount.WithLabelValues("/proxy/config", "", strconv.Itoa(resp.StatusCode())).Inc()
+			p.requestDuration.WithLabelValues("/proxy/config", "").Observe(time.Since(start).Seconds())
+		}
 	}()
 
 	return p.next.GetProxyConfigWithResponse(ctx, params, reqEditors...)
@@ -75,8 +79,10 @@ func (p prometheusClient) GetProxyConfigWithResponse(ctx context.Context, params
 func (p prometheusClient) GetAllSegmentsWithResponse(ctx context.Context, environmentUUID string, params *clientgen.GetAllSegmentsParams, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.GetAllSegmentsResponse, err error) {
 	start := time.Now()
 	defer func() {
-		p.requestCount.WithLabelValues("/client/env/:env/target-segments", environmentUUID, strconv.Itoa(resp.StatusCode())).Inc()
-		p.requestDuration.WithLabelValues("/client/env/:env/target-segments", environmentUUID).Observe(time.Since(start).Seconds())
+		if resp != nil {
+			p.requestCount.WithLabelValues("/client/env/:env/target-segments", environmentUUID, strconv.Itoa(resp.StatusCode())).Inc()
+			p.requestDuration.WithLabelValues("/client/env/:env/target-segments", environmentUUID).Observe(time.Since(start).Seconds())
+		}
 	}()
 
 	return p.next.GetAllSegmentsWithResponse(ctx, environmentUUID, params, reqEditors...)
@@ -85,8 +91,10 @@ func (p prometheusClient) GetAllSegmentsWithResponse(ctx context.Context, enviro
 func (p prometheusClient) GetFeatureConfigWithResponse(ctx context.Context, environmentUUID string, params *clientgen.GetFeatureConfigParams, reqEditors ...clientgen.RequestEditorFn) (resp *clientgen.GetFeatureConfigResponse, err error) {
 	start := time.Now()
 	defer func() {
-		p.requestCount.WithLabelValues("/client/env/:env/feature-configs", environmentUUID, strconv.Itoa(resp.StatusCode())).Inc()
-		p.requestDuration.WithLabelValues("/client/env/:env/feature-configs", environmentUUID).Observe(time.Since(start).Seconds())
+		if resp != nil {
+			p.requestCount.WithLabelValues("/client/env/:env/feature-configs", environmentUUID, strconv.Itoa(resp.StatusCode())).Inc()
+			p.requestDuration.WithLabelValues("/client/env/:env/feature-configs", environmentUUID).Observe(time.Since(start).Seconds())
+		}
 	}()
 
 	return p.next.GetFeatureConfigWithResponse(ctx, environmentUUID, params, reqEditors...)


### PR DESCRIPTION
**What**

- Adds a nil check to the response object in the prometheus metrics for interactions with the Saas client service

**Why**

- To prevent a potential panic that could occur if the Saas is unreachable

**Testing**

Ran local Harness Proxy -> local http reverse proxy -> Harness Saas

When I kill the reverse Proxy the Harness Proxy will panic because it gets a nil response object trying to reconnect to harness saas. Re-ran the same test after the code change and we don't panic anymore we just log out

```
 {"level":"error","ts":"2024-04-04T13:54:37Z","caller":"stream/on_connect_disconnect_handlers.go:35","msg":"SSE stream disconnected, failed to poll for new config","err":"Post \"http://host.docker.internal:9092/proxy/auth\": dial tcp 192.168.65.2:9092: connect: connection refused"}
```