### PR TITLE
FFM-11111 Prevent Proxy from posting empty metric payloads to Saas

### DIFF
--- a/clients/metrics_service/client.go
+++ b/clients/metrics_service/client.go
@@ -98,7 +98,7 @@ func (c Client) PostMetrics(ctx context.Context, envID string, metric domain.Met
 	}
 
 	if res != nil && res.StatusCode() != 200 {
-		return fmt.Errorf("got non 200 status code from feature flags: status_code=%d", res.StatusCode())
+		return fmt.Errorf("got non 200 status code from feature flags: status_code=%d, body: %s", res.StatusCode(), res.Body)
 	}
 
 	return nil

--- a/clients/metrics_service/queue.go
+++ b/clients/metrics_service/queue.go
@@ -32,7 +32,7 @@ type Queue struct {
 	targetsDuration time.Duration
 }
 
-// NewQueue creates a Queue //asz should really return both queues.
+// NewQueue creates a Queue
 func NewQueue(ctx context.Context, l log.Logger, duration time.Duration) Queue {
 	l.With("component", "Queue")
 	q := Queue{
@@ -107,6 +107,11 @@ func (q Queue) StoreMetrics(ctx context.Context, m domain.MetricsRequest) error 
 }
 
 func (q Queue) handleMetricsData(ctx context.Context, m domain.MetricsRequest) error {
+	// If we've no metric data to handle then we can exit early
+	if m.MetricsData == nil {
+		return nil
+	}
+
 	// we are aggregating the metrics Data and set it to its map.
 	if q.metricsData.size() < maxEvaluationQueueSize {
 		aggregatedMetricsData, err := q.metricsData.aggregate(m)
@@ -142,6 +147,11 @@ func (q Queue) handleMetricsData(ctx context.Context, m domain.MetricsRequest) e
 	return nil
 }
 func (q Queue) handleTargetData(ctx context.Context, m domain.MetricsRequest) error {
+	// If we've no target data to handle then we can exit early
+	if m.TargetData == nil {
+		return nil
+	}
+
 	// check if we have maxed out target metrics
 	if q.targetData.size() < maxTargetQueueSize {
 		//add and  increment for target

--- a/clients/metrics_service/worker.go
+++ b/clients/metrics_service/worker.go
@@ -140,7 +140,7 @@ func (w Worker) postMetrics(ctx context.Context) {
 
 		for envID, metric := range metrics {
 			if err := w.metricsService.PostMetrics(ctx, envID, metric, w.clusterIdentifier); err != nil {
-				w.log.Error("sending metrics failed", "environment", envID, "error", err)
+				w.log.Error("sending metrics failed", "environment", envID, "cluster_identifier", w.clusterIdentifier, "error", err)
 			}
 		}
 	}


### PR DESCRIPTION
**What**

- Adds nil checks to our handleMetricData and handleTargetData functions
  which queue up metric requests to be sent to Saas

**Why**

- We split the metrics logic so that Metrics Data and Target Data is
  sent in two different requests. This could result in a scenario where
we attempted to post empty metrics payloads to Saas when sending the
Target Data if the SDK didn't send any Target data to the Proxy. This
would then result in the Proxy getting a 400 response from Saas and
logging out an error.

**Testing**

- Tested manually locally with an SDK set to annonymous
- Added unit test to make sure we aren't saving metrics payloads with
  nil MetricsData and nil TargetsData in the queue