### PR TITLE
FFM-11276 - Add option to expose prometheus metrics on a different port

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -525,7 +525,7 @@ func main() {
 
 	// Configure endpoints and server
 	endpoints := transport.NewEndpoints(service)
-	server := transport.NewHTTPServer(port, endpoints, logger, tlsEnabled, tlsCert, tlsKey, promReg)
+	server := transport.NewHTTPServer(port, endpoints, logger, tlsEnabled, tlsCert, tlsKey)
 	server.Use(
 		middleware.NewEchoRequestIDMiddleware(),
 		middleware.NewEchoLoggingMiddleware(logger),

--- a/domain/immutable_map.go
+++ b/domain/immutable_map.go
@@ -1,0 +1,17 @@
+package domain
+
+// ImmutableSet is a struct representing an immutable set
+type ImmutableSet struct {
+	data map[string]struct{}
+}
+
+// NewImmutableSet creates a new ImmutableSet with the given data.
+func NewImmutableSet(data map[string]struct{}) *ImmutableSet {
+	return &ImmutableSet{data: data}
+}
+
+// Has checks if the key exists in the Set
+func (i *ImmutableSet) Has(key string) bool {
+	_, ok := i.data[key]
+	return ok
+}

--- a/transport/http_server.go
+++ b/transport/http_server.go
@@ -32,6 +32,8 @@ var proxyRoutes = domain.NewImmutableSet(map[string]struct{}{
 	featureConfigsIdentifierRoute: {},
 	segmentsRoute:                 {},
 	segmentsIdentifierRoute:       {},
+	evaluationsRoute:              {},
+	evaluationsFlagRoute:          {},
 	streamRoute:                   {},
 	metricsRoute:                  {},
 })
@@ -53,7 +55,7 @@ type HTTPServer struct {
 
 // NewHTTPServer registers the passed endpoints against routes and returns an
 // HTTPServer that's ready to use
-func NewHTTPServer(port int, e *Endpoints, l log.Logger, tlsEnabled bool, tlsCert string, tlsKey string, reg prometheusRegister) *HTTPServer {
+func NewHTTPServer(port int, e *Endpoints, l log.Logger, tlsEnabled bool, tlsCert string, tlsKey string) *HTTPServer {
 	l = l.With("component", "HTTPServer")
 
 	router := echo.New()
@@ -74,7 +76,7 @@ func NewHTTPServer(port int, e *Endpoints, l log.Logger, tlsEnabled bool, tlsCer
 		tlsCert:    tlsCert,
 		tlsKey:     tlsKey,
 	}
-	h.registerEndpoints(e, reg)
+	h.registerEndpoints(e)
 	return h
 }
 
@@ -106,7 +108,7 @@ func (h *HTTPServer) Use(mw ...echo.MiddlewareFunc) {
 	}
 }
 
-func (h *HTTPServer) registerEndpoints(e *Endpoints, reg prometheusRegister) {
+func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 	h.router.POST(authRoute, NewUnaryHandler(
 		e.PostAuthenticate,
 		decodeAuthRequest,

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/harness-community/sse/v3"
 	sdkstream "github.com/harness/ff-golang-server-sdk/stream"
+	"github.com/labstack/echo/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
@@ -1361,6 +1362,135 @@ func TestHTTPServer_Stream(t *testing.T) {
 				}
 			}
 
+		})
+	}
+}
+
+func TestHTTPServer_WithCustomHandler(t *testing.T) {
+	type args struct {
+		method  string
+		route   string
+		handler http.Handler
+	}
+
+	type mocks struct {
+	}
+
+	type expected struct {
+	}
+
+	testCases := map[string]struct {
+		args      args
+		mocks     mocks
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I try to register a custom handler on /client/auth": {
+			args: args{
+				method:  http.MethodGet,
+				route:   authRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /health": {
+			args: args{
+				method:  http.MethodGet,
+				route:   healthRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /feature-configs": {
+			args: args{
+				method:  http.MethodGet,
+				route:   featureConfigsRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /feature-configs/:identifier": {
+			args: args{
+				method:  http.MethodGet,
+				route:   featureConfigsIdentifierRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /target-segments": {
+			args: args{
+				method:  http.MethodGet,
+				route:   segmentsRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /target-segments/:identifier": {
+			args: args{
+				method:  http.MethodGet,
+				route:   segmentsRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /evaluations": {
+			args: args{
+				method:  http.MethodGet,
+				route:   evaluationsRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /evaluations/:feature": {
+			args: args{
+				method:  http.MethodGet,
+				route:   evaluationsFlagRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /metrics/:environmentUUID": {
+			args: args{
+				method:  http.MethodGet,
+				route:   metricsRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /stream": {
+			args: args{
+				method:  http.MethodGet,
+				route:   streamRoute,
+				handler: nil,
+			},
+			shouldErr: true,
+		},
+		"Given I try to register a custom handler on /metrics": {
+			args: args{
+				method:  http.MethodGet,
+				route:   "/metrics",
+				handler: nil,
+			},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			server := &HTTPServer{
+				router: echo.New(),
+			}
+
+			err := server.WithCustomHandler(tc.args.method, tc.args.route, tc.args.handler)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
 		})
 	}
 }

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -280,7 +280,7 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 		},
 	}
 
-	server := NewHTTPServer(8000, endpoints, logger, false, "", "", prometheus.NewRegistry())
+	server := NewHTTPServer(8000, endpoints, logger, false, "", "")
 	server.Use(
 		middleware.NewEchoRequestIDMiddleware(),
 		middleware.NewEchoLoggingMiddleware(logger),
@@ -1451,7 +1451,7 @@ func TestHTTPServer_WithCustomHandler(t *testing.T) {
 		},
 		"Given I try to register a custom handler on /metrics/:environmentUUID": {
 			args: args{
-				method:  http.MethodGet,
+				method:  http.MethodPost,
 				route:   metricsRoute,
 				handler: nil,
 			},

--- a/transport/prometheus_server.go
+++ b/transport/prometheus_server.go
@@ -1,0 +1,48 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// PrometheusServer is a HTTPServer that's used for exposing Prometheus metrics
+type PrometheusServer struct {
+	log    log.Logger
+	server *http.Server
+}
+
+// NewPrometheusServer creates a PrometheusServer
+func NewPrometheusServer(port int, promReg prometheusRegister, logger log.Logger) *PrometheusServer {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(promReg, promhttp.HandlerOpts{Registry: promReg}))
+
+	return &PrometheusServer{
+		log: logger,
+		server: &http.Server{
+			Addr:              fmt.Sprintf(":%d", port),
+			Handler:           mux,
+			ReadTimeout:       30 * time.Second,
+			ReadHeaderTimeout: 30 * time.Second,
+			WriteTimeout:      30 * time.Second,
+			IdleTimeout:       1 * time.Minute,
+		},
+	}
+}
+
+// Serve listens on the PrometheusServers addr and handles requests
+func (p *PrometheusServer) Serve() error {
+	p.log.Info("starting prometheus server", "addr", p.server.Addr)
+
+	return p.server.ListenAndServe()
+}
+
+// Shutdown gracefully shuts down the server
+func (p *PrometheusServer) Shutdown(ctx context.Context) error {
+	p.log.Info("shutting down prometheus server", "addr", p.server.Addr)
+	return p.server.Shutdown(ctx)
+}


### PR DESCRIPTION
**What**

- Adds the option to expose prometheus metrics on a different port
- By default we still use the main proxy server so there's no breaking change here for existing users
- The prometheus endpoint was hardcoded into the HTTPServer, I've added a method that lets us add the http handler for it separately so we can do this in the main depending on if the `PROMETHEUS_PORT` env var is set

**Why**

- You might not always want your prometheus metrics exposed on the same port as the main Proxy server

**Testing**

- Tested locally
- Added a unit test for the WithCustomHandler func to make sure you can't accidentally override one of the main proxy routes