### PR TITLE
FFM-11310 Harden StreamStatus

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -331,7 +331,7 @@ func main() {
 				"control_uri": "http://localhost:5561",
 			},
 		})
-		saasStreamHealth = stream.NewHealth("ffproxy_saas_stream_health", cache.NewKeyValCache(redisClient), logger)
+		streamHealth     = stream.NewHealth(logger, "ffproxy_saas_stream_health", cache.NewKeyValCache(redisClient), readReplica)
 		connectedStreams = domain.NewSafeMap()
 
 		getConnectedStreams = func() map[string]interface{} {
@@ -347,9 +347,13 @@ func main() {
 	// If we're running as replicas we kick off a routine to make sure the in memory status matches the
 	// cached status
 	if !readReplica {
-		go saasStreamHealth.VerifyStreamStatus(ctx, 60*time.Second)
+		if h, ok := streamHealth.(stream.PrimaryHealth); ok {
+			go h.VerifyStreamStatus(ctx, 60*time.Second)
+		}
 	} else {
-		go saasStreamHealth.UpdateInMemStreamStatus(ctx, 60*time.Second)
+		if h, ok := streamHealth.(stream.ReplicaHealth); ok {
+			go h.GetStreamStatus(ctx)
+		}
 	}
 
 	// Get the underlying type from the pushpinStream which is currently the
@@ -387,7 +391,7 @@ func main() {
 		logger,
 		"proxy:primary_to_replica_control_events",
 		redisStream,
-		domain.NewReadReplicaMessageHandler(),
+		domain.NewReadReplicaMessageHandler(logger, streamHealth),
 		stream.WithOnDisconnect(stream.ReadReplicaSSEStreamOnDisconnect(logger, pushpin, getConnectedStreams)),
 		stream.WithBackoff(backoff.NewConstantBackOff(1*time.Minute)),
 	)
@@ -457,11 +461,11 @@ func main() {
 			"*",
 			stream.NewPrometheusStream("ff_proxy_saas_to_primary_sse_consumer", sseClient, promReg),
 			messageHandler,
-			stream.WithOnConnect(stream.SaasStreamOnConnect(logger, saasStreamHealth, reloadConfig)),
+			stream.WithOnConnect(stream.SaasStreamOnConnect(logger, streamHealth, reloadConfig, primaryToReplicaControlStream)),
 			stream.WithOnDisconnect(
 				stream.SaasStreamOnDisconnect(
 					logger,
-					saasStreamHealth,
+					streamHealth,
 					pushpin,
 					primaryToReplicaControlStream, // When we disconnect we send a message on this stream to the replica to let it know the saas stream has disconnected
 					getConnectedStreams,
@@ -493,7 +497,7 @@ func main() {
 
 	apiKeyHasher := hash.NewSha256()
 	tokenSource := token.NewSource(logger, authRepo, apiKeyHasher, []byte(authSecret))
-	proxyHealth := health.NewProxyHealth(logger, configStatus, saasStreamHealth.StreamStatus, cacheHealthCheck)
+	proxyHealth := health.NewProxyHealth(logger, configStatus, streamHealth.Status, cacheHealthCheck)
 	proxyHealth.PollCacheHealth(ctx, 1*time.Minute)
 
 	// Setup service and middleware
@@ -510,7 +514,7 @@ func main() {
 		Hasher:        apiKeyHasher,
 		Health:        proxyHealth.Health,
 		HealthySaasStream: func() bool {
-			streamStatus, err := saasStreamHealth.StreamStatus(ctx)
+			streamStatus, err := streamHealth.Status(ctx)
 			if err != nil {
 				logger.Error("failed to check status of saas -> proxy stream health", "err", err)
 				return false

--- a/domain/message_handlers.go
+++ b/domain/message_handlers.go
@@ -3,6 +3,8 @@ package domain
 import (
 	"context"
 	"io"
+
+	"github.com/harness/ff-proxy/v2/log"
 )
 
 // MessageHandler defines the interface for handling an SSE message
@@ -19,6 +21,11 @@ func (n NoOpMessageHandler) HandleMessage(_ context.Context, _ SSEMessage) error
 	return nil
 }
 
+type healther interface {
+	SetUnhealthy(ctx context.Context) error
+	SetHealthy(ctx context.Context) error
+}
+
 // ReadReplicaMessageHandler defines the message handler used by the read replica.
 // The ReadReplica doesn't need to care about 99% of the messages it receives, and
 // the only thing it really needs to do is forward these messages on to any connected
@@ -28,28 +35,52 @@ func (n NoOpMessageHandler) HandleMessage(_ context.Context, _ SSEMessage) error
 // The Replica can then use these events to forcibly disconnect SDKs and block new stream
 // requests until the Writer Proxy -> SaaS stream has been reestablished
 type ReadReplicaMessageHandler struct {
+	log          log.Logger
+	streamStatus healther
 }
 
 // NewReadReplicaMessageHandler creates a ReadReplicaMessageHandler
-func NewReadReplicaMessageHandler() ReadReplicaMessageHandler {
-	return ReadReplicaMessageHandler{}
+func NewReadReplicaMessageHandler(l log.Logger, s healther) ReadReplicaMessageHandler {
+	l = l.With("component", "ReadReplicaMessageHandler")
+	return ReadReplicaMessageHandler{
+		log:          l,
+		streamStatus: s,
+	}
 }
 
 // HandleMessage makes ReadReplicaMessageHandler implement the MessageHandler interface.
 // It checks the message's event type & domain and calls the appropriate method to deal with these.
-func (r ReadReplicaMessageHandler) HandleMessage(_ context.Context, msg SSEMessage) error {
-	// Any other event types we don't care about, we just want our chain of message handlers
-	// to forward this on to pushpin so SDKs get these events.
-	if msg.Event != "stream_action" {
-		// Return EOF to indicate the stream was closed
-		if msg.Domain == "disconnect" {
-			return io.EOF
-		}
-		return nil
+func (r ReadReplicaMessageHandler) HandleMessage(ctx context.Context, msg SSEMessage) error {
+	if msg.Event == "stream_action" {
+		return r.handleStreamAction(ctx, msg)
 	}
 
 	if msg.Event == "environmentsRemoved" || msg.Event == "apiKeyRemoved" {
 		return io.EOF
+	}
+	return nil
+
+}
+
+// handleStreamAction sets the internal StreamHealth in the read replica based on the type of message we get
+func (r ReadReplicaMessageHandler) handleStreamAction(ctx context.Context, msg SSEMessage) error {
+	if msg.Domain == "disconnect" {
+		r.log.Info("received stream disconnect event from primary proxy")
+
+		if err := r.streamStatus.SetUnhealthy(ctx); err != nil {
+			r.log.Error("failed to set unhealthy stream status", "err", err)
+		}
+
+		// Return EOF to indicate the stream was closed
+		return io.EOF
+	}
+
+	if msg.Domain == "connect" {
+		r.log.Info("received stream connect event from primary proxy")
+
+		if err := r.streamStatus.SetHealthy(ctx); err != nil {
+			r.log.Error("failed to set healthy stream status", "err", err)
+		}
 	}
 
 	return nil

--- a/domain/message_handlers_test.go
+++ b/domain/message_handlers_test.go
@@ -1,0 +1,120 @@
+package domain
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHealth struct {
+	*sync.Mutex
+	healthy bool
+}
+
+func (m *mockHealth) SetUnhealthy(ctx context.Context) error {
+	m.Lock()
+	defer m.Unlock()
+	m.healthy = false
+
+	return nil
+}
+
+func (m *mockHealth) SetHealthy(ctx context.Context) error {
+	m.Lock()
+	defer m.Unlock()
+	m.healthy = true
+
+	return nil
+}
+
+func (m *mockHealth) getHealth() bool {
+	m.Lock()
+	defer m.Unlock()
+	return m.healthy
+}
+
+func TestReadReplicaMessageHandler_HandleMessage(t *testing.T) {
+
+	type args struct {
+		msg SSEMessage
+	}
+
+	type mocks struct {
+		health *mockHealth
+	}
+
+	type expected struct {
+		health bool
+		err    error
+	}
+
+	testCases := map[string]struct {
+		args      args
+		mocks     mocks
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I have a healthy status and get a stream disconnect event": {
+			args: args{
+				msg: SSEMessage{
+					Event:  "stream_action",
+					Domain: "disconnect",
+				},
+			},
+			mocks: mocks{
+				health: &mockHealth{
+					Mutex:   &sync.Mutex{},
+					healthy: true,
+				},
+			},
+			expected: expected{
+				health: false,
+				err:    io.EOF,
+			},
+			shouldErr: true,
+		},
+		"Given I have a unhealthy status and get a stream connect event": {
+			args: args{
+				msg: SSEMessage{
+					Event:  "stream_action",
+					Domain: "connect",
+				},
+			},
+			mocks: mocks{
+				health: &mockHealth{
+					Mutex:   &sync.Mutex{},
+					healthy: false,
+				},
+			},
+			expected: expected{
+				health: true,
+				err:    nil,
+			},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+			ctx := context.Background()
+
+			r := NewReadReplicaMessageHandler(log.NoOpLogger{}, tc.mocks.health)
+
+			err := r.HandleMessage(ctx, tc.args.msg)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tc.expected.health, tc.mocks.health.getHealth())
+		})
+	}
+}

--- a/stream/health.go
+++ b/stream/health.go
@@ -10,8 +10,24 @@ import (
 	"github.com/harness/ff-proxy/v2/log"
 )
 
-// Health maintains the health/status of a stream in a cache
-type Health struct {
+// Health defines the health interface for a Stream
+type Health interface {
+	SetHealthy(ctx context.Context) error
+	SetUnhealthy(ctx context.Context) error
+	Status(ctx context.Context) (domain.StreamStatus, error)
+}
+
+// NewHealth is a constructor that creates a Health implementation depending on if the Proxy is a Primary or Replica
+func NewHealth(l log.Logger, key string, c cache.Cache, readReplica bool) Health {
+	if readReplica {
+		return NewReplicaHealth(key, c, l)
+	}
+
+	return NewPrimaryHealth(key, c, l)
+}
+
+// PrimaryHealth maintains the health/status of a stream in a cache
+type PrimaryHealth struct {
 	log log.Logger
 	c   cache.Cache
 	key string
@@ -22,16 +38,16 @@ type Health struct {
 	inMemStatus *domain.SafeStreamStatus
 }
 
-// NewHealth creates a Health
-func NewHealth(k string, c cache.Cache, l log.Logger) Health {
-	l = l.With("component", "StreamHealth")
+// NewPrimaryHealth creates a PrimaryHealth
+func NewPrimaryHealth(k string, c cache.Cache, l log.Logger) PrimaryHealth {
+	l = l.With("component", "PrimaryStreamHealth")
 
 	defaultStreamStatus := domain.StreamStatus{
 		State: domain.StreamStateInitializing,
 		Since: time.Now().UnixMilli(),
 	}
 
-	h := Health{
+	h := PrimaryHealth{
 		log:         l,
 		key:         k,
 		c:           c,
@@ -52,7 +68,7 @@ func NewHealth(k string, c cache.Cache, l log.Logger) Health {
 
 // SetHealthy sets the stream status as CONNECTED in the cache.
 // If the stream status is already CONNECTED it does nothing.
-func (h Health) SetHealthy(ctx context.Context) error {
+func (h PrimaryHealth) SetHealthy(ctx context.Context) error {
 	streamStatus := domain.StreamStatus{
 		State: domain.StreamStateConnected,
 		Since: time.Now().UnixMilli(),
@@ -83,7 +99,7 @@ func (h Health) SetHealthy(ctx context.Context) error {
 
 // SetUnhealthy sets the stream status as DISCONNECTED in the cache.
 // If the stream status is already DISCONNECTED it does nothing.
-func (h Health) SetUnhealthy(ctx context.Context) error {
+func (h PrimaryHealth) SetUnhealthy(ctx context.Context) error {
 	streamStatus := domain.StreamStatus{
 		State: domain.StreamStateDisconnected,
 		Since: time.Now().UnixMilli(),
@@ -116,7 +132,7 @@ func (h Health) SetUnhealthy(ctx context.Context) error {
 //
 // This thread should resolve that issue because the stream status stored in memory isn't affected by network issues so
 // should always be up to date.
-func (h Health) VerifyStreamStatus(ctx context.Context, interval time.Duration) {
+func (h PrimaryHealth) VerifyStreamStatus(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -149,29 +165,117 @@ func (h Health) VerifyStreamStatus(ctx context.Context, interval time.Duration) 
 	}
 }
 
-// UpdateInMemStreamStatus polls for the cached status and makes sure the in memory status matches
-// This is only needed by replicas to avoid their in memory status always being stuck as 'INITIALIZING'
-func (h Health) UpdateInMemStreamStatus(ctx context.Context, interval time.Duration) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			h.log.Info("context canceled, stopping thread that checks the cached stream status matches the in memory status")
-			return
-		case <-ticker.C:
-			var cachedStatus domain.StreamStatus
-			if err := h.c.Get(ctx, h.key, &cachedStatus); err != nil {
-				h.log.Error("failed to get stream status from cache", "err", err)
-			}
-
-			h.inMemStatus.Set(cachedStatus)
-		}
-	}
+// Status returns the StreamStatus from the cache
+func (h PrimaryHealth) Status(_ context.Context) (domain.StreamStatus, error) {
+	return h.inMemStatus.Get(), nil
 }
 
-// StreamStatus returns the StreamStatus from the cache
-func (h Health) StreamStatus(_ context.Context) (domain.StreamStatus, error) {
-	return h.inMemStatus.Get(), nil
+type getter interface {
+	Get(ctx context.Context, key string, v interface{}) error
+}
+
+// ReplicaHealth is a Health implementation that's used when the Proxy is running as a read replica
+type ReplicaHealth struct {
+	log log.Logger
+	c   getter
+	key string
+
+	// Also keep a copy of the status in memory. This way we can
+	// recover if we failed to update the remote status in the cache
+	// due to a network error and avoid getting in a stuck state.
+	inMemStatus *domain.SafeStreamStatus
+}
+
+// NewReplicaHealth creates a ReplicaHealth
+func NewReplicaHealth(k string, c cache.Cache, l log.Logger) ReplicaHealth {
+	l = l.With("component", "ReplicaStreamHealth")
+
+	defaultStreamStatus := domain.StreamStatus{
+		State: domain.StreamStateInitializing,
+		Since: time.Now().UnixMilli(),
+	}
+
+	h := ReplicaHealth{
+		log:         l,
+		key:         k,
+		c:           c,
+		inMemStatus: domain.NewSafeStreamStatus(defaultStreamStatus),
+	}
+
+	return h
+}
+
+// SetHealthy sets the in memory stream status in the read replica to CONNECTED
+func (r ReplicaHealth) SetHealthy(_ context.Context) error {
+	currentStatus := r.inMemStatus.Get()
+
+	// If we're already connected we don't need to modify the status
+	if currentStatus.State == domain.StreamStateConnected {
+		return nil
+	}
+
+	r.inMemStatus.Set(domain.StreamStatus{
+		State: domain.StreamStateConnected,
+		Since: time.Now().UnixMilli(),
+	})
+
+	return nil
+}
+
+// SetUnhealthy sets the in memory stream status in the read replica to DISCONNECTED
+func (r ReplicaHealth) SetUnhealthy(_ context.Context) error {
+	currentStatus := r.inMemStatus.Get()
+
+	// If we're already disconnected we don't need to modify the status
+	if currentStatus.State == domain.StreamStateDisconnected {
+		return nil
+	}
+
+	r.inMemStatus.Set(domain.StreamStatus{
+		State: domain.StreamStateDisconnected,
+		Since: time.Now().UnixMilli(),
+	})
+
+	return nil
+}
+
+// Status returns the read replicas in memory stream status
+func (r ReplicaHealth) Status(_ context.Context) (domain.StreamStatus, error) {
+	return r.inMemStatus.Get(), nil
+}
+
+// GetStreamStatus gets the StreamStatus from the cache. This is needed at startup for replicas to load
+// the correct stream status into memory but after startup the replicas in memory stream status will be
+// kept up to date by the CONNECT & DISCONNECT messages sent from the primary
+func (r ReplicaHealth) GetStreamStatus(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	status := domain.StreamStatus{}
+
+	done := false
+	for !done {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.log.Info("getting cached stream status as a part of the startup flow")
+
+			if err := r.c.Get(ctx, r.key, &status); err != nil {
+				r.log.Error("failed to get stream status from cache", "err", err)
+				continue
+			}
+
+			// Once we've sucessfully fetched the status once from the cache at startup we're done
+			// and can rely on receiving events from the Primary to find out the stream status
+			if status.State == domain.StreamStateConnected || status.State == domain.StreamStateDisconnected {
+				done = true
+			}
+
+			r.inMemStatus.Set(status)
+		}
+	}
+
+	r.inMemStatus.Set(status)
+	r.log.Info("successfully retrieved cached stream status and set it in memory")
 }

--- a/stream/health_test.go
+++ b/stream/health_test.go
@@ -646,3 +646,77 @@ func TestHealth_SetUnhealthy(t *testing.T) {
 		})
 	}
 }
+
+func TestReplicaHealth_SetHealthy(t *testing.T) {
+
+	type expected struct {
+		state domain.StreamState
+	}
+
+	testCases := map[string]struct {
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I have a status of INITIALIZING and call SetHealthy": {
+			expected:  expected{state: domain.StreamStateConnected},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			r := NewReplicaHealth("", nil, log.NoOpLogger{})
+
+			err := r.SetHealthy(context.Background())
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			actual := r.inMemStatus.Get().State
+			assert.Equal(t, tc.expected.state, actual)
+		})
+	}
+}
+
+func TestReplicaHealth_SetUnhealthy(t *testing.T) {
+
+	type expected struct {
+		state domain.StreamState
+	}
+
+	testCases := map[string]struct {
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I have a status of INITIALIZING and call SetUnhealthy": {
+			expected:  expected{state: domain.StreamStateDisconnected},
+			shouldErr: false,
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			r := NewReplicaHealth("", nil, log.NoOpLogger{})
+
+			err := r.SetUnhealthy(context.Background())
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			actual := r.inMemStatus.Get().State
+			assert.Equal(t, tc.expected.state, actual)
+		})
+	}
+}

--- a/stream/health_test.go
+++ b/stream/health_test.go
@@ -84,7 +84,7 @@ func TestHealth_VerifyStreamStatus(t *testing.T) {
 
 		t.Run(desc, func(t *testing.T) {
 
-			h := Health{
+			h := PrimaryHealth{
 				log:         log.NoOpLogger{},
 				c:           tc.mocks.cache,
 				key:         "foo",
@@ -353,7 +353,7 @@ func TestHealth_SetHealthy(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 
 			tc.mocks.cache.cachedState = tc.args.startingCachedStatus
-			h := Health{
+			h := PrimaryHealth{
 				log:         log.NoOpLogger{},
 				c:           tc.mocks.cache,
 				key:         "foo",
@@ -623,7 +623,7 @@ func TestHealth_SetUnhealthy(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 
 			tc.mocks.cache.cachedState = tc.args.startingCachedStatus
-			h := Health{
+			h := PrimaryHealth{
 				log: log.NoOpLogger{},
 				c:   tc.mocks.cache,
 				key: "foo",

--- a/stream/on_connect_disconnect_handlers_test.go
+++ b/stream/on_connect_disconnect_handlers_test.go
@@ -1,0 +1,188 @@
+package stream
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockHealth struct {
+	*sync.Mutex
+	healthy bool
+}
+
+func (m *mockHealth) SetUnhealthy(ctx context.Context) error {
+	m.Lock()
+	defer m.Unlock()
+	m.healthy = false
+
+	return nil
+}
+
+func (m *mockHealth) SetHealthy(ctx context.Context) error {
+	m.Lock()
+	defer m.Unlock()
+	m.healthy = true
+
+	return nil
+}
+
+func (m *mockHealth) Status(ctx context.Context) (domain.StreamStatus, error) {
+	return domain.StreamStatus{}, nil
+}
+
+func (m *mockHealth) getHealth() bool {
+	m.Lock()
+	defer m.Unlock()
+	return m.healthy
+}
+
+type mockStream struct {
+	events []interface{}
+}
+
+func (m *mockStream) Pub(ctx context.Context, channel string, msg interface{}) error {
+	m.events = append(m.events, msg)
+	return nil
+}
+
+func (m *mockStream) Sub(ctx context.Context, channel string, id string, msg domain.HandleMessageFn) error {
+	m.events = append(m.events, msg)
+	return nil
+}
+
+func (m *mockStream) Close(channel string) error {
+	return nil
+}
+
+func TestSaasStreamOnDisconnect(t *testing.T) {
+	type mocks struct {
+		health  *mockHealth
+		pushpin Pushpin
+		stream  *mockStream
+
+		connectedStreamsFunc func() map[string]interface{}
+		pollFn               func() error
+	}
+
+	type expected struct {
+		events       []interface{}
+		streamHealth bool
+	}
+
+	testCases := map[string]struct {
+		mocks    mocks
+		expected expected
+	}{
+		"Given I have a healthy streams status and disconnect from the Saas stream": {
+			mocks: mocks{
+				health: &mockHealth{
+					Mutex:   &sync.Mutex{},
+					healthy: true,
+				},
+				pushpin: Pushpin{stream: &mockGripStream{}},
+				stream:  &mockStream{events: []interface{}{}},
+				pollFn: func() error {
+					return nil
+				},
+				connectedStreamsFunc: func() map[string]interface{} {
+					return map[string]interface{}{"foo": struct{}{}}
+				},
+			},
+			expected: expected{
+				events: []interface{}{
+					domain.SSEMessage{Event: "stream_action", Domain: "disconnect", Identifier: "", Version: 0, Environment: "", Environments: []string(nil), APIKey: ""},
+				},
+				streamHealth: false,
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			redisStream := NewStream(
+				log.NoOpLogger{},
+				"foo",
+				tc.mocks.stream,
+				domain.NoOpMessageHandler{},
+			)
+
+			SaasStreamOnDisconnect(log.NoOpLogger{}, tc.mocks.health, tc.mocks.pushpin, redisStream, tc.mocks.connectedStreamsFunc, tc.mocks.pollFn)()
+
+			t.Log("Then the stream status will become unhealthy")
+			assert.Equal(t, tc.expected.streamHealth, tc.mocks.health.getHealth())
+
+			t.Log("And a disconnect event will be sent down the redis stream")
+			assert.Equal(t, tc.expected.events, tc.mocks.stream.events)
+		})
+	}
+}
+
+func TestSaasStreamOnConnect(t *testing.T) {
+	type mocks struct {
+		health *mockHealth
+		stream *mockStream
+
+		reloadConfig func() error
+	}
+
+	type expected struct {
+		events       []interface{}
+		streamHealth bool
+	}
+
+	testCases := map[string]struct {
+		mocks    mocks
+		expected expected
+	}{
+		"Given I have a unhealthy streams status and disconnect from the Saas stream": {
+			mocks: mocks{
+				health: &mockHealth{
+					Mutex:   &sync.Mutex{},
+					healthy: false,
+				},
+				stream: &mockStream{events: []interface{}{}},
+				reloadConfig: func() error {
+					return nil
+				},
+			},
+			expected: expected{
+				events: []interface{}{
+					domain.SSEMessage{Event: "stream_action", Domain: "connect", Identifier: "", Version: 0, Environment: "", Environments: []string(nil), APIKey: ""},
+				},
+				streamHealth: true,
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			redisStream := NewStream(
+				log.NoOpLogger{},
+				"foo",
+				tc.mocks.stream,
+				domain.NoOpMessageHandler{},
+			)
+
+			SaasStreamOnConnect(log.NoOpLogger{}, tc.mocks.health, tc.mocks.reloadConfig, redisStream)()
+
+			t.Log("Then the stream status will become healthy")
+			assert.Equal(t, tc.expected.streamHealth, tc.mocks.health.getHealth())
+
+			t.Log("And a connect event will be sent down the redis stream")
+			assert.Equal(t, tc.expected.events, tc.mocks.stream.events)
+		})
+	}
+}

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -24,7 +24,7 @@ type SSEClient struct {
 }
 
 // NewSSEClient creates an SSEClient
-func NewSSEClient(l log.Logger, url string, key string, token string, accountID string) *SSEClient {
+func NewSSEClient(l log.Logger, url string, key string, token string, accountID string, onConn func(), onDisconn func()) *SSEClient {
 	c := sse.NewClient(url)
 	c.Headers = map[string]string{
 		"Authorization":     fmt.Sprintf("Bearer %s", token),
@@ -32,6 +32,14 @@ func NewSSEClient(l log.Logger, url string, key string, token string, accountID 
 		"Harness-Accountid": accountID,
 		"Harness-Sdk-Info":  fmt.Sprintf("Proxy %s", build.Version),
 	}
+
+	c.OnConnect(func(c *sse.Client) {
+		onConn()
+	})
+
+	c.OnDisconnect(func(c *sse.Client) {
+		onDisconn()
+	})
 
 	// don't use the default exponentialBackoff strategy - we'll have our own disconnect logic
 	// that we'll implement


### PR DESCRIPTION
**What**

- Changes how the replica is notified of stream disconnects and keeps its in memory stream status in sync. With the old code the replica polled redis to get the stream status which could result in a lag. Now the replica hits redis at startup to get the stream status, but from that point on relies on the disconnect and connect messages that the Primary sends it.

- Creates seperate Health types for the Primary and Replica. Previously we'd the one type used for both and there was something dodgy going on when it ran in a read replica proxy. The seperate types should make debugging a lot easier.

**Why**

- We've seen some hard to reproduce buggy behaviour where the read replica status can get stuck on DISCONNECTED

**Testing**

- Added additional unit tests
- Running a Primary & Replica locally with a curl script checking their health endpoints and they've been staying in sync