### PR TITLE
FFM-11471 Add AllowQuerySemicolons middleware

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -532,6 +532,7 @@ func main() {
 		middleware.NewEchoLoggingMiddleware(logger),
 		middleware.NewEchoAuthMiddleware(logger, authRepo, []byte(authSecret), bypassAuth),
 		middleware.NewPrometheusMiddleware(promReg),
+		middleware.AllowQuerySemicolons(),
 	)
 
 	// We want to be able to expose prometheus metrics on a different server than the

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -114,6 +114,12 @@ func NewEchoRequestIDMiddleware() echo.MiddlewareFunc {
 	}
 }
 
+func AllowQuerySemicolons() echo.MiddlewareFunc {
+	return echo.WrapMiddleware(func(next http.Handler) http.Handler {
+		return http.AllowQuerySemicolons(next)
+	})
+}
+
 type prometheusMiddleware struct {
 	requestCount    *prometheus.CounterVec
 	requestDuration *prometheus.HistogramVec

--- a/tests/e2e/testhelpers/project.go
+++ b/tests/e2e/testhelpers/project.go
@@ -299,7 +299,6 @@ func CreateProjectRemote(org string, identifier string) (*http.Response, error) 
 	err = retry.Do(
 		func() error {
 
-			log.Info("attempting to fetch %d", identifier)
 			projectResponse, err := ReadProject(org, v1.Identifier(identifier))
 			if err != nil || projectResponse.StatusCode() != http.StatusOK {
 				return errors.New("project not found")

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -286,6 +286,7 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 		middleware.NewEchoLoggingMiddleware(logger),
 		middleware.NewEchoAuthMiddleware(logger, repo, []byte(`secret`), bypassAuth),
 		middleware.NewPrometheusMiddleware(prometheus.NewRegistry()),
+		middleware.AllowQuerySemicolons(),
 	)
 	return server
 }


### PR DESCRIPTION
**What**

- Uses the [AllowQuerySemicolons](https://pkg.go.dev/net/http#AllowQuerySemicolons) middleware which replaces ';' separators in URLs with '&'

**Why**

- If a client used a ';' seperator in a url query the Go HTTP server would log out this error message which we have no control over  `http: URL query contains semicolon, which is no longer a supported separator; parts of the query may be stripped when parsed; see golang.org/issue/25192`


**Testing**

- Manually tested (see screenshots for before and after)
- Added new middleware to the HTTP tests so it's covered by them 

Before
![Screenshot 2024-05-13 at 11 43 04](https://github.com/harness/ff-proxy/assets/16992818/ae7f03d6-97fe-40bc-90f7-1a60d3042865)



After
![Screenshot 2024-05-13 at 11 40 00](https://github.com/harness/ff-proxy/assets/16992818/a56e1819-2d09-4f67-b2d0-e8650f8e81f2)


