### PR TITLE
FFM-11504 Explicitly list allowed headers for cors

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -528,6 +528,7 @@ func main() {
 	endpoints := transport.NewEndpoints(service)
 	server := transport.NewHTTPServer(port, endpoints, logger, tlsEnabled, tlsCert, tlsKey)
 	server.Use(
+		middleware.NewCorsMiddleware(),
 		middleware.NewEchoRequestIDMiddleware(),
 		middleware.NewEchoLoggingMiddleware(logger),
 		middleware.NewEchoAuthMiddleware(logger, authRepo, []byte(authSecret), bypassAuth),

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -208,3 +208,12 @@ func NewPrometheusMiddleware(reg prometheus.Registerer) echo.MiddlewareFunc {
 		}
 	}
 }
+
+// NewCorsMiddleware returns a cors middleware
+func NewCorsMiddleware() echo.MiddlewareFunc {
+	return middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"*"},
+		AllowMethods: []string{http.MethodGet, http.MethodOptions, http.MethodPost},
+		AllowHeaders: []string{"*", "Authorization"},
+	})
+}

--- a/transport/http_server.go
+++ b/transport/http_server.go
@@ -61,7 +61,7 @@ func NewHTTPServer(port int, e *Endpoints, l log.Logger, tlsEnabled bool, tlsCer
 	router := echo.New()
 	server := &http.Server{
 		Addr:              fmt.Sprintf(":%d", port),
-		Handler:           cors(router),
+		Handler:           router,
 		ReadTimeout:       30 * time.Second,
 		ReadHeaderTimeout: 30 * time.Second,
 		WriteTimeout:      30 * time.Second,
@@ -198,18 +198,4 @@ func (h *HTTPServer) WithCustomHandler(method string, route string, handler http
 		return nil
 	}
 	return fmt.Errorf("http method %s not supported, update WithCustomHandler to add support", method)
-}
-
-func cors(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Access-Control-Allow-Origin", "*")
-		w.Header().Add("Access-Control-Allow-Methods", "GET,OPTIONS,POST")
-		w.Header().Add("Access-Control-Allow-Headers", "*")
-
-		if r.Method == http.MethodOptions {
-			return
-		}
-
-		next.ServeHTTP(w, r)
-	})
 }

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -282,6 +282,7 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 
 	server := NewHTTPServer(8000, endpoints, logger, false, "", "")
 	server.Use(
+		middleware.NewCorsMiddleware(),
 		middleware.NewEchoRequestIDMiddleware(),
 		middleware.NewEchoLoggingMiddleware(logger),
 		middleware.NewEchoAuthMiddleware(logger, repo, []byte(`secret`), bypassAuth),


### PR DESCRIPTION
**What**

- Add 'Authorization' header to cors allow list
- Replaced our old 'hacky' cors middleware with a more official middleware func

**Why**

- Firefox now requires the 'Authorization' header to be explicitly allowed and doesn't allow it under the `*` wildcard anymore

**Testing**

- Tested with a local JS app in firefox with `network.cors_preflight.authorization_covered_by_wildcard` set to `false`