### PR TITLE
FFM-11471 update AllowQuerySemicolons middleware

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -528,12 +528,12 @@ func main() {
 	endpoints := transport.NewEndpoints(service)
 	server := transport.NewHTTPServer(port, endpoints, logger, tlsEnabled, tlsCert, tlsKey)
 	server.Use(
+		middleware.AllowQuerySemicolons(),
 		middleware.NewCorsMiddleware(),
 		middleware.NewEchoRequestIDMiddleware(),
 		middleware.NewEchoLoggingMiddleware(logger),
 		middleware.NewEchoAuthMiddleware(logger, authRepo, []byte(authSecret), bypassAuth),
 		middleware.NewPrometheusMiddleware(promReg),
-		middleware.AllowQuerySemicolons(),
 	)
 
 	// We want to be able to expose prometheus metrics on a different server than the

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -283,11 +283,11 @@ func setupHTTPServer(t *testing.T, bypassAuth bool, opts ...setupOpts) *HTTPServ
 	server := NewHTTPServer(8000, endpoints, logger, false, "", "")
 	server.Use(
 		middleware.NewCorsMiddleware(),
+		middleware.AllowQuerySemicolons(),
 		middleware.NewEchoRequestIDMiddleware(),
 		middleware.NewEchoLoggingMiddleware(logger),
 		middleware.NewEchoAuthMiddleware(logger, repo, []byte(`secret`), bypassAuth),
 		middleware.NewPrometheusMiddleware(prometheus.NewRegistry()),
-		middleware.AllowQuerySemicolons(),
 	)
 	return server
 }


### PR DESCRIPTION
**What**

- Manually implements the AllowQuerySemicolons middleware from the Go HTTP package

**Why**

- Wrapping it the way we were meant we weren't invoking the next middleware properly which was leading to the status code in the prometheus middleware being set to `0` for 200 responses. Client's were still seeing a 200 response but for some reason our other middlewares weren't seeing the 200 status code. 

**Testing**

- Tested locally