### PR TITLE
FFM-11310 Use gauge to track stream connectivity 

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -331,7 +331,7 @@ func main() {
 				"control_uri": "http://localhost:5561",
 			},
 		})
-		streamHealth     = stream.NewHealth(logger, "ffproxy_saas_stream_health", cache.NewKeyValCache(redisClient), readReplica)
+		streamHealth     = stream.NewStreamHealthMetrics(stream.NewHealth(logger, "ffproxy_saas_stream_health", cache.NewKeyValCache(redisClient), readReplica), promReg)
 		connectedStreams = domain.NewSafeMap()
 
 		getConnectedStreams = func() map[string]interface{} {

--- a/stream/health.go
+++ b/stream/health.go
@@ -12,49 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type streamHealthMetrics struct {
-	next     Health
-	gauge    *prometheus.GaugeVec
-	hostName string
-}
-
-func NewStreamHealthMetrics(next Health, r prometheus.Registerer) Health {
-	hostName, _ := os.Hostname()
-	if hostName == "" {
-		hostName = "unknown"
-	}
-
-	h := streamHealthMetrics{
-		next:     next,
-		hostName: hostName,
-		gauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			// Tracks the health of Proxy streaming i.e are we connected to Saas stream and
-			// are SDKs connected to Replica streams. Or are we disconnected fromm Saas & polling
-			// in which case SDKs would also be disconnected from replicas and polling
-			Name: "ff_proxy_stream_health",
-		},
-			[]string{"host"},
-		),
-	}
-
-	r.MustRegister(h.gauge)
-	return h
-}
-
-func (p streamHealthMetrics) SetHealthy(ctx context.Context) error {
-	p.gauge.WithLabelValues(p.hostName).Set(1)
-	return p.next.SetHealthy(ctx)
-}
-
-func (p streamHealthMetrics) SetUnhealthy(ctx context.Context) error {
-	p.gauge.WithLabelValues(p.hostName).Set(0)
-	return p.next.SetUnhealthy(ctx)
-}
-
-func (p streamHealthMetrics) Status(ctx context.Context) (domain.StreamStatus, error) {
-	return p.next.Status(ctx)
-}
-
 // Health defines the health interface for a Stream
 type Health interface {
 	SetHealthy(ctx context.Context) error
@@ -324,4 +281,47 @@ func (r ReplicaHealth) GetStreamStatus(ctx context.Context) {
 			}
 		}
 	}
+}
+
+type streamHealthMetrics struct {
+	next     Health
+	gauge    *prometheus.GaugeVec
+	hostName string
+}
+
+func NewStreamHealthMetrics(next Health, r prometheus.Registerer) Health {
+	hostName, _ := os.Hostname()
+	if hostName == "" {
+		hostName = "unknown"
+	}
+
+	h := streamHealthMetrics{
+		next:     next,
+		hostName: hostName,
+		gauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			// Tracks the health of Proxy streaming i.e are we connected to Saas stream and
+			// are SDKs connected to Replica streams. Or are we disconnected fromm Saas & polling
+			// in which case SDKs would also be disconnected from replicas and polling
+			Name: "ff_proxy_stream_health",
+		},
+			[]string{"host"},
+		),
+	}
+
+	r.MustRegister(h.gauge)
+	return h
+}
+
+func (p streamHealthMetrics) SetHealthy(ctx context.Context) error {
+	p.gauge.WithLabelValues(p.hostName).Set(1)
+	return p.next.SetHealthy(ctx)
+}
+
+func (p streamHealthMetrics) SetUnhealthy(ctx context.Context) error {
+	p.gauge.WithLabelValues(p.hostName).Set(0)
+	return p.next.SetUnhealthy(ctx)
+}
+
+func (p streamHealthMetrics) Status(ctx context.Context) (domain.StreamStatus, error) {
+	return p.next.Status(ctx)
 }

--- a/stream/health.go
+++ b/stream/health.go
@@ -3,12 +3,57 @@ package stream
 import (
 	"context"
 	"errors"
+	"os"
 	"time"
 
 	"github.com/harness/ff-proxy/v2/cache"
 	"github.com/harness/ff-proxy/v2/domain"
 	"github.com/harness/ff-proxy/v2/log"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+type streamHealthMetrics struct {
+	next     Health
+	gauge    *prometheus.GaugeVec
+	hostName string
+}
+
+func NewStreamHealthMetrics(next Health, r prometheus.Registerer) Health {
+	hostName, _ := os.Hostname()
+	if hostName == "" {
+		hostName = "unknown"
+	}
+
+	h := streamHealthMetrics{
+		next:     next,
+		hostName: hostName,
+		gauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			// Tracks the health of Proxy streaming i.e are we connected to Saas stream and
+			// are SDKs connected to Replica streams. Or are we disconnected fromm Saas & polling
+			// in which case SDKs would also be disconnected from replicas and polling
+			Name: "ff_proxy_stream_health",
+		},
+			[]string{"host"},
+		),
+	}
+
+	r.MustRegister(h.gauge)
+	return h
+}
+
+func (p streamHealthMetrics) SetHealthy(ctx context.Context) error {
+	p.gauge.WithLabelValues(p.hostName).Set(1)
+	return p.next.SetHealthy(ctx)
+}
+
+func (p streamHealthMetrics) SetUnhealthy(ctx context.Context) error {
+	p.gauge.WithLabelValues(p.hostName).Set(0)
+	return p.next.SetUnhealthy(ctx)
+}
+
+func (p streamHealthMetrics) Status(ctx context.Context) (domain.StreamStatus, error) {
+	return p.next.Status(ctx)
+}
 
 // Health defines the health interface for a Stream
 type Health interface {

--- a/stream/health_test.go
+++ b/stream/health_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/harness/ff-proxy/v2/cache"
 	"github.com/harness/ff-proxy/v2/domain"
 	"github.com/harness/ff-proxy/v2/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -360,7 +361,9 @@ func TestHealth_SetHealthy(t *testing.T) {
 				inMemStatus: domain.NewSafeStreamStatus(tc.args.startingInMemStatus),
 			}
 
-			err := h.SetHealthy(context.Background())
+			h2 := NewStreamHealthMetrics(h, prometheus.NewRegistry())
+
+			err := h2.SetHealthy(context.Background())
 			if tc.shouldErr {
 				assert.NotNil(t, err)
 			} else {
@@ -633,7 +636,9 @@ func TestHealth_SetUnhealthy(t *testing.T) {
 				}),
 			}
 
-			err := h.SetUnhealthy(context.Background())
+			h2 := NewStreamHealthMetrics(h, prometheus.NewRegistry())
+
+			err := h2.SetUnhealthy(context.Background())
 			if tc.shouldErr {
 				assert.NotNil(t, err)
 			} else {
@@ -670,8 +675,9 @@ func TestReplicaHealth_SetHealthy(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 
 			r := NewReplicaHealth("", nil, log.NoOpLogger{})
+			r2 := NewStreamHealthMetrics(r, prometheus.NewRegistry())
 
-			err := r.SetHealthy(context.Background())
+			err := r2.SetHealthy(context.Background())
 			if tc.shouldErr {
 				assert.NotNil(t, err)
 			} else {
@@ -707,8 +713,9 @@ func TestReplicaHealth_SetUnhealthy(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 
 			r := NewReplicaHealth("", nil, log.NoOpLogger{})
+			r2 := NewStreamHealthMetrics(r, prometheus.NewRegistry())
 
-			err := r.SetUnhealthy(context.Background())
+			err := r2.SetUnhealthy(context.Background())
 			if tc.shouldErr {
 				assert.NotNil(t, err)
 			} else {


### PR DESCRIPTION
**What**

- Uses a prometheus gauge to track the connected/disconnected status of
  streams in the Proxy

**Why**

- This should be more robust and easier to monitor than the way we're
  currently monitoring it with logs

**Testing**

- Tested locally with a primary & read replica in docker
- Tested in ff-play 
- Tested displaying the new metrics in grafana with forced disconnects


![Screenshot 2024-05-21 at 12 44 02](https://github.com/harness/ff-proxy/assets/16992818/f3063660-2e97-457b-837c-3d517641ad9f)

