### PR TITLE
FFM-11552 Add prometheus gauge to track polling status

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -453,6 +453,8 @@ func main() {
 		redisForwarder := stream.NewForwarder(logger, redisStream, cacheRefresher, stream.WithStreamName(sseStreamTopic))
 		messageHandler = stream.NewForwarder(logger, pushpinStream, redisForwarder)
 
+		pollingStatus := stream.NewPollingStatusMetric(promReg)
+
 		streamURL := fmt.Sprintf("%s/stream?cluster=%s", clientService, conf.ClusterIdentifier())
 		sseClient := stream.NewSSEClient(
 			logger,
@@ -460,8 +462,8 @@ func main() {
 			proxyKey,
 			conf.Token(),
 			conf.AccountID(),
-			stream.SaasStreamOnConnect(logger, streamHealth, reloadConfig, primaryToReplicaControlStream),
-			stream.SaasStreamOnDisconnect(logger, streamHealth, pushpin, primaryToReplicaControlStream, getConnectedStreams, reloadConfig),
+			stream.SaasStreamOnConnect(logger, streamHealth, reloadConfig, primaryToReplicaControlStream, pollingStatus),
+			stream.SaasStreamOnDisconnect(logger, streamHealth, pushpin, primaryToReplicaControlStream, getConnectedStreams, reloadConfig, pollingStatus),
 		)
 
 		saasStream := stream.NewStream(

--- a/stream/on_connect_disconnect_handlers_test.go
+++ b/stream/on_connect_disconnect_handlers_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/harness/ff-proxy/v2/domain"
 	"github.com/harness/ff-proxy/v2/log"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -115,7 +116,9 @@ func TestSaasStreamOnDisconnect(t *testing.T) {
 				domain.NoOpMessageHandler{},
 			)
 
-			SaasStreamOnDisconnect(log.NoOpLogger{}, tc.mocks.health, tc.mocks.pushpin, redisStream, tc.mocks.connectedStreamsFunc, tc.mocks.pollFn)()
+			ps := NewPollingStatusMetric(prometheus.NewRegistry())
+
+			SaasStreamOnDisconnect(log.NoOpLogger{}, tc.mocks.health, tc.mocks.pushpin, redisStream, tc.mocks.connectedStreamsFunc, tc.mocks.pollFn, ps)()
 
 			t.Log("Then the stream status will become unhealthy")
 			assert.Equal(t, tc.expected.streamHealth, tc.mocks.health.getHealth())
@@ -175,8 +178,9 @@ func TestSaasStreamOnConnect(t *testing.T) {
 				tc.mocks.stream,
 				domain.NoOpMessageHandler{},
 			)
+			ps := NewPollingStatusMetric(prometheus.NewRegistry())
 
-			SaasStreamOnConnect(log.NoOpLogger{}, tc.mocks.health, tc.mocks.reloadConfig, redisStream)()
+			SaasStreamOnConnect(log.NoOpLogger{}, tc.mocks.health, tc.mocks.reloadConfig, redisStream, ps)()
 
 			t.Log("Then the stream status will become healthy")
 			assert.Equal(t, tc.expected.streamHealth, tc.mocks.health.getHealth())


### PR DESCRIPTION
**What**

- Adds a prometheus gague that's used to track whether or not the Primary is polling Saas for changes.

**Why**

- We can use this alongside our stream connection status gauge to visualise that when streaming disconnects polling kicks in and when streaming reconnects polling stops

**Testing**

- Using prometheus & grafana locally I'm able to graph this

![Screenshot 2024-05-23 at 10 53 43](https://github.com/harness/ff-proxy/assets/16992818/dd4325c8-378a-4029-ac53-26561cfed961)
