### PR TITLE
FFM-11556 Fix failing type assertion

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -347,20 +347,23 @@ func main() {
 	// the in memory status.
 	// If we're running as replicas we kick off a routine to make sure the in memory status matches the
 	// cached status
+	// nolint:nestif
 	if !readReplica {
-		h, ok := sHealth.(stream.PrimaryHealth)
+		h, ok := streamHealth.(stream.PrimaryHealth)
 		if !ok {
 			logger.Error("got unexpected type for streamHealth", "expected", "stream.PrimaryHealth", "got", fmt.Sprintf("%T", h))
+		} else {
+			go h.VerifyStreamStatus(ctx, 60*time.Second)
 		}
 
-		go h.VerifyStreamStatus(ctx, 60*time.Second)
 	} else {
-		h, ok := sHealth.(stream.ReplicaHealth)
+		h, ok := streamHealth.(stream.ReplicaHealth)
 		if !ok {
 			logger.Error("got unexpected type for streamHealth", "expected", "stream.ReplicaHealth", "got", fmt.Sprintf("%T", h))
+		} else {
+			go h.GetStreamStatus(ctx)
 		}
 
-		go h.GetStreamStatus(ctx)
 	}
 
 	// Get the underlying type from the pushpinStream which is currently the

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -349,7 +349,7 @@ func main() {
 	// cached status
 	// nolint:nestif
 	if !readReplica {
-		h, ok := streamHealth.(stream.PrimaryHealth)
+		h, ok := sHealth.(stream.PrimaryHealth)
 		if !ok {
 			logger.Error("got unexpected type for streamHealth", "expected", "stream.PrimaryHealth", "got", fmt.Sprintf("%T", h))
 		} else {
@@ -357,7 +357,7 @@ func main() {
 		}
 
 	} else {
-		h, ok := streamHealth.(stream.ReplicaHealth)
+		h, ok := sHealth.(stream.ReplicaHealth)
 		if !ok {
 			logger.Error("got unexpected type for streamHealth", "expected", "stream.ReplicaHealth", "got", fmt.Sprintf("%T", h))
 		} else {

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -348,17 +348,19 @@ func main() {
 	// If we're running as replicas we kick off a routine to make sure the in memory status matches the
 	// cached status
 	if !readReplica {
-		if h, ok := sHealth.(stream.PrimaryHealth); ok {
-			go h.VerifyStreamStatus(ctx, 60*time.Second)
-		} else {
+		h, ok := sHealth.(stream.PrimaryHealth)
+		if !ok {
 			logger.Error("got unexpected type for streamHealth", "expected", "stream.PrimaryHealth", "got", fmt.Sprintf("%T", h))
 		}
+
+		go h.VerifyStreamStatus(ctx, 60*time.Second)
 	} else {
-		if h, ok := sHealth.(stream.ReplicaHealth); ok {
-			go h.GetStreamStatus(ctx)
-		} else {
+		h, ok := sHealth.(stream.ReplicaHealth)
+		if !ok {
 			logger.Error("got unexpected type for streamHealth", "expected", "stream.ReplicaHealth", "got", fmt.Sprintf("%T", h))
 		}
+
+		go h.GetStreamStatus(ctx)
 	}
 
 	// Get the underlying type from the pushpinStream which is currently the

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -350,10 +350,14 @@ func main() {
 	if !readReplica {
 		if h, ok := sHealth.(stream.PrimaryHealth); ok {
 			go h.VerifyStreamStatus(ctx, 60*time.Second)
+		} else {
+			logger.Error("got unexpected type for streamHealth", "expected", "stream.PrimaryHealth", "got", fmt.Sprintf("%T", h))
 		}
 	} else {
 		if h, ok := sHealth.(stream.ReplicaHealth); ok {
 			go h.GetStreamStatus(ctx)
+		} else {
+			logger.Error("got unexpected type for streamHealth", "expected", "stream.ReplicaHealth", "got", fmt.Sprintf("%T", h))
 		}
 	}
 


### PR DESCRIPTION
**What**

- Instantiates StreamHealth before passing it to StreamMetrics

**Why**

- The StreamHealth types are decorated with a StreamMetrics type which
  meant the type assertions in the main.go weren't passing. This meant
that the goroutines weren't being kicked off when they should have been

**Testing**

- Tested locally and I can see the logs from the goroutines coming out