### PR TITLE
FFM-11556 

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -729,6 +729,7 @@ func getStreamStatusForReplica(ctx context.Context, c cache.Cache, log log.Logge
 				if err := h.SetHealthy(ctx); err != nil {
 					log.Error("failed to set healthy stream status in read replica", "err", err)
 				}
+				log.Info("successfully retrieved cached status and set it in memory", "state", status.State, "since", status.Since)
 				return
 			}
 
@@ -736,6 +737,7 @@ func getStreamStatusForReplica(ctx context.Context, c cache.Cache, log log.Logge
 				if err := h.SetUnhealthy(ctx); err != nil {
 					log.Error("failed to set unhealthy status in read replica", "err", err)
 				}
+				log.Info("successfully retrieved cached status and set it in memory", "state", status.State, "since", status.Since)
 				return
 			}
 		}


### PR DESCRIPTION
**What**

- Moves GetStreamStatus func used by the replica to the main.go

**Why**

- Previously the GetStreamStatus func wasn't able to set values for the
  promethues metric that records the stream connectivity in replicas
because this code was running at too low a level and bypassing the
Metrics decorator.

**Testing**

- Stopping and bringing up read replicas I can see this goroutine is now
  able to set the prometheus gauge