### PR TITLE
FFM-11605 Close Pushpin streams in ReadReplicaMessageHandler

### DIFF
--- a/domain/message_handlers_test.go
+++ b/domain/message_handlers_test.go
@@ -36,19 +36,47 @@ func (m *mockHealth) getHealth() bool {
 	return m.healthy
 }
 
+type mockPushpin struct {
+	*sync.Mutex
+	closed bool
+}
+
+func (m *mockPushpin) Close(topic string) error {
+	m.Lock()
+	defer m.Unlock()
+
+	m.closed = true
+	return nil
+}
+
+func (m *mockPushpin) status() bool {
+	m.Lock()
+	defer m.Unlock()
+
+	return m.closed
+}
+
 func TestReadReplicaMessageHandler_HandleMessage(t *testing.T) {
+	connectedStreams := func() map[string]interface{} {
+		return map[string]interface{}{
+			"env-123": struct{}{},
+		}
+	}
 
 	type args struct {
 		msg SSEMessage
 	}
 
 	type mocks struct {
-		health *mockHealth
+		health           *mockHealth
+		pp               *mockPushpin
+		connectedStreams func() map[string]interface{}
 	}
 
 	type expected struct {
-		health bool
-		err    error
+		health              bool
+		err                 error
+		pushpinStreamClosed bool
 	}
 
 	testCases := map[string]struct {
@@ -69,10 +97,13 @@ func TestReadReplicaMessageHandler_HandleMessage(t *testing.T) {
 					Mutex:   &sync.Mutex{},
 					healthy: true,
 				},
+				connectedStreams: connectedStreams,
+				pp:               &mockPushpin{Mutex: &sync.Mutex{}},
 			},
 			expected: expected{
-				health: false,
-				err:    nil,
+				health:              false,
+				err:                 nil,
+				pushpinStreamClosed: true,
 			},
 			shouldErr: false,
 		},
@@ -88,10 +119,13 @@ func TestReadReplicaMessageHandler_HandleMessage(t *testing.T) {
 					Mutex:   &sync.Mutex{},
 					healthy: false,
 				},
+				connectedStreams: connectedStreams,
+				pp:               &mockPushpin{Mutex: &sync.Mutex{}},
 			},
 			expected: expected{
-				health: true,
-				err:    nil,
+				health:              true,
+				err:                 nil,
+				pushpinStreamClosed: false,
 			},
 			shouldErr: false,
 		},
@@ -104,7 +138,7 @@ func TestReadReplicaMessageHandler_HandleMessage(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			ctx := context.Background()
 
-			r := NewReadReplicaMessageHandler(log.NoOpLogger{}, tc.mocks.health)
+			r := NewReadReplicaMessageHandler(log.NoOpLogger{}, tc.mocks.health, tc.mocks.connectedStreams, tc.mocks.pp)
 
 			err := r.HandleMessage(ctx, tc.args.msg)
 			if tc.shouldErr {
@@ -114,6 +148,7 @@ func TestReadReplicaMessageHandler_HandleMessage(t *testing.T) {
 			}
 
 			assert.Equal(t, tc.expected.health, tc.mocks.health.getHealth())
+			assert.Equal(t, tc.expected.pushpinStreamClosed, tc.mocks.pp.status())
 		})
 	}
 }

--- a/domain/stream.go
+++ b/domain/stream.go
@@ -21,5 +21,10 @@ type Subscriber interface {
 	Sub(ctx context.Context, channel string, id string, message HandleMessageFn) error
 }
 
+// Closer defines the interface for closing a stream
+type Closer interface {
+	Close(topic string) error
+}
+
 // HandleMessageFn is the function that gets called whenever a subscriber receives a message on a stream
 type HandleMessageFn func(id string, v interface{}) error

--- a/stream/on_connect_disconnect_handlers.go
+++ b/stream/on_connect_disconnect_handlers.go
@@ -117,16 +117,9 @@ func SaasStreamOnConnect(l log.Logger, streamHealth Health, reloadConfig func() 
 	}
 }
 
-// ReadReplicaSSEStreamOnDisconnect closes any open 'Read Replica' Proxy -> SDK streams
-func ReadReplicaSSEStreamOnDisconnect(l log.Logger, pp Pushpin, streams getConnectedStreamsFn) func() {
+// ReadReplicaSSEStreamOnDisconnect is called whenever the read replica disconnects from a redis stream
+func ReadReplicaSSEStreamOnDisconnect(l log.Logger, topic string) func() {
 	return func() {
-		// Close any open stream between this Proxy and SDKs. This is to force SDKs to poll the Proxy for
-		// changes until we've a healthy SaaS -> Proxy stream to make sure they don't miss out on changes
-		// the Proxy may have pulled down while the Proxy -> Saas stream was down.
-		for streamID := range streams() {
-			if err := pp.Close(streamID); err != nil {
-				l.Error("failed to close Proxy->SDK stream", "streamID", streamID, "err", err)
-			}
-		}
+		l.Error("read replica disconnected from stream", "stream_name", topic)
 	}
 }


### PR DESCRIPTION
**What**

- Moves the closure of Pushpin streams in the replica to the message
  handler that receives the disconnect

**Why**

- It makes more sense to live here rather than in an OnDisconnect func
  that gets returned by another functioning returning an error

**Testing**

- Tested manually
- Unit tests