### PR TITLE
FFM-11600 Use featureName in metrics aggregation if featureIdentifier is empty

### DIFF
--- a/clients/metrics_service/safe_metrics_request_map.go
+++ b/clients/metrics_service/safe_metrics_request_map.go
@@ -122,6 +122,7 @@ func makeKey(envID string, attributes []clientgen.KeyValue) string {
 	var (
 		variationIdentifier string
 		flagIdentifier      string
+		flagName            string
 		sdkLanguage         string
 		sdkVersion          string
 
@@ -160,7 +161,22 @@ func makeKey(envID string, attributes []clientgen.KeyValue) string {
 			gotSDKVersion = true
 			continue
 		}
+
+		// If the flagIdentifier is already populated we don't need to bother
+		// fetching the flagName
+		if attr.Key == "featureName" && flagIdentifier == "" {
+			flagName = attr.Value
+			continue
+		}
 	}
 
-	return fmt.Sprintf("%s-%s-%s-%s-%s", envID, flagIdentifier, variationIdentifier, sdkLanguage, sdkVersion)
+	// Some SDKs send us a featureIdentifier attribute in the metrics but some
+	// only send a featureName (but use the identifier as the value). So if we
+	// don't find a featureIdentifier in the attributes we should use the name instead
+	flagIdent := flagIdentifier
+	if flagIdent == "" {
+		flagIdent = flagName
+	}
+
+	return fmt.Sprintf("%s-%s-%s-%s-%s", envID, flagIdent, variationIdentifier, sdkLanguage, sdkVersion)
 }

--- a/clients/metrics_service/safe_metrics_request_map.go
+++ b/clients/metrics_service/safe_metrics_request_map.go
@@ -118,6 +118,7 @@ func (s *safeMetricsRequestMap) get() map[string]domain.MetricsRequest {
 	return result
 }
 
+// nolint:cyclop
 func makeKey(envID string, attributes []clientgen.KeyValue) string {
 	var (
 		variationIdentifier string

--- a/clients/metrics_service/safe_metrics_request_map_test.go
+++ b/clients/metrics_service/safe_metrics_request_map_test.go
@@ -143,6 +143,82 @@ func Test_SafeMetricsRequestMap(t *testing.T) {
 		Timestamp:   0,
 	}
 
+	featureNameFlag := clientgen.MetricsData{
+		Attributes: []clientgen.KeyValue{
+			{
+				Key:   "featureName",
+				Value: "fname",
+			},
+			{
+				Key:   "variationIdentifier",
+				Value: "false",
+			},
+			{
+				Key:   "SDK_LANGUAGE",
+				Value: "java",
+			},
+			{
+				Key:   "SDK_VERSION",
+				Value: "1.0.0",
+			},
+		},
+		Count:       1,
+		MetricsType: "Server",
+		Timestamp:   0,
+	}
+
+	featureNameFlag2 := clientgen.MetricsData{
+		Attributes: []clientgen.KeyValue{
+			{
+				Key:   "featureName",
+				Value: "fname2",
+			},
+			{
+				Key:   "variationIdentifier",
+				Value: "false",
+			},
+			{
+				Key:   "SDK_LANGUAGE",
+				Value: "java",
+			},
+			{
+				Key:   "SDK_VERSION",
+				Value: "1.0.0",
+			},
+		},
+		Count:       1,
+		MetricsType: "Server",
+		Timestamp:   0,
+	}
+
+	featureNameAndIdentifierFlag := clientgen.MetricsData{
+		Attributes: []clientgen.KeyValue{
+			{
+				Key:   "featureName",
+				Value: "fname",
+			},
+			{
+				Key:   "featureIdentifier",
+				Value: "hello-world",
+			},
+			{
+				Key:   "variationIdentifier",
+				Value: "false",
+			},
+			{
+				Key:   "SDK_LANGUAGE",
+				Value: "java",
+			},
+			{
+				Key:   "SDK_VERSION",
+				Value: "1.0.0",
+			},
+		},
+		Count:       1,
+		MetricsType: "Server",
+		Timestamp:   0,
+	}
+
 	type args struct {
 		envID           string
 		metricsRequests []domain.MetricsRequest
@@ -374,6 +450,71 @@ func Test_SafeMetricsRequestMap(t *testing.T) {
 							MetricsData: domain.ToPtr([]clientgen.MetricsData{
 								flagOneFalseGolangOne,
 								flagOneFalseJaveOne,
+							}),
+						},
+					},
+				},
+			},
+		},
+		"Given I have one metrics requests with only a featureName attribute": {
+			args: args{
+				envID: "123",
+				metricsRequests: []domain.MetricsRequest{
+					makeMetricsRequest("123", 12, featureNameFlag),
+				},
+			},
+			expected: expected{
+				mapSize: 12,
+				data: map[string]domain.MetricsRequest{
+					"123": {
+						EnvironmentID: "123",
+						Metrics: clientgen.Metrics{
+							MetricsData: domain.ToPtr([]clientgen.MetricsData{
+								featureNameFlag,
+							}),
+						},
+					},
+				},
+			},
+		},
+		"Given I have two metrics requests with only a featureName attribute": {
+			args: args{
+				envID: "123",
+				metricsRequests: []domain.MetricsRequest{
+					makeMetricsRequest("123", 12, featureNameFlag),
+					makeMetricsRequest("123", 12, featureNameFlag2),
+				},
+			},
+			expected: expected{
+				mapSize: 24,
+				data: map[string]domain.MetricsRequest{
+					"123": {
+						EnvironmentID: "123",
+						Metrics: clientgen.Metrics{
+							MetricsData: domain.ToPtr([]clientgen.MetricsData{
+								featureNameFlag,
+								featureNameFlag2,
+							}),
+						},
+					},
+				},
+			},
+		},
+		"Given I have one metrics requests with a featureName & featureIdentifier": {
+			args: args{
+				envID: "123",
+				metricsRequests: []domain.MetricsRequest{
+					makeMetricsRequest("123", 12, featureNameAndIdentifierFlag),
+				},
+			},
+			expected: expected{
+				mapSize: 12,
+				data: map[string]domain.MetricsRequest{
+					"123": {
+						EnvironmentID: "123",
+						Metrics: clientgen.Metrics{
+							MetricsData: domain.ToPtr([]clientgen.MetricsData{
+								featureNameAndIdentifierFlag,
 							}),
 						},
 					},


### PR DESCRIPTION
**What**

- The metrics aggregation in the Proxy now uses the `featureName` attribute in the key if the `featureIdentifier` isn't present

**Why**

- It turns out all SDKs send a `featureIdentifer` but they do all send a `featureName` attribute. This resulted in a bug where the Proxy could merge evaluations for two different flags during its aggregation because it couldn't find a `flagIdentifier` in the attributes to use as the key name (occurs with the java sdk).

**Testing**

- Added unit tests
- Built an image locally and tested out with the Java SDK by instantiation multiple clients that evaluated different flags and I can see all evalautions appearing in Saas