### PR TITLE
FFM-11692 Add Connection: close header to metrics requests

### DIFF
--- a/clients/metrics_service/client.go
+++ b/clients/metrics_service/client.go
@@ -92,6 +92,10 @@ func (c Client) PostMetrics(ctx context.Context, envID string, metric domain.Met
 	},
 		addAuthToken(c.token()),
 		domain.AddHarnessXHeaders(envID),
+		func(ctx context.Context, req *http.Request) error {
+			req.Header.Add("Connection", "close")
+			return nil
+		},
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What**

- Adds a `Connection: close` header to the metrics request that we send to Saas

**Why**

- We occasionally see some strange i/o timeout errors posting metrics to Saas e.g. `dial tcp <host>:<port>: i/o timeout`. We had some similarish errors in the Go SDK where it would get the odd EOF error posting metrics to Saas. In the Go SDK the root cause seemed to be it was trying to reuse the connection but it had been closed by the server and the fix was to add this `Connection: close` header. We think there might be a similar issue here and since the metrics requests are only sent once a minute we probably don't need to try and reuse this connection so there's no harm adding the `Connection: close` header

**Testing**

- Built an image and tested that posting metrics still work