### PR TITLE
FFM-11697 Add support for Harness-Target header

### DIFF
--- a/domain/requests.go
+++ b/domain/requests.go
@@ -50,6 +50,9 @@ type TargetSegmentsByIdentifierRequest struct {
 type EvaluationsRequest struct {
 	EnvironmentID    string
 	TargetIdentifier string
+
+	// Target is an optional field that will be populated if the client provides a 'Harness-Target' header in the request
+	Target *Target
 }
 
 // EvaluationsByFeatureRequest contains the fields sent in a GET /client/env/{environmentUUID}/target/{target}/evaluations/{feature} request
@@ -57,6 +60,9 @@ type EvaluationsByFeatureRequest struct {
 	EnvironmentID     string
 	TargetIdentifier  string
 	FeatureIdentifier string
+
+	// Target is an optional field that will be populated if the client provides a 'Harness-Target' header in the request
+	Target *Target
 }
 
 // StreamRequest contains the fields sent in a GET /stream request

--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -215,7 +215,7 @@ func decodeGetEvaluationsRequest(c echo.Context) (interface{}, error) {
 
 	target, err := extractTarget(c)
 	if err != nil {
-		return nil, errBadRequest
+		return nil, fmt.Errorf("%w: %s", errBadRequest, err)
 	}
 
 	req := domain.EvaluationsRequest{
@@ -317,7 +317,7 @@ func extractTarget(c echo.Context) (*domain.Target, error) {
 	}
 
 	if err := decodeBase64String(encodedTarget, &target); err != nil {
-		return nil, fmt.Errorf("failed to decode target from header: %w", err)
+		return nil, errors.New("failed to decode target from header - check target encoding is valid")
 	}
 
 	return target, nil

--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 
 	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
 	proxyservice "github.com/harness/ff-proxy/v2/proxy-service"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/labstack/echo/v4"
@@ -81,25 +82,29 @@ func codeFrom(err error) int {
 // decodeAuthRequest decodes POST /client/auth requests into a domain.AuthRequest
 // that can be passed to the service. It returns a wrapped bad request error if
 // the request body is empty or if the apiKey is empty
-func decodeAuthRequest(c echo.Context) (interface{}, error) {
+func decodeAuthRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	//#nosec G307
 	defer c.Request().Body.Close()
 
 	req := domain.AuthRequest{}
 	b, err := io.ReadAll(c.Request().Body)
 	if err != nil {
+		l.Error("failed to read auth request body", "err", err)
 		return nil, err
 	}
 
 	if len(b) == 0 {
+		l.Info("invalid AuthRequest, request body is empty")
 		return nil, fmt.Errorf("%w: request body cannot be empty", errBadRequest)
 	}
 
 	if err := jsoniter.Unmarshal(b, &req); err != nil {
+		l.Error("failed to decode auth request", "err", err)
 		return nil, err
 	}
 
 	if req.APIKey == "" {
+		l.Info("invalid AuthRequest, apiKey cannot be empty", "apiKey", req.APIKey)
 		return nil, fmt.Errorf("%w: apiKey cannot be empty", errBadRequest)
 	}
 
@@ -110,10 +115,12 @@ func decodeAuthRequest(c echo.Context) (interface{}, error) {
 	}
 
 	if req.Target.Identifier != "" && !isIdentifierValid(req.Target.Identifier) {
+		l.Warn("invalid AuthRequest, target identifier is invalid", "targetIdentifier", req.Target.Identifier)
 		return nil, fmt.Errorf("%w: target identifier is invalid", errBadRequest)
 	}
 
 	if req.Target.Name != "" && !isNameValid(req.Target.Name) {
+		l.Warn("invalid AuthRequest, target name is invalid", "targetName", req.Target.Name)
 		return nil, fmt.Errorf("%w: target name is invalid", errBadRequest)
 	}
 
@@ -121,15 +128,16 @@ func decodeAuthRequest(c echo.Context) (interface{}, error) {
 }
 
 // decodeHealthRequest returns an empty interface
-func decodeHealthRequest(_ echo.Context) (interface{}, error) {
+func decodeHealthRequest(_ echo.Context, _ log.Logger) (interface{}, error) {
 	return nil, nil
 }
 
 // decodeGetFeatureConfigisRequest decodes GET /client/env/{environmentUUID}/feature-configs requests
 // into a domain.FeatureConfigRequest that can be passed to the ProxyService
-func decodeGetFeatureConfigsRequest(c echo.Context) (interface{}, error) {
+func decodeGetFeatureConfigsRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	envID := c.Param("environment_uuid")
 	if envID == "" {
+		l.Info("invalid FeatureConfigs request, envID cannot be empty", "envID", envID)
 		return nil, errBadRouting
 	}
 
@@ -141,11 +149,12 @@ func decodeGetFeatureConfigsRequest(c echo.Context) (interface{}, error) {
 
 // decodeGetFeatureConfigsByIdentifierRequest decodes GET /client/env/{environmentUUID}/feature-configs/{identifier} requests
 // into a domain.FeatureConfigsByIdentifierRequest that can be passed to the ProxyService
-func decodeGetFeatureConfigsByIdentifierRequest(c echo.Context) (interface{}, error) {
+func decodeGetFeatureConfigsByIdentifierRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	envID := c.Param("environment_uuid")
 	identifier := c.Param("identifier")
 
 	if envID == "" || identifier == "" {
+		l.Info("invalid FeatureConfigsByIdentifier request, envID and identifier cannot be empty", "envID", envID, "identifier", identifier)
 		return nil, errBadRouting
 	}
 
@@ -158,9 +167,10 @@ func decodeGetFeatureConfigsByIdentifierRequest(c echo.Context) (interface{}, er
 
 // decodeGetTargetSegmentsRequest decodes GET /client/env/{environmentUUID}/target-segments requests
 // into a domain.TargetSegmentsRequest that can be passed to the ProxyService
-func decodeGetTargetSegmentsRequest(c echo.Context) (interface{}, error) {
+func decodeGetTargetSegmentsRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	envID := c.Param("environment_uuid")
 	if envID == "" {
+		l.Info("invalid TargetSegments request, envID cannot be empty", "envID", envID)
 		return nil, errBadRouting
 	}
 	rules := c.QueryParam(rulesQueryParam)
@@ -174,11 +184,12 @@ func decodeGetTargetSegmentsRequest(c echo.Context) (interface{}, error) {
 
 // decodeGetTargetSegmentsByIdentifierRequest decodes GET /client/env/{environmentUUID}/target-segments/{identifier}
 // requests into a domain.TargetSegmentsByIdentifierRequest that can be passed to the ProxyService
-func decodeGetTargetSegmentsByIdentifierRequest(c echo.Context) (interface{}, error) {
+func decodeGetTargetSegmentsByIdentifierRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	envID := c.Param("environment_uuid")
 	identifier := c.Param("identifier")
 
 	if envID == "" || identifier == "" {
+		l.Info("invalid TargetSegmentsByIdentifier request, envID and identifier cannot be empty", "envID", envID, "identifier", identifier)
 		return nil, errBadRouting
 	}
 
@@ -205,17 +216,18 @@ func decodeBase64String(data string, value interface{}) error {
 
 // decodeGetEvaluationsRequest decodes GET /client/env/{environmentUUID}/target/{target}/evaluations
 // requests into a domain.EvaluationsRequest that can be passed to the ProxyService
-func decodeGetEvaluationsRequest(c echo.Context) (interface{}, error) {
+func decodeGetEvaluationsRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	envID := c.Param("environment_uuid")
 	targetIdentifier := c.Param("target")
 
 	if envID == "" || targetIdentifier == "" {
+		l.Info("invalid EvaluationsRequest request, envID and targetIdentifier cannot be empty", "envID", envID, "targetIdentifier", targetIdentifier)
 		return nil, errBadRouting
 	}
 
 	target, err := extractTarget(c)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", errBadRequest, err)
+		l.Warn("failed to extract target from header", "err", err)
 	}
 
 	req := domain.EvaluationsRequest{
@@ -228,14 +240,14 @@ func decodeGetEvaluationsRequest(c echo.Context) (interface{}, error) {
 
 // decodeGetEvaluationsByFeatureRequest decodes GET /client/env/{environmentUUID}/target/{target}/evaluations/{feature}
 // requests into a domain.EvaluationsByFeatureRequest that can be passed to the ProxyService
-func decodeGetEvaluationsByFeatureRequest(c echo.Context) (interface{}, error) {
+func decodeGetEvaluationsByFeatureRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	envID := c.Param("environment_uuid")
 	targetIdentifier := c.Param("target")
 	feature := c.Param("feature")
 
 	target, err := extractTarget(c)
 	if err != nil {
-		return nil, errBadRequest
+		l.Warn("failed to extract target from header", "err", err)
 	}
 
 	req := domain.EvaluationsByFeatureRequest{
@@ -249,7 +261,7 @@ func decodeGetEvaluationsByFeatureRequest(c echo.Context) (interface{}, error) {
 
 // decodeGetStreamRequest decodes GET /stream requests into a domain.StreamRequest that
 // can be passed to the ProxyService
-func decodeGetStreamRequest(c echo.Context) (interface{}, error) {
+func decodeGetStreamRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	apiKey := c.Request().Header.Get("API-Key")
 
 	req := domain.StreamRequest{
@@ -257,13 +269,14 @@ func decodeGetStreamRequest(c echo.Context) (interface{}, error) {
 	}
 
 	if req.APIKey == "" {
+		l.Info("invalid Stream request, API Key is empty", "apiKey", req.APIKey)
 		return nil, fmt.Errorf("%w: API-Key can't be empty", errBadRequest)
 	}
 	return req, nil
 }
 
 // decodeMetricsRequest decodes POST /metrics/{environment} requests into domain.Metrics
-func decodeMetricsRequest(c echo.Context) (interface{}, error) {
+func decodeMetricsRequest(c echo.Context, l log.Logger) (interface{}, error) {
 	//#nosec G307
 	defer c.Request().Body.Close()
 
@@ -279,6 +292,7 @@ func decodeMetricsRequest(c echo.Context) (interface{}, error) {
 
 	req.EnvironmentID = c.Param("environment_uuid")
 	if req.EnvironmentID == "" {
+		l.Info("invalid Metrics request, environmentID cannot be empty", "envID", req.EnvironmentID)
 		return nil, errBadRouting
 	}
 
@@ -317,7 +331,7 @@ func extractTarget(c echo.Context) (*domain.Target, error) {
 	}
 
 	if err := decodeBase64String(encodedTarget, &target); err != nil {
-		return nil, errors.New("failed to decode target from header - check target encoding is valid")
+		return nil, fmt.Errorf("failed to decode target from header: %s", err)
 	}
 
 	return target, nil

--- a/transport/encode_decode_test.go
+++ b/transport/encode_decode_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/harness/ff-proxy/v2/domain"
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	"github.com/harness/ff-proxy/v2/log"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -245,7 +246,7 @@ func Test_decodeGetEvaluationsRequest(t *testing.T) {
 			c.SetParamNames("environment_uuid", "target")
 			c.SetParamValues(tc.args.envID, tc.args.target)
 
-			actual, err := decodeGetEvaluationsRequest(c)
+			actual, err := decodeGetEvaluationsRequest(c, log.NoOpLogger{})
 			if tc.shouldErr {
 				assert.NotNil(t, err)
 			} else {
@@ -289,7 +290,7 @@ func Test_decodeGetEvaluationsByFeatureRequest(t *testing.T) {
 		expected  expected
 		shouldErr bool
 	}{
-		"Given I make a evaluations request and include a target header": {
+		"Given I make a evaluations by feature request and include a target header": {
 			args: args{
 				envID:   "123",
 				target:  "foo",
@@ -306,7 +307,7 @@ func Test_decodeGetEvaluationsByFeatureRequest(t *testing.T) {
 				},
 			},
 		},
-		"Given I make a evaluations request and don't include a target header": {
+		"Given I make a evaluations by feature request and don't include a target header": {
 			args: args{
 				envID:   "123",
 				target:  "foo",
@@ -342,7 +343,7 @@ func Test_decodeGetEvaluationsByFeatureRequest(t *testing.T) {
 			c.SetParamNames("environment_uuid", "target", "feature")
 			c.SetParamValues(tc.args.envID, tc.args.target, tc.args.feature)
 
-			actual, err := decodeGetEvaluationsByFeatureRequest(c)
+			actual, err := decodeGetEvaluationsByFeatureRequest(c, log.NoOpLogger{})
 			if tc.shouldErr {
 				assert.NotNil(t, err)
 			} else {

--- a/transport/encode_decode_test.go
+++ b/transport/encode_decode_test.go
@@ -1,6 +1,17 @@
 package transport
 
-import "testing"
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/harness/ff-proxy/v2/domain"
+	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
 
 func Test_isIdentifierValid(t *testing.T) {
 	type args struct {
@@ -150,6 +161,195 @@ func Test_isNameValid(t *testing.T) {
 			if got := isNameValid(tt.args.name); got != tt.want {
 				t.Errorf("IsIdentifierValid() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_decodeGetEvaluationsRequest(t *testing.T) {
+	target := domain.Target{
+		Target: clientgen.Target{
+			Attributes: domain.ToPtr(map[string]interface{}{
+				"email": "foo@gmail.com",
+			}),
+			Identifier: "foo",
+			Name:       "bar",
+		},
+	}
+
+	b, err := jsoniter.Marshal(target)
+	assert.Nil(t, err)
+
+	encodedTarget := base64.StdEncoding.EncodeToString(b)
+
+	type args struct {
+		envID   string
+		target  string
+		headers map[string]string
+	}
+
+	type expected struct {
+		req domain.EvaluationsRequest
+	}
+
+	testCases := map[string]struct {
+		args      args
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I make a evaluations request and include a target header": {
+			args: args{
+				envID:   "123",
+				target:  "foo",
+				headers: map[string]string{targetHeader: encodedTarget},
+			},
+			shouldErr: false,
+			expected: expected{
+				req: domain.EvaluationsRequest{
+					EnvironmentID:    "123",
+					TargetIdentifier: "foo",
+					Target:           &target,
+				},
+			},
+		},
+		"Given I make a evaluations request and don't include a target header": {
+			args: args{
+				envID:   "123",
+				target:  "foo",
+				headers: nil,
+			},
+			shouldErr: false,
+			expected: expected{
+				req: domain.EvaluationsRequest{
+					EnvironmentID:    "123",
+					TargetIdentifier: "foo",
+					Target:           nil,
+				},
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			for h, v := range tc.args.headers {
+				req.Header.Set(h, v)
+			}
+
+			e := echo.New()
+			c := e.NewContext(req, httptest.NewRecorder())
+			c.SetPath(evaluationsFlagRoute)
+			c.SetParamNames("environment_uuid", "target")
+			c.SetParamValues(tc.args.envID, tc.args.target)
+
+			actual, err := decodeGetEvaluationsRequest(c)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tc.expected.req, actual)
+		})
+	}
+}
+
+func Test_decodeGetEvaluationsByFeatureRequest(t *testing.T) {
+	target := domain.Target{
+		Target: clientgen.Target{
+			Attributes: domain.ToPtr(map[string]interface{}{
+				"email": "foo@gmail.com",
+			}),
+			Identifier: "foo",
+			Name:       "bar",
+		},
+	}
+
+	b, err := jsoniter.Marshal(target)
+	assert.Nil(t, err)
+
+	encodedTarget := base64.StdEncoding.EncodeToString(b)
+
+	type args struct {
+		envID   string
+		target  string
+		feature string
+		headers map[string]string
+	}
+
+	type expected struct {
+		req domain.EvaluationsByFeatureRequest
+	}
+
+	testCases := map[string]struct {
+		args      args
+		expected  expected
+		shouldErr bool
+	}{
+		"Given I make a evaluations request and include a target header": {
+			args: args{
+				envID:   "123",
+				target:  "foo",
+				feature: "booleanFlag",
+				headers: map[string]string{targetHeader: encodedTarget},
+			},
+			shouldErr: false,
+			expected: expected{
+				req: domain.EvaluationsByFeatureRequest{
+					EnvironmentID:     "123",
+					TargetIdentifier:  "foo",
+					FeatureIdentifier: "booleanFlag",
+					Target:            &target,
+				},
+			},
+		},
+		"Given I make a evaluations request and don't include a target header": {
+			args: args{
+				envID:   "123",
+				target:  "foo",
+				feature: "booleanFlag",
+				headers: nil,
+			},
+			shouldErr: false,
+			expected: expected{
+				req: domain.EvaluationsByFeatureRequest{
+					EnvironmentID:     "123",
+					TargetIdentifier:  "foo",
+					FeatureIdentifier: "booleanFlag",
+					Target:            nil,
+				},
+			},
+		},
+	}
+
+	for desc, tc := range testCases {
+		desc := desc
+		tc := tc
+
+		t.Run(desc, func(t *testing.T) {
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			for h, v := range tc.args.headers {
+				req.Header.Set(h, v)
+			}
+
+			e := echo.New()
+			c := e.NewContext(req, httptest.NewRecorder())
+			c.SetPath(evaluationsFlagRoute)
+			c.SetParamNames("environment_uuid", "target", "feature")
+			c.SetParamValues(tc.args.envID, tc.args.target, tc.args.feature)
+
+			actual, err := decodeGetEvaluationsByFeatureRequest(c)
+			if tc.shouldErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tc.expected.req, actual)
 		})
 	}
 }

--- a/transport/handlers.go
+++ b/transport/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-kit/kit/endpoint"
+	"github.com/harness/ff-proxy/v2/log"
 	"github.com/labstack/echo/v4"
 )
 
@@ -13,19 +14,19 @@ import (
 type errorEncoderFunc func(c echo.Context, err error) error
 
 // decodeRequestFunc is a function that decodes http requests into a type
-type decodeRequestFunc func(c echo.Context) (request interface{}, err error)
+type decodeRequestFunc func(c echo.Context, l log.Logger) (request interface{}, err error)
 
 // encodeResponseFunc is a function for encoding http responses
 type encodeResponseFunc func(ctx context.Context, w http.ResponseWriter, resp interface{}) (err error)
 
 // NewUnaryHandler creates and returns an echo.HandlerFunc that accepts a single request
 // and returns a single response
-func NewUnaryHandler(e endpoint.Endpoint, dec decodeRequestFunc, enc encodeResponseFunc, errorEncoder errorEncoderFunc) echo.HandlerFunc {
+func NewUnaryHandler(e endpoint.Endpoint, dec decodeRequestFunc, enc encodeResponseFunc, errorEncoder errorEncoderFunc, l log.Logger) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		ctx := c.Request().Context()
 		w := c.Response().Writer
 
-		req, err := dec(c)
+		req, err := dec(c, l)
 		if err != nil {
 			return errorEncoder(c, err)
 		}

--- a/transport/http_server.go
+++ b/transport/http_server.go
@@ -114,6 +114,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeAuthRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.GET(healthRoute, NewUnaryHandler(
@@ -121,6 +122,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeHealthRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.GET(featureConfigsRoute, NewUnaryHandler(
@@ -128,6 +130,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeGetFeatureConfigsRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.GET(featureConfigsIdentifierRoute, NewUnaryHandler(
@@ -135,6 +138,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeGetFeatureConfigsByIdentifierRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.GET(segmentsRoute, NewUnaryHandler(
@@ -142,6 +146,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeGetTargetSegmentsRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.GET(segmentsIdentifierRoute, NewUnaryHandler(
@@ -149,6 +154,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeGetTargetSegmentsByIdentifierRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.GET(evaluationsRoute, NewUnaryHandler(
@@ -156,6 +162,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeGetEvaluationsRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.GET(evaluationsFlagRoute, NewUnaryHandler(
@@ -163,6 +170,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeGetEvaluationsByFeatureRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.GET(streamRoute, NewUnaryHandler(
@@ -170,6 +178,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeGetStreamRequest,
 		encodeStreamResponse,
 		encodeEchoError,
+		h.log,
 	))
 
 	h.router.POST(metricsRoute, NewUnaryHandler(
@@ -177,6 +186,7 @@ func (h *HTTPServer) registerEndpoints(e *Endpoints) {
 		decodeMetricsRequest,
 		encodeResponse,
 		encodeEchoError,
+		h.log,
 	))
 }
 

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -782,13 +782,12 @@ func TestHTTPServer_GetEvaluations(t *testing.T) {
 			expectedStatusCode:   http.StatusOK,
 			expectedResponseBody: targetDavejEvaluations,
 		},
-		"Given I make a GET request with an invalid Target in the Harness-Target": {
-			method:             http.MethodGet,
-			url:                fmt.Sprintf("%s/client/env/1234/target/foo/evaluations", testServer.URL),
-			headers:            map[string]string{targetHeader: badlyEncodedTarget},
-			expectedStatusCode: http.StatusBadRequest,
-			expectedResponseBody: []byte(`{"error":"bad request: failed to decode target from header - check target encoding is valid"}
-`),
+		"Given I make a GET request with an invalid Target in the Harness-Target, then the target from the path will be used": {
+			method:               http.MethodGet,
+			url:                  fmt.Sprintf("%s/client/env/1234/target/foo/evaluations", testServer.URL),
+			headers:              map[string]string{targetHeader: badlyEncodedTarget},
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: targetFooEvaluations,
 		},
 	}
 	for desc, tc := range testCases {
@@ -921,13 +920,12 @@ func TestHTTPServer_GetEvaluationsByFeature(t *testing.T) {
 			expectedStatusCode:   http.StatusOK,
 			expectedResponseBody: targetDavejDarkModeEvaluation,
 		},
-		"Given I make a GET request with an invalid Target in the Harness-Target": {
-			method:             http.MethodGet,
-			url:                fmt.Sprintf("%s/client/env/1234/target/foo/evaluations", testServer.URL),
-			headers:            map[string]string{targetHeader: badlyEncodedTarget},
-			expectedStatusCode: http.StatusBadRequest,
-			expectedResponseBody: []byte(`{"error":"bad request: failed to decode target from header - check target encoding is valid"}
-`),
+		"Given I make a GET request with an invalid Target in the Harness-Target, then the target from the path will be used": {
+			method:               http.MethodGet,
+			url:                  fmt.Sprintf("%s/client/env/1234/target/foo/evaluations/harnessappdemodarkmode", testServer.URL),
+			headers:              map[string]string{targetHeader: badlyEncodedTarget},
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: darkModeEvaluationTrue,
 		},
 	}
 

--- a/transport/http_server_test.go
+++ b/transport/http_server_test.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"github.com/harness-community/sse/v3"
 	sdkstream "github.com/harness/ff-golang-server-sdk/stream"
 	clientgen "github.com/harness/ff-proxy/v2/gen/client"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/labstack/echo/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
@@ -701,6 +703,9 @@ var (
 	// targetFooEvaluations is the expected response body for a Evaluations request - the newline at the end is intentional
 	targetFooEvaluations = []byte(`[{"flag":"harnessappdemodarkmode","identifier":"true","kind":"boolean","value":"true"},{"flag":"yet_another_flag","identifier":"1","kind":"string","value":"1"}]
 `)
+
+	targetDavejEvaluations = []byte(`[{"flag":"harnessappdemodarkmode","identifier":"false","kind":"boolean","value":"false"},{"flag":"yet_another_flag","identifier":"1","kind":"string","value":"1"}]
+`)
 )
 
 // TestHTTPServer_GetEvaluations sets up a service with repositories populated
@@ -712,9 +717,27 @@ func TestHTTPServer_GetEvaluations(t *testing.T) {
 	testServer := httptest.NewServer(server)
 	defer testServer.Close()
 
+	target := domain.Target{
+		Target: clientgen.Target{
+			Attributes: domain.ToPtr(map[string]interface{}{
+				"email": "foo@gmail.com",
+			}),
+			Identifier: "davej",
+			Name:       "Dave Johnson",
+		},
+	}
+
+	b, err := jsoniter.Marshal(target)
+	assert.Nil(t, err)
+
+	encodedTarget := base64.StdEncoding.EncodeToString(b)
+
+	badlyEncodedTarget := base64.StdEncoding.EncodeToString([]byte(`{"identifier": "foo", "name": "foo"`))
+
 	testCases := map[string]struct {
 		method               string
 		url                  string
+		headers              map[string]string
 		expectedStatusCode   int
 		expectedResponseBody []byte
 	}{
@@ -752,6 +775,21 @@ func TestHTTPServer_GetEvaluations(t *testing.T) {
 			expectedStatusCode:   http.StatusOK,
 			expectedResponseBody: targetFooEvaluations,
 		},
+		"Given I make a GET request with a valid Target in the Harness-Target header then the Target in the header will be used for evaluations": {
+			method:               http.MethodGet,
+			url:                  fmt.Sprintf("%s/client/env/1234/target/foo/evaluations", testServer.URL),
+			headers:              map[string]string{targetHeader: encodedTarget},
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: targetDavejEvaluations,
+		},
+		"Given I make a GET request with an invalid Target in the Harness-Target": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/1234/target/foo/evaluations", testServer.URL),
+			headers:            map[string]string{targetHeader: badlyEncodedTarget},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponseBody: []byte(`{"error":"bad request: failed to decode target from header - check target encoding is valid"}
+`),
+		},
 	}
 	for desc, tc := range testCases {
 		tc := tc
@@ -770,6 +808,10 @@ func TestHTTPServer_GetEvaluations(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+			}
+
+			for h, v := range tc.headers {
+				req.Header.Set(h, v)
 			}
 
 			resp, err := testServer.Client().Do(req)
@@ -802,6 +844,9 @@ var (
 	// darkModeEvaluationTrue is the expected response body for a EvaluationsByFeature request when identifer='james' and feature='harnessappdemodarkmode '- the newline at the end is intentional
 	darkModeEvaluationTrue = []byte(`{"flag":"harnessappdemodarkmode","identifier":"true","kind":"boolean","value":"true"}
 `)
+
+	targetDavejDarkModeEvaluation = []byte(`{"flag":"harnessappdemodarkmode","identifier":"false","kind":"boolean","value":"false"}
+`)
 )
 
 // TestHTTPServer_GetEvaluationsByFeature sets up an service with repositories
@@ -813,9 +858,27 @@ func TestHTTPServer_GetEvaluationsByFeature(t *testing.T) {
 	testServer := httptest.NewServer(server)
 	defer testServer.Close()
 
+	target := domain.Target{
+		Target: clientgen.Target{
+			Attributes: domain.ToPtr(map[string]interface{}{
+				"email": "foo@gmail.com",
+			}),
+			Identifier: "davej",
+			Name:       "Dave Johnson",
+		},
+	}
+
+	b, err := jsoniter.Marshal(target)
+	assert.Nil(t, err)
+
+	encodedTarget := base64.StdEncoding.EncodeToString(b)
+
+	badlyEncodedTarget := base64.StdEncoding.EncodeToString([]byte(`{"identifier": "foo", "name": "foo"`))
+
 	testCases := map[string]struct {
 		method               string
 		url                  string
+		headers              map[string]string
 		expectedStatusCode   int
 		expectedResponseBody []byte
 	}{
@@ -851,7 +914,23 @@ func TestHTTPServer_GetEvaluationsByFeature(t *testing.T) {
 			expectedStatusCode:   http.StatusOK,
 			expectedResponseBody: darkModeEvaluationTrue,
 		},
+		"Given I make a GET request with a valid Target in the Harness-Target header then the Target in the header will be used for evaluations": {
+			method:               http.MethodGet,
+			url:                  fmt.Sprintf("%s/client/env/1234/target/foo/evaluations/harnessappdemodarkmode", testServer.URL),
+			headers:              map[string]string{targetHeader: encodedTarget},
+			expectedStatusCode:   http.StatusOK,
+			expectedResponseBody: targetDavejDarkModeEvaluation,
+		},
+		"Given I make a GET request with an invalid Target in the Harness-Target": {
+			method:             http.MethodGet,
+			url:                fmt.Sprintf("%s/client/env/1234/target/foo/evaluations", testServer.URL),
+			headers:            map[string]string{targetHeader: badlyEncodedTarget},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponseBody: []byte(`{"error":"bad request: failed to decode target from header - check target encoding is valid"}
+`),
+		},
 	}
+
 	for desc, tc := range testCases {
 		tc := tc
 		t.Run(desc, func(t *testing.T) {
@@ -869,6 +948,10 @@ func TestHTTPServer_GetEvaluationsByFeature(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+			}
+
+			for h, v := range tc.headers {
+				req.Header.Set(h, v)
 			}
 
 			resp, err := testServer.Client().Do(req)


### PR DESCRIPTION
**What**

- Adds support for extracting a Target from a `Harness-Target` header that's provided in evaluation requests.
- If the Target is provided via this header we'll use it for performing the evaluations. If this header isn't used we'll still fetch the Target from redis to perform evaluations.

**Why**

- Newer versinos of SDKs send the Target in a header for evaluations requests. Saas supports using this Target for evaluations so the Proxy should also support it.
- This should save us unecessarily fetching targets from redis when newer SDKs are used with the Proxy

**Testing**

- Tested with v1.20.0 (Pre Target Header Work) and v.1.26.3 (post target header work) of the JS SDK
- Added unit tests