### PR TITLE
FFM-11707 Make REDIS_ADDR required

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -281,12 +281,12 @@ func main() {
 		}
 	}
 
-	// we currently don't require any config to run in offline mode
-	requiredFlags := map[string]interface{}{}
-	if !offline && !readReplica {
-		requiredFlags = map[string]interface{}{
-			proxyKeyEnv: proxyKey,
-		}
+	requiredFlags := map[string]interface{}{
+		redisAddrEnv:  redisAddress,
+		authSecretEnv: authSecret,
+	}
+	if !readReplica {
+		requiredFlags[proxyKeyEnv] = proxyKey
 	}
 	validateFlags(requiredFlags)
 

--- a/examples/ha_mode_with_monitoring/docker-compose.yml
+++ b/examples/ha_mode_with_monitoring/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   primary:
-    image: "harness/ff-proxy:2.0.0-rc.20"
+    image: "harness/ff-proxy:2.0.1"
     environment:
       - LOG_LEVEL=INFO
       - PROXY_KEY=<proxy key>
@@ -14,12 +14,12 @@ services:
       - redis
 
   replica:
-    image: "harness/ff-proxy:2.0.0-rc.20"
+    image: "harness/ff-proxy:2.0.1"
     environment:
       - LOG_LEVEL=INFO
-      - REDIS_ADDRESS=redis:6379
+      - REDIS_ADDRESS=redis:67379
       - READ_REPLICA=true
-      - AUTH_SECRET=foobar
+      - AUTH_SECRET=
     ports:
       - "7002:7000"
     depends_on:

--- a/examples/ha_mode_with_monitoring/docker-compose.yml
+++ b/examples/ha_mode_with_monitoring/docker-compose.yml
@@ -17,9 +17,9 @@ services:
     image: "harness/ff-proxy:2.0.1"
     environment:
       - LOG_LEVEL=INFO
-      - REDIS_ADDRESS=redis:67379
+      - REDIS_ADDRESS=redis:6379
       - READ_REPLICA=true
-      - AUTH_SECRET=
+      - AUTH_SECRET=foobar
     ports:
       - "7002:7000"
     depends_on:

--- a/examples/redis_cluster_ha_mode_with_monitoring/docker-compose.yaml
+++ b/examples/redis_cluster_ha_mode_with_monitoring/docker-compose.yaml
@@ -4,7 +4,7 @@ networks:
     driver: bridge
 services:
   primary:
-    image: "harness/ff-proxy:2.0.0-rc.20"
+    image: "harness/ff-proxy:2.0.1"
     container_name: primary-proxy
     environment:
       - LOG_LEVEL=INFO
@@ -18,7 +18,7 @@ services:
       - redis-net
       
   replica:
-    image: "harness/ff-proxy:2.0.0-rc.20"
+    image: "harness/ff-proxy:2.0.1"
     container_name: replica-proxy
     environment:
       - LOG_LEVEL=INFO


### PR DESCRIPTION
**What**

- Makes REDIS_ADDR required configuration
- Makes AUTH_SECRET required configuration
- Also updates our examples to use the latest version `2.0.1`

**Why**

- These are listed as [required in our docs](ae8a2865-f8b5-4e56-b01b-ebfc0a8f6af8) and they are required for the Proxy to function so we should be enforcing that requirement in the code as well

**Testing**

- Built and tested locally, when I don't provide this config I get an error message telling me they're required