### PR TITLE
FFM-11691 Don't log context cancelled in DeltaAdd func

### DIFF
--- a/repository/target_repo.go
+++ b/repository/target_repo.go
@@ -57,6 +57,7 @@ func (t TargetRepo) GetByIdentifier(ctx context.Context, envID string, identifie
 // an error to avoid wiping all of the Targets from the cache. If we want to remove
 // all of the Targets for a given key then we should add an explicit Remove method
 // that calls cache.Remove.
+// nolint:cyclop
 func (t TargetRepo) DeltaAdd(ctx context.Context, envID string, targets ...domain.Target) error {
 	if len(targets) == 0 {
 		return fmt.Errorf("can't perform DeltaAdd with zero targets for environment %s", envID)

--- a/repository/target_repo.go
+++ b/repository/target_repo.go
@@ -91,8 +91,12 @@ func (t TargetRepo) DeltaAdd(ctx context.Context, envID string, targets ...domai
 	// then we'll want to remove them.
 	for identifier := range existingTargets {
 		if _, ok := newTargets[identifier]; !ok {
-			if err := t.cache.Delete(ctx, string(key)); err != nil {
-				t.log.Error("failed to flush stale target from cache during DeltaAdd", "err", err)
+			if err2 := t.cache.Delete(ctx, string(key)); err != nil {
+
+				// We don't want to log context cancelled errors
+				if !errors.Is(err2, context.Canceled) {
+					t.log.Error("failed to flush stale target from cache during DeltaAdd", "err", err)
+				}
 			}
 		}
 	}

--- a/repository/target_repo.go
+++ b/repository/target_repo.go
@@ -93,10 +93,13 @@ func (t TargetRepo) DeltaAdd(ctx context.Context, envID string, targets ...domai
 		if _, ok := newTargets[identifier]; !ok {
 			if err2 := t.cache.Delete(ctx, string(key)); err != nil {
 
-				// We don't want to log context cancelled errors
+				// We don't want to log context cancelled as an error in here
 				if !errors.Is(err2, context.Canceled) {
-					t.log.Error("failed to flush stale target from cache during DeltaAdd", "err", err)
+					t.log.Info("context was cancelled during DeltaAdd", "err", err)
+					continue
 				}
+
+				t.log.Error("failed to flush stale target from cache during DeltaAdd", "err", err)
 			}
 		}
 	}


### PR DESCRIPTION
**What**

- If we get a context cancelled error in `TargetRepo.DeltaAdd` we'll log it at the info level
  rather than the error level

**Why**

- We saw this error log appearing occasionally in our QA env `{"caller":"repository/target_repo.go:95", "component":"TargetRepo", "err":"context canceled: KeyValCache.Delete failed for key: env-63c9bbc0-15fe-453e-97f0-cd1ff20e7264-target-configs", "level":"error", "msg":"failed to flush stale target from cache during DeltaAdd", "ts":"2024-06-10T11:10:04Z"}`
- I suspect this log happens when a client makes an auth request and
  then cancels it before the server can complete the request so we
shouldn't log it as an error

**Testing**

- I'm able to trigger the error log by making an auth request with a
  client and cancelling it before the server responds.

