### PR TITLE
FFM-11714 - More memory optimisations for response encoding

### DIFF
--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -32,25 +33,11 @@ var (
 func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
-	b, err := jsoniter.Marshal(response)
-	if err != nil {
+	encoder := json.NewEncoder(w)
+	if err := encoder.Encode(response); err != nil {
 		return err
 	}
 
-	_, err = w.Write(b)
-	if err != nil {
-		return err
-	}
-
-	// We previously used jsoniter.NewEncoder(w).Encode(response) which appended a newline
-	// character on to the end of the response body to make it compliant with RFC 7159.
-	// We swapped to json.Marshal because it reduced the number of memory allocations we
-	// were making but it doesn't append the newline character. So we're adding the newline
-	// character back in so that we haven't changed any functionality.
-	_, err = w.Write([]byte{'\n'})
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/transport/encode_decode.go
+++ b/transport/encode_decode.go
@@ -34,11 +34,7 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 
 	encoder := json.NewEncoder(w)
-	if err := encoder.Encode(response); err != nil {
-		return err
-	}
-
-	return nil
+	return encoder.Encode(response)
 }
 
 func encodeStreamResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {


### PR DESCRIPTION
**What**

- Uses json.NewEncoder for encoding the response body

**Why**

- Benchmarks show this is pretty much as fast as jsoniter.Marshal but
  uses less memory and fewer allocations

**Testing**

- Ran benchmarks
```
Benchmark_EncodeResponse
Benchmark_EncodeResponse/jsoniter.Marshal
Benchmark_EncodeResponse/jsoniter.Marshal-12         	    4872	    227514 ns/op	  155079 B/op	      12 allocs/op
Benchmark_EncodeResponse/json.Marshal
Benchmark_EncodeResponse/json.Marshal-12             	    4597	    260348 ns/op	  151189 B/op	      12 allocs/op
Benchmark_EncodeResponse/json.NewEncoder
Benchmark_EncodeResponse/json.NewEncoder-12          	    4885	    236368 ns/op	   75636 B/op	      11 allocs/op
Benchmark_EncodeResponse/jsoniter.NewEncoder
Benchmark_EncodeResponse/jsoniter.NewEncoder-12      	    3776	    293798 ns/op	  359755 B/op	      29 allocs/op
```