### PR TITLE
FFM-11799 Don't apply EnvValidation middleware to health endpoint

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -267,6 +267,8 @@ func skipValidateEnv(c echo.Context, bypassAuth bool) bool {
 		return true
 	case domain.StreamRoute:
 		return true
+	case domain.HealthRoute:
+		return true
 	default:
 		// Skip for prometheus requests
 		if urlPath == metricsPath && c.Request().Method == http.MethodGet {

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -196,6 +196,12 @@ func TestSkipper(t *testing.T) {
 			urlPath:  "/other",
 			expected: false,
 		},
+		{
+			name:     "Health check request",
+			method:   http.MethodGet,
+			urlPath:  "/health",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What**

- Skips the EnvValidation middleware for the health endpoint

**Why**

- To fix healthchecks which were broken by the env validation middleware change

**Testing**

- Unit tests
- Built an image locally and manually tested