### PR TITLE
FFM-11686 Don't encode error if the response has been committed

### DIFF
--- a/transport/handlers.go
+++ b/transport/handlers.go
@@ -37,7 +37,10 @@ func NewUnaryHandler(e endpoint.Endpoint, dec decodeRequestFunc, enc encodeRespo
 		}
 
 		if err := enc(ctx, w, resp); err != nil {
-			return errorEncoder(c, err)
+			if !c.Response().Committed {
+				return errorEncoder(c, err)
+			}
+			l.Error("response headers already written", "err", err)
 		}
 		return nil
 	}


### PR DESCRIPTION
**What**

- If we get an error encoding the response, don't call `errorEncoder`

**Why**

- `enc` and `errornEncoder` both result in `WriteHeader` calls on the ResponseWriter and could the be source of this error log we see occasionally when clients disconnect

```
8 http: superfluous response.WriteHeader call from github.com/labstack/echo/v4.(*Response).WriteHeader (response.go:63)
```