### PR TITLE
fix: remove user/pass from removeRedisScheme

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -667,7 +667,8 @@ func newMetricStore(ctx context.Context, logger log.Logger, readReplica bool, re
 }
 
 func removeRedisScheme(addr string) string {
-	return strings.TrimPrefix(strings.TrimPrefix(addr, "redis://"), "rediss://")
+	parts := strings.Split(addr, "@")
+	return strings.TrimPrefix(strings.TrimPrefix(parts[len(parts)-1], "redis://"), "rediss://")
 }
 
 func newRedisClient(addr string, logger log.Logger) redis.UniversalClient {

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -668,7 +668,11 @@ func newMetricStore(ctx context.Context, logger log.Logger, readReplica bool, re
 
 func removeRedisScheme(addr string) string {
 	parts := strings.Split(addr, "@")
-	return strings.TrimPrefix(strings.TrimPrefix(parts[len(parts)-1], "redis://"), "rediss://")
+	if len(parts) > 1 {
+		return parts[1]
+	} else {
+		return strings.TrimPrefix(strings.TrimPrefix(parts[0], "redis://"), "rediss://")
+	}
 }
 
 func newRedisClient(addr string, logger log.Logger) redis.UniversalClient {


### PR DESCRIPTION
I think we are leaving in the username and password in the connection string for redis.

Customer is trying to pass username:password and getting `too many colons in address`.

tests:
```
package main

import (
	"fmt"
	"strings"
)

func main() {
	secureUserPass := "rediss://user:pass@host:port"
	secureUser := "rediss://user@host:port"
	secure := "rediss://host:port"
	userPass := "redis://user:pass@host:port"
	user := "redis://user@host:port"
	base := "redis://host:port"

	fmt.Printf("before: %s, after: %s\n", removeRedisScheme(secureUserPass), removeRedisSchemeAndUser(secureUserPass))
	fmt.Printf("before: %s, after: %s\n", removeRedisScheme(secureUser), removeRedisSchemeAndUser(secureUser))
	fmt.Printf("before: %s, after: %s\n", removeRedisScheme(secure), removeRedisSchemeAndUser(secure))
	fmt.Printf("before: %s, after: %s\n", removeRedisScheme(userPass), removeRedisSchemeAndUser(userPass))
	fmt.Printf("before: %s, after: %s\n", removeRedisScheme(user), removeRedisSchemeAndUser(user))
	fmt.Printf("before: %s, after: %s\n", removeRedisScheme(base), removeRedisSchemeAndUser(base))

}

func removeRedisScheme(addr string) string {
	return strings.TrimPrefix(strings.TrimPrefix(addr, "redis://"), "rediss://")
}

func removeRedisSchemeAndUser(addr string) string {
	parts := strings.Split(addr, "@")
	if len(parts) > 1 {
		fmt.Println("user found, take lazy route")
		return parts[1]
	} else {
		fmt.Println("no user found, strip possible prefix")
		return strings.TrimPrefix(strings.TrimPrefix(parts[0], "redis://"), "rediss://")
	}
}
```
results:
```
user found, take lazy route
before: user:pass@host:port, after: host:port
user found, take lazy route
before: user@host:port, after: host:port
no user found, strip possible prefix
before: host:port, after: host:port
user found, take lazy route
before: user:pass@host:port, after: host:port
user found, take lazy route
before: user@host:port, after: host:port
no user found, strip possible prefix
before: host:port, after: host:port
```