### PR TITLE
FFM-11839 When SDK keys don't exist don't log an error

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -98,7 +98,11 @@ func isKeyInCache(ctx context.Context, logger log.Logger, repo keyLookUp, claims
 	key := claims.APIKey
 	_, exists, err := repo.Get(ctx, domain.AuthAPIKey(key))
 	if err != nil {
-		logger.Error("auth middleware failed to lookup key in cache", "err", err)
+		if errors.Is(err, domain.ErrCacheNotFound) {
+			logger.Info("cannot authenticate SDK key because it does not exist")
+			return exists
+		}
+		logger.Error("auth middleware failed to lookup sdk key in cache", "err", err)
 	}
 	return exists
 }


### PR DESCRIPTION
**What**

- When you try and auth and the SDK key in your auth token doesn't exist the Proxy logs an INFO log rather than an ERROR log

**Why**

- This isn't a Proxy error so shouldn't be logged as one

**Testing**

- Tested locally