### PR TITLE
PL-56357 - Fix regex used to generate notifications

### DIFF
--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -22,8 +22,8 @@ const (
 )
 
 var (
-	featureConfigRegEx = regexp.MustCompile(`env-([a-zA-Z0-9-]+)-feature-config-([a-zA-Z0-9-]+)`)
-	segmentConfigRegEx = regexp.MustCompile(`env-([a-zA-Z0-9-]+)-segment-([a-zA-Z0-9-]+)`)
+	featureConfigRegEx = regexp.MustCompile(`env-([a-zA-Z0-9-_]+)-feature-config-([a-zA-Z0-9-_]+)`)
+	segmentConfigRegEx = regexp.MustCompile(`env-([a-zA-Z0-9-]+)-segment-([a-zA-Z0-9-_]+)`)
 )
 
 // InventoryRepo is a repository that stores all references to all assets for the key.


### PR DESCRIPTION
**What**

- Updates the regex's used to extract flag names from redis keys to handle underscores

**Why**

- When the Primary restarts it diffs the new and old config and sends notifications if there have been any changes. The Regex used to extract the identifier wasn't handling underscores and was truncating flag identifiers. This meant it sent notifications with incorrect flag identifiers to SDKs.

**Testing**

- Added a unit test for the `BuildNotification` method
- Tested manually locally