### PR TITLE
FFM-11984 Remove stale inventory key after removing stale assets

### DIFF
--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -159,7 +159,7 @@ func (i InventoryRepo) removeOldKeyData(ctx context.Context, key string) error {
 			return fmt.Errorf("failed to remove stale assets for inventory key %q: %w", k, err)
 		}
 
-		// Once we've remove all the assets associated with this key we should remove
+		// Once we've removed all the assets associated with this key we should remove
 		// the key itself so that we don't fetch it the next time we start up
 		if err := i.cache.Delete(ctx, k); err != nil {
 			return fmt.Errorf("failed to remove stale inventory key %q: %w", k, err)

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -151,18 +151,21 @@ func (i InventoryRepo) removeOldKeyData(ctx context.Context, key string) error {
 	for k := range res {
 		var oldAssets map[string]string
 		err := i.cache.Get(ctx, k, &oldAssets)
-		if err != nil {
-			return fmt.Errorf("failed to get stale assets for inventory key %q: %s", k, err)
+		if err != nil && !errors.Is(err, domain.ErrCacheNotFound) {
+			i.log.Error("failed to get stale assets for inventory key", "key", k, "err", err)
+			continue
 		}
 
 		if err := i.removeAssets(ctx, oldAssets); err != nil {
-			return fmt.Errorf("failed to remove stale assets for inventory key %q: %w", k, err)
+			i.log.Error("failed to remove stale assets for inventory key", "key", k, "err", err)
+			continue
 		}
 
 		// Once we've removed all the assets associated with this key we should remove
 		// the key itself so that we don't fetch it the next time we start up
 		if err := i.cache.Delete(ctx, k); err != nil {
-			return fmt.Errorf("failed to remove stale inventory key %q: %w", k, err)
+			i.log.Error("failed to stale inventory key", "key", k, "err", err)
+			continue
 		}
 	}
 


### PR DESCRIPTION
**What**

- Remove the stale inventory key after we remove any stale assets associated with it

**Why**

- We already removed the stale assets associated with the stale key but didn't remove the stale key itself. This meant that the key would remain in redis and the next time the Primary started up it would fetch it and attempt to remove the stale assets again even though they don't exist. 

**Testing**

- Added unit test
- Manually tested locally