### PR TITLE
FFM-12009 Extract AppID header and log it out

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -231,16 +231,30 @@ func ExtractRequestValuesFromContext(ctx context.Context) []interface{} {
 		values = append(values, reqID)
 	}
 
+	appID := getAppID(ctx)
+	if appID != "" {
+		values = append(values, "appID")
+		values = append(values, appID)
+	}
+
 	return values
 }
 
 type contextKey string
 
 // RequestIDKey is the key we associate with the requestID that we set in the request context
-const RequestIDKey contextKey = "requestID"
+const (
+	RequestIDKey contextKey = "requestID"
+	AppIDKey     contextKey = "appID"
+)
 
 // getRequestID extracts the requestID value from the context if it exists.
 func getRequestID(ctx context.Context) string {
 	requestID, _ := ctx.Value(RequestIDKey).(string)
 	return requestID
+}
+
+func getAppID(ctx context.Context) string {
+	appID, _ := ctx.Value(AppIDKey).(string)
+	return appID
 }


### PR DESCRIPTION
**What**

- Extracts the the Harness-SDK-ApplicationID header from the request and
  sets it in the request context
- Extracts the appID from the context and logs it in the logging
  middleware and the standard logger.

**Why**

- Makes it easier to link requests to specific applications

**Testing**

- Manually tested locally
```
{"level":"info","ts":"2024-09-10T15:36:00+01:00","caller":"middleware/middleware.go:44","msg":"request","component":"LoggingMiddleware","method":"GET","path":"/client/env/:environment_uuid/feature-configs","status":401,"took":"80.619µs","reqID":"456","appID":"foobar-app"}

{"level":"info","ts":"2024-09-10T15:35:51+01:00","caller":"middleware/middleware.go:44","msg":"request","component":"LoggingMiddleware","method":"GET","path":"/client/env/:environment_uuid/feature-configs","status":401,"took":"59.64µs","reqID":"456","appID":"unknown"}

```