### PR TITLE
FFM-12006 - Proxy send Harness-SDK-ApplicationID to Harness

### DIFF
--- a/domain/requests.go
+++ b/domain/requests.go
@@ -111,7 +111,7 @@ type AuthenticateProxyKeyResponse struct {
 	ClusterIdentifier string
 }
 
-func getAppID() string {
+func GetAppID() string {
 	a := os.Getenv("APP_ID")
 	if a != "" {
 		return a
@@ -126,7 +126,7 @@ func getAppID() string {
 }
 
 var (
-	appID = getAppID()
+	appID = GetAppID()
 
 	// Assign os.Hostname to a variable so we can mock it for testing
 	hostnameFunc = os.Hostname

--- a/domain/requests_test.go
+++ b/domain/requests_test.go
@@ -5,16 +5,9 @@ import (
 	"testing"
 )
 
-// Mocking os.Hostname function
-var osHostname = os.Hostname
-
-func Test_getAppID(t *testing.T) {
+func Test_GetAppID(t *testing.T) {
 	// Mock hostname for tests
 	mockHostname := "mock-hostname"
-
-	osHostname = func() (string, error) {
-		return mockHostname, nil
-	}
 
 	tests := []struct {
 		name         string
@@ -64,7 +57,7 @@ func Test_getAppID(t *testing.T) {
 			}
 
 			// Execute function
-			result := getAppID()
+			result := GetAppID()
 
 			// Validate result
 			if result != tt.expected {

--- a/domain/requests_test.go
+++ b/domain/requests_test.go
@@ -1,0 +1,75 @@
+package domain
+
+import (
+	"os"
+	"testing"
+)
+
+// Mocking os.Hostname function
+var osHostname = os.Hostname
+
+func Test_getAppID(t *testing.T) {
+	// Mock hostname for tests
+	mockHostname := "mock-hostname"
+
+	osHostname = func() (string, error) {
+		return mockHostname, nil
+	}
+
+	tests := []struct {
+		name         string
+		envAppID     string
+		mockHostname string
+		mockError    error
+		expected     string
+	}{
+		{
+			name:         "APP_ID is set",
+			envAppID:     "my-app-id",
+			mockHostname: "",
+			mockError:    nil,
+			expected:     "my-app-id",
+		},
+		{
+			name:         "APP_ID is empty, hostname available",
+			envAppID:     "",
+			mockHostname: mockHostname,
+			mockError:    nil,
+			expected:     mockHostname,
+		},
+		{
+			name:         "APP_ID is empty, hostname error",
+			envAppID:     "",
+			mockHostname: "",
+			mockError:    os.ErrNotExist,
+			expected:     "unknown",
+		},
+		{
+			name:         "APP_ID is empty, empty hostname",
+			envAppID:     "",
+			mockHostname: "",
+			mockError:    nil,
+			expected:     "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable
+			os.Setenv("APP_ID", tt.envAppID)
+
+			// Override hostname function to return mock values
+			hostnameFunc = func() (string, error) {
+				return tt.mockHostname, tt.mockError
+			}
+
+			// Execute function
+			result := getAppID()
+
+			// Validate result
+			if result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/stream/sse.go
+++ b/stream/sse.go
@@ -27,10 +27,11 @@ type SSEClient struct {
 func NewSSEClient(l log.Logger, url string, key string, token string, accountID string, onConn func(), onDisconn func()) *SSEClient {
 	c := sse.NewClient(url)
 	c.Headers = map[string]string{
-		"Authorization":     fmt.Sprintf("Bearer %s", token),
-		"API-Key":           key,
-		"Harness-Accountid": accountID,
-		"Harness-Sdk-Info":  fmt.Sprintf("Proxy %s", build.Version),
+		"Authorization":             fmt.Sprintf("Bearer %s", token),
+		"API-Key":                   key,
+		"Harness-Accountid":         accountID,
+		"Harness-Sdk-Info":          fmt.Sprintf("Proxy %s", build.Version),
+		"Harness-SDK-ApplicationID": domain.GetAppID(),
 	}
 
 	c.OnConnect(func(c *sse.Client) {


### PR DESCRIPTION
**What**

- The Proxy will now send a Harness-SDK-ApplicationID to Harness
- Users can configure the applicationID or it will use the hostname by
  default

**Testing**

- Added tests
- Tested locally with a reverse proxy logging out the headers