### PR TITLE
FFM-12075 - Bump base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN make build
 # TODO - this will rarely change - publish as an image we can consume
 ############################
 # Pull the base image
-FROM ubuntu:24.04 as pushpin
+FROM ubuntu:24.10 as pushpin
 
 # Add private APT repository
 RUN \


### PR DESCRIPTION
**What**

- Bumps the base image version

**Why**

- Resolves a high level [vulnerability](https://www.cve.org/CVERecord?id=CVE-2024-26130) 