### PR TITLE
FFM-12086 reduce pushpin log level

### DIFF
--- a/config/pushpin/pushpin.conf
+++ b/config/pushpin/pushpin.conf
@@ -25,7 +25,7 @@ http_port=7000
 logdir=/pushpin/log
 
 # logging level. 2 = info, >2 = verbose
-log_level=2
+log_level=1
 
 # client full request header must fit in this buffer
 client_buffer_size=8192


### PR DESCRIPTION
**What**

- Reduces the log level in pushpin to error level

**Why**

- The pushpin log level was set to info
- Pushpin writes logs to a `/pushpin/log` directory and this was causing a high amount of ephemeral storage to be used when deployed in k8s. Other options I looked at for resolving this were:
  -  **Redirecting the Pushpin logs to stdout** `logdir=/dev/stdout`. 
    - Problem with this is pushpin was trying to create a `/dev/stdout` directory on startup which would fail with this error `ERR] 2024-10-02 13:23:37.801 failed to create directory: /dev/stdout`
  - **Capping the size of the `/pushpin` directory via k8s config**
    -  Problem with this was once we reached the max size the pod was evicted by kubernetes
  - **Adding some sort of log rotation**
    - Thought this would be overkill/more complicated than necessary for now
    
    
**Testing**

- Tested in QA and simulated traffic to generate pushpin logs. 
- Left running overnight as well and ephemeral storage usage has stayed down rather than climbing up slowly