### PR TITLE
FFM-12164 - Pass REDIS_DB to client

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -317,7 +317,7 @@ func main() {
 	var hashCache *cache.HashCache
 
 	if redisAddress != "" && !generateOfflineConfig { //nolint:nestif
-		redisClient = newRedisClient(redisAddress, redisUsername, redisPassword, logger)
+		redisClient = newRedisClient(redisAddress, redisUsername, redisPassword, redisDB, logger)
 
 		mcMetrics := cache.NewMemoizeMetrics("proxy", promReg)
 		mcCache := cache.NewMemoizeCache(redisClient, 1*time.Minute, 2*time.Minute, mcMetrics)
@@ -675,7 +675,7 @@ func removeRedisScheme(addr string) string {
 	return strings.TrimPrefix(strings.TrimPrefix(addr, "redis://"), "rediss://")
 }
 
-func newRedisClient(addr string, username string, password string, logger log.Logger) redis.UniversalClient {
+func newRedisClient(addr string, username string, password string, db int, logger log.Logger) redis.UniversalClient {
 	splitAddr := strings.Split(addr, ",")
 
 	// if address does not start with redis:// or rediss:// then default to redis://
@@ -697,7 +697,7 @@ func newRedisClient(addr string, username string, password string, logger log.Lo
 
 	opts := redis.UniversalOptions{
 		Addrs:     splitAddr,
-		DB:        parsed.DB,
+		DB:        db,
 		Username:  username,
 		Password:  password,
 		PoolSize:  redisPoolSize * runtime.NumCPU(),


### PR DESCRIPTION
**What**

- Passes the REDIS_DB to the redis client

**Why**

- If you tried to configure the redis DB using the `REDIS_DB` env var it never got passed to the client. This meant the redis client would always use the `0` DB regardless of configuration.