### PR TITLE
FFM-12326 Expose pushpin prometheus metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ test-report: ## Run the go tests and generate a coverage report
 
 PHONY+= dev
 dev: ## Brings up services that the proxy uses
-	docker-compose -f ./docker-compose.yml up -d --remove-orphans redis pushpin
+	docker compose -f ./docker-compose.yml up -d --remove-orphans redis pushpin
 
 e2e-cleanup: ## Generates the .env files needed to run the e2e tests below
 	go run tests/e2e/testhelpers/cleanup/main.go

--- a/charts/internal/ff-proxy/Chart.yaml
+++ b/charts/internal/ff-proxy/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.7"
+appVersion: "2.0.8"
 
 dependencies:
   - name: harness-common

--- a/charts/internal/ff-proxy/templates/primary-deployment.yaml
+++ b/charts/internal/ff-proxy/templates/primary-deployment.yaml
@@ -52,6 +52,9 @@ spec:
             - name: sdk
               containerPort: 7000
               protocol: TCP
+            - name: pushpin_prometheus
+              containerPort: 9000
+              protocol: TCP
           {{- include "harnesscommon.monitoring.containerPort" . | nindent 12 }}
           {{- toYaml .Values.primary.probes | nindent 10 }}
           resources:

--- a/charts/internal/ff-proxy/templates/read-replica-deployment.yaml
+++ b/charts/internal/ff-proxy/templates/read-replica-deployment.yaml
@@ -52,6 +52,9 @@ spec:
             - name: sdk
               containerPort: 7000
               protocol: TCP
+            - name: pushpin_prometheus
+              containerPort: 9000
+              protocol: TCP
           {{- include "harnesscommon.monitoring.containerPort" . | nindent 12 }}
           {{- toYaml .Values.readReplica.probes | nindent 10 }}
           resources:

--- a/charts/internal/ff-proxy/values.yaml
+++ b/charts/internal/ff-proxy/values.yaml
@@ -241,7 +241,7 @@ readReplica:
 
 #common configs which other services use.
 config:
-  ENV: SMP
+  ENV: qa
 
 secrets:
   default:

--- a/config/pushpin/pushpin.conf
+++ b/config/pushpin/pushpin.conf
@@ -140,3 +140,6 @@ stats_report_interval=10
 
 # stats output format
 stats_format=tnetstring
+
+# Expose pushpin prometheus metrics
+prometheus_port=0.0.0.0:9000


### PR DESCRIPTION
**What**

- Exposes the pushpin prometheus metrics

**Why**

- So we can monitor the number of connections, messages sent by pushpin etc

**Testing**

- Did a dry-run on the chart changes
- Built an image locally and when I run it I can curl the endpoint exposing the pushpin metrics