### PR TITLE
feat: [FFM-12441]: Optimise SSE events

### DIFF
--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -188,14 +188,14 @@ func (s Refresher) handleAddEnvironmentEvent(ctx context.Context, environments [
 			return err
 		}
 		// update key inventory for environment.
-		if err := s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]string) (map[string]string, error) {
+		if err := s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]int64) (map[string]int64, error) {
 			newAssets, err := s.inventory.BuildAssetListFromConfig(proxyConfig)
 			if err != nil {
 				return newAssets, err
 			}
-			for k := range newAssets {
+			for k, version := range newAssets {
 				if _, ok := assets[k]; !ok {
-					assets[k] = ""
+					assets[k] = version
 				}
 			}
 			return assets, nil
@@ -244,7 +244,7 @@ func (s Refresher) removeAssets(ctx context.Context, env string) error {
 		return err
 	}
 
-	if err := s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]string) (map[string]string, error) {
+	if err := s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]int64) (map[string]int64, error) {
 		// remove deleted keys from the assets
 		for k := range assetsToDelete {
 			delete(assets, k)
@@ -299,7 +299,7 @@ func (s Refresher) handleAddAPIKeyEvent(ctx context.Context, env, apiKey string)
 	}
 
 	// add key to the invetnory if does not exits
-	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]string) (map[string]string, error) {
+	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]int64) (map[string]int64, error) {
 		apiKeyEntry := string(domain.NewAuthAPIKey(apiKey))
 		apiConfigsEntry := string(domain.NewAPIConfigsKey(env))
 		return s.addItems(assets, apiKeyEntry, apiConfigsEntry)
@@ -321,7 +321,7 @@ func (s Refresher) handleRemoveAPIKeyEvent(ctx context.Context, env, apiKey stri
 		return err
 	}
 
-	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]string) (map[string]string, error) {
+	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]int64) (map[string]int64, error) {
 		_, ok := assets[apiKeyEntry]
 		if ok {
 			delete(assets, apiKeyEntry)
@@ -353,7 +353,7 @@ func (s Refresher) handleFetchFeatureEvent(ctx context.Context, env, id string) 
 		return err
 	}
 	// patch the inventory
-	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]string) (map[string]string, error) {
+	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]int64) (map[string]int64, error) {
 		featureConfigEntry := string(domain.NewFeatureConfigKey(env, id))
 		featureConfigsEntry := string(domain.NewFeatureConfigsKey(env))
 		return s.addItems(assets, featureConfigEntry, featureConfigsEntry)
@@ -387,7 +387,7 @@ func (s Refresher) handleDeleteFeatureEvent(ctx context.Context, env, identifier
 		}
 	}
 
-	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]string) (map[string]string, error) {
+	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]int64) (map[string]int64, error) {
 		_, ok := assets[featureConfigEntry]
 		if ok {
 			delete(assets, featureConfigEntry)
@@ -433,7 +433,7 @@ func (s Refresher) handleFetchSegmentEvent(ctx context.Context, env, id string) 
 		return err
 	}
 	// patch the inventory
-	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]string) (map[string]string, error) {
+	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]int64) (map[string]int64, error) {
 		segmentConfigEntry := string(domain.NewSegmentKey(env, id))
 		segmentConfigsEntry := string(domain.NewSegmentsKey(env))
 		return s.addItems(assets, segmentConfigEntry, segmentConfigsEntry)
@@ -465,7 +465,7 @@ func (s Refresher) handleDeleteSegmentEvent(ctx context.Context, env, identifier
 		}
 	}
 
-	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]string) (map[string]string, error) {
+	return s.inventory.Patch(ctx, s.config.Key(), func(assets map[string]int64) (map[string]int64, error) {
 		_, ok := assets[segmentConfig]
 		if ok {
 			delete(assets, segmentConfig)
@@ -492,14 +492,16 @@ func (s Refresher) updateSegmentConfigsEntry(ctx context.Context, env string, id
 	})
 }
 
-func (s Refresher) addItems(assets map[string]string, configKey, configsKey string) (map[string]string, error) {
-	_, ok := assets[configKey]
+func (s Refresher) addItems(assets map[string]int64, configKey, configsKey string) (map[string]int64, error) {
+	version, ok := assets[configKey]
 	if !ok {
-		assets[configKey] = ""
+		assets[configKey] = version
 	}
 	_, ok = assets[configsKey]
 	if !ok {
-		assets[configsKey] = ""
+		// Configs Keys aren't versioned the way keys for individual items are e.g. Flags, Segments are individually versioned,
+		// but the Flag/Segment config for an entire environment isn't versioned, so we can just set this to 0.
+		assets[configKey] = 0
 	}
 	return assets, nil
 }

--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -260,20 +260,20 @@ func TestRefresher_HandleMessage(t *testing.T) {
 		setProxyConfigFn: func(proxyConfig []domain.ProxyConfig) {},
 	}
 	inventoryRepo := mockInventoryRepo{
-		addFn: func(ctx context.Context, key string, assets map[string]string) error {
+		addFn: func(ctx context.Context, key string, assets map[string]int64) error {
 			return nil
 		},
 		removeFn: func(ctx context.Context, key string) error {
 			return nil
 		},
-		getFn: func(ctx context.Context, key string) (map[string]string, error) {
-			return map[string]string{}, nil
+		getFn: func(ctx context.Context, key string) (map[string]int64, error) {
+			return map[string]int64{}, nil
 		},
-		patchFn: func(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error {
+		patchFn: func(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error {
 			return nil
 		},
-		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]string, error) {
-			return map[string]string{}, nil
+		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]int64, error) {
+			return map[string]int64{}, nil
 		},
 		cleanupFn: func(ctx context.Context, key string, config []domain.ProxyConfig) ([]domain.SSEMessage, error) {
 			return []domain.SSEMessage{}, nil
@@ -370,12 +370,12 @@ func TestRefresher_handleAddEnvironmentEvent(t *testing.T) {
 	}
 
 	inventoryRepo := mockInventoryRepo{
-		patchFn: func(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error {
+		patchFn: func(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error {
 			return nil
 		},
 
-		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]string, error) {
-			return map[string]string{}, nil
+		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]int64, error) {
+			return map[string]int64{}, nil
 		},
 	}
 	for desc, tc := range testCases {
@@ -438,11 +438,11 @@ func TestRefresher_handleRemoveEnvironmentEvent(t *testing.T) {
 		},
 	}
 	inventoryRepo := mockInventoryRepo{
-		patchFn: func(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error {
+		patchFn: func(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error {
 			return nil
 		},
-		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]string, error) {
-			return map[string]string{}, nil
+		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]int64, error) {
+			return map[string]int64{}, nil
 		},
 	}
 
@@ -531,7 +531,7 @@ func TestRefresher_handleRemoveEnvironmentEvent(t *testing.T) {
 					},
 				},
 				inventoryRepo: mockInventoryRepo{
-					patchFn: func(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error {
+					patchFn: func(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error {
 						return domain.ErrCacheInternal
 					},
 					getKeysForEnvironmentFn: func(ctx context.Context, env string) (map[string]string, error) {
@@ -581,17 +581,17 @@ type mockConfig struct {
 }
 
 type mockInventoryRepo struct {
-	addFn                      func(ctx context.Context, key string, assets map[string]string) error
+	addFn                      func(ctx context.Context, key string, assets map[string]int64) error
 	removeFn                   func(ctx context.Context, key string) error
-	getFn                      func(ctx context.Context, key string) (map[string]string, error)
-	patchFn                    func(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error
-	buildAssetListFromConfigFn func(config []domain.ProxyConfig) (map[string]string, error)
+	getFn                      func(ctx context.Context, key string) (map[string]int64, error)
+	patchFn                    func(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error
+	buildAssetListFromConfigFn func(config []domain.ProxyConfig) (map[string]int64, error)
 	cleanupFn                  func(ctx context.Context, key string, config []domain.ProxyConfig) ([]domain.SSEMessage, error)
 	keyExistsFn                func(ctx context.Context, key string) bool
 	getKeysForEnvironmentFn    func(ctx context.Context, env string) (map[string]string, error)
 }
 
-func (m mockInventoryRepo) Add(ctx context.Context, key string, assets map[string]string) error {
+func (m mockInventoryRepo) Add(ctx context.Context, key string, assets map[string]int64) error {
 	return m.addFn(ctx, key, assets)
 }
 
@@ -599,15 +599,15 @@ func (m mockInventoryRepo) Remove(ctx context.Context, key string) error {
 	return m.removeFn(ctx, key)
 }
 
-func (m mockInventoryRepo) Get(ctx context.Context, key string) (map[string]string, error) {
+func (m mockInventoryRepo) Get(ctx context.Context, key string) (map[string]int64, error) {
 	return m.getFn(ctx, key)
 }
 
-func (m mockInventoryRepo) Patch(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error {
+func (m mockInventoryRepo) Patch(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error {
 	return m.patchFn(ctx, key, patch)
 }
 
-func (m mockInventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]string, error) {
+func (m mockInventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]int64, error) {
 	return m.buildAssetListFromConfigFn(config)
 }
 

--- a/config/remote/config_test.go
+++ b/config/remote/config_test.go
@@ -26,17 +26,17 @@ import (
 )
 
 type mockInventoryRepo struct {
-	addFn                      func(ctx context.Context, key string, assets map[string]string) error
+	addFn                      func(ctx context.Context, key string, assets map[string]int64) error
 	removeFn                   func(ctx context.Context, key string) error
-	getFn                      func(ctx context.Context, key string) (map[string]string, error)
-	patchFn                    func(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error
-	buildAssetListFromConfigFn func(config []domain.ProxyConfig) (map[string]string, error)
+	getFn                      func(ctx context.Context, key string) (map[string]int64, error)
+	patchFn                    func(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error
+	buildAssetListFromConfigFn func(config []domain.ProxyConfig) (map[string]int64, error)
 	cleanupFn                  func(ctx context.Context, key string, config []domain.ProxyConfig) ([]domain.SSEMessage, error)
 	keyExistsFn                func(ctx context.Context, key string) bool
 	getKeysForEnvironmentFn    func(ctx context.Context, env string) (map[string]string, error)
 }
 
-func (m mockInventoryRepo) Add(ctx context.Context, key string, assets map[string]string) error {
+func (m mockInventoryRepo) Add(ctx context.Context, key string, assets map[string]int64) error {
 	return m.addFn(ctx, key, assets)
 }
 
@@ -44,15 +44,15 @@ func (m mockInventoryRepo) Remove(ctx context.Context, key string) error {
 	return m.removeFn(ctx, key)
 }
 
-func (m mockInventoryRepo) Get(ctx context.Context, key string) (map[string]string, error) {
+func (m mockInventoryRepo) Get(ctx context.Context, key string) (map[string]int64, error) {
 	return m.getFn(ctx, key)
 }
 
-func (m mockInventoryRepo) Patch(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error {
+func (m mockInventoryRepo) Patch(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error {
 	return m.patchFn(ctx, key, patch)
 }
 
-func (m mockInventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]string, error) {
+func (m mockInventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]int64, error) {
 	return m.buildAssetListFromConfigFn(config)
 }
 
@@ -510,20 +510,20 @@ func TestConfig_Populate(t *testing.T) {
 	}
 
 	inventoryRepo := mockInventoryRepo{
-		addFn: func(ctx context.Context, key string, assets map[string]string) error {
+		addFn: func(ctx context.Context, key string, assets map[string]int64) error {
 			return nil
 		},
 		removeFn: func(ctx context.Context, key string) error {
 			return nil
 		},
-		getFn: func(ctx context.Context, key string) (map[string]string, error) {
-			return map[string]string{}, nil
+		getFn: func(ctx context.Context, key string) (map[string]int64, error) {
+			return map[string]int64{}, nil
 		},
-		patchFn: func(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error {
+		patchFn: func(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error {
 			return nil
 		},
-		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]string, error) {
-			return map[string]string{}, nil
+		buildAssetListFromConfigFn: func(config []domain.ProxyConfig) (map[string]int64, error) {
+			return map[string]int64{}, nil
 		},
 		cleanupFn: func(ctx context.Context, key string, config []domain.ProxyConfig) ([]domain.SSEMessage, error) {
 			return []domain.SSEMessage{}, nil

--- a/domain/inventory.go
+++ b/domain/inventory.go
@@ -8,9 +8,9 @@ import (
 type KeyInventory string
 
 type Assets struct {
-	Deleted map[string]string
-	Created map[string]string
-	Patched map[string]string
+	Deleted map[string]int64
+	Created map[string]int64
+	Patched map[string]int64
 }
 
 // NewKeyInventory creates a key inventory entry for the proxy key. This key contains all the entries associated with the proxy key.

--- a/domain/repository.go
+++ b/domain/repository.go
@@ -6,11 +6,11 @@ import (
 
 // KeyRepo the interface for keyRepository.
 type InventoryRepo interface {
-	Add(ctx context.Context, key string, assets map[string]string) error
+	Add(ctx context.Context, key string, assets map[string]int64) error
 	Remove(ctx context.Context, key string) error
-	Get(ctx context.Context, key string) (map[string]string, error)
-	Patch(ctx context.Context, key string, patch func(assets map[string]string) (map[string]string, error)) error
-	BuildAssetListFromConfig(config []ProxyConfig) (map[string]string, error)
+	Get(ctx context.Context, key string) (map[string]int64, error)
+	Patch(ctx context.Context, key string, patch func(assets map[string]int64) (map[string]int64, error)) error
+	BuildAssetListFromConfig(config []ProxyConfig) (map[string]int64, error)
 	Cleanup(ctx context.Context, key string, config []ProxyConfig) ([]SSEMessage, error)
 	KeyExists(ctx context.Context, key string) bool
 	GetKeysForEnvironment(ctx context.Context, env string) (map[string]string, error)

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -149,7 +149,7 @@ func (i InventoryRepo) removeOldKeyData(ctx context.Context, key string) error {
 	delete(res, string(excludeKey))
 
 	for k := range res {
-		var oldAssets map[string]string
+		var oldAssets map[string]int64
 		err := i.cache.Get(ctx, k, &oldAssets)
 		if err != nil && !errors.Is(err, domain.ErrCacheNotFound) {
 			i.log.Error("failed to get stale assets for inventory key", "key", k, "err", err)
@@ -172,7 +172,7 @@ func (i InventoryRepo) removeOldKeyData(ctx context.Context, key string) error {
 	return nil
 }
 
-func (i InventoryRepo) removeAssets(ctx context.Context, assets map[string]string) error {
+func (i InventoryRepo) removeAssets(ctx context.Context, assets map[string]int64) error {
 	var (
 		wg        = &sync.WaitGroup{}
 		errChan   = make(chan error)

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/harness/ff-proxy/v2/cache"
-	"github.com/harness/ff-proxy/v2/domain"
-	"github.com/harness/ff-proxy/v2/log"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/harness/ff-proxy/v2/cache"
+	"github.com/harness/ff-proxy/v2/domain"
+	"github.com/harness/ff-proxy/v2/log"
 )
 
 const (

--- a/repository/inventory_repo.go
+++ b/repository/inventory_repo.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
-	"strings"
-	"sync"
-
 	"github.com/harness/ff-proxy/v2/cache"
 	"github.com/harness/ff-proxy/v2/domain"
 	"github.com/harness/ff-proxy/v2/log"
+	"regexp"
+	"strings"
+	"sync"
 )
 
 const (
@@ -42,23 +41,24 @@ func NewInventoryRepo(c cache.Cache, l log.Logger) InventoryRepo {
 }
 
 // Add sets the inventory for proxy config - list of assets for the key.
-func (i InventoryRepo) Add(ctx context.Context, key string, assets map[string]string) error {
+func (i InventoryRepo) Add(ctx context.Context, key string, assets map[string]int64) error {
 	return i.cache.Set(ctx, string(domain.NewKeyInventory(key)), assets)
 }
 
 func (i InventoryRepo) Remove(_ context.Context, _ string) error {
 	return nil
 }
-func (i InventoryRepo) Get(ctx context.Context, key string) (map[string]string, error) {
-	var inventory map[string]string
+func (i InventoryRepo) Get(ctx context.Context, key string) (map[string]int64, error) {
+	var inventory map[string]int64
 	err := i.cache.Get(ctx, string(domain.NewKeyInventory(key)), &inventory)
 	if err != nil && !errors.Is(err, domain.ErrCacheNotFound) {
 		return inventory, err
 	}
+
 	return inventory, nil
 }
 
-func (i InventoryRepo) Patch(ctx context.Context, key string, updateInventory func(assets map[string]string) (map[string]string, error)) error {
+func (i InventoryRepo) Patch(ctx context.Context, key string, updateInventory func(assets map[string]int64) (map[string]int64, error)) error {
 	oldAssets, err := i.Get(ctx, key)
 	if err != nil {
 		return err
@@ -207,17 +207,21 @@ func (i InventoryRepo) removeAssets(ctx context.Context, assets map[string]strin
 	return nil
 }
 
-func diffAssets(oldMap, newMap map[string]string) domain.Assets {
-	deleted := make(map[string]string)
-	created := make(map[string]string)
-	patched := make(map[string]string)
+func diffAssets(oldMap map[string]int64, newMap map[string]int64) domain.Assets {
+	deleted := make(map[string]int64)
+	created := make(map[string]int64)
+	patched := make(map[string]int64)
 
 	// Check elements in old but not in new
-	for key, value := range oldMap {
-		if newValue, exists := newMap[key]; !exists || newValue != value {
-			deleted[key] = value
+	for key, oldVersion := range oldMap {
+		if newVersion, exists := newMap[key]; !exists {
+			deleted[key] = oldVersion
 		} else {
-			patched[key] = value
+			// If the version number of the newAsset is greater than the old one then we can
+			// assume it was updated in Saas so we should send a patch event
+			if newVersion > oldVersion {
+				patched[key] = newVersion
+			}
 		}
 	}
 
@@ -235,31 +239,31 @@ func diffAssets(oldMap, newMap map[string]string) domain.Assets {
 }
 
 // BuildAssetListFromConfig returns the list of keys for all assets associated with this proxyKey
-func (i InventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]string, error) {
+func (i InventoryRepo) BuildAssetListFromConfig(config []domain.ProxyConfig) (map[string]int64, error) {
 
-	empty := ""
-	inventory := make(map[string]string)
+	inventory := make(map[string]int64)
 
 	for _, cfg := range config {
 		for _, env := range cfg.Environments {
 			environment := env.ID.String()
 			if len(env.APIKeys) > 0 {
-				inventory[string(domain.NewAPIConfigsKey(environment))] = empty
+				// APIKeys aren't versioned so we can hardcode their version to 0
+				inventory[string(domain.NewAPIConfigsKey(environment))] = 0
 				for _, apiKey := range env.APIKeys {
-					inventory[string(domain.NewAuthAPIKey(apiKey))] = empty
+					inventory[string(domain.NewAuthAPIKey(apiKey))] = 0
 				}
 			}
 			if len(env.FeatureConfigs) > 0 {
-				inventory[string(domain.NewFeatureConfigsKey(environment))] = empty
+				inventory[string(domain.NewFeatureConfigsKey(environment))] = 0
 				for _, f := range env.FeatureConfigs {
-					inventory[string(domain.NewFeatureConfigKey(environment, f.Feature))] = empty
+					inventory[string(domain.NewFeatureConfigKey(environment, f.Feature))] = domain.SafePtrDereference(f.Version)
 				}
 			}
 
 			if len(env.Segments) > 0 {
-				inventory[string(domain.NewSegmentsKey(environment))] = empty
+				inventory[string(domain.NewSegmentsKey(environment))] = 0
 				for _, s := range env.Segments {
-					inventory[string(domain.NewSegmentKey(environment, s.Name))] = empty
+					inventory[string(domain.NewSegmentKey(environment, s.Name))] = domain.SafePtrDereference(s.Version)
 				}
 			}
 		}
@@ -297,55 +301,55 @@ func (i InventoryRepo) BuildNotifications(assets domain.Assets) []domain.SSEMess
 	return events
 }
 
-func (i InventoryRepo) getDeleteEvents(m map[string]string) []domain.SSEMessage {
+func (i InventoryRepo) getDeleteEvents(m map[string]int64) []domain.SSEMessage {
 	res := make([]domain.SSEMessage, 0, len(m))
 	if m == nil {
 		return []domain.SSEMessage{}
 	}
-	for k := range m {
+	for k, version := range m {
 		if strings.Contains(k, featureVariant) {
-			res = append(res, i.parseFlagEntry(k, deleteVariant))
+			res = append(res, i.parseFlagEntry(k, deleteVariant, version))
 		}
 		if strings.Contains(k, segmentVariant) {
-			res = append(res, i.parseSegmentEntry(k, deleteVariant))
+			res = append(res, i.parseSegmentEntry(k, deleteVariant, version))
 		}
 	}
 	return res
 }
 
-func (i InventoryRepo) getCreateEvents(m map[string]string) []domain.SSEMessage {
+func (i InventoryRepo) getCreateEvents(m map[string]int64) []domain.SSEMessage {
 	res := make([]domain.SSEMessage, 0, len(m))
 	if m == nil {
 		return []domain.SSEMessage{}
 	}
-	for k := range m {
+	for k, version := range m {
 		if strings.Contains(k, featureVariant) {
-			res = append(res, i.parseFlagEntry(k, createVariant))
+			res = append(res, i.parseFlagEntry(k, createVariant, version))
 		}
 		if strings.Contains(k, segmentVariant) {
-			res = append(res, i.parseSegmentEntry(k, createVariant))
+			res = append(res, i.parseSegmentEntry(k, createVariant, version))
 		}
 	}
 	return res
 }
 
-func (i InventoryRepo) getPatchEvents(m map[string]string) []domain.SSEMessage {
+func (i InventoryRepo) getPatchEvents(m map[string]int64) []domain.SSEMessage {
 	res := make([]domain.SSEMessage, 0, len(m))
 	if m == nil {
 		return []domain.SSEMessage{}
 	}
-	for k := range m {
+	for k, version := range m {
 		if strings.Contains(k, featureVariant) {
-			res = append(res, i.parseFlagEntry(k, patchVariant))
+			res = append(res, i.parseFlagEntry(k, patchVariant, version))
 		}
 		if strings.Contains(k, segmentVariant) {
-			res = append(res, i.parseSegmentEntry(k, patchVariant))
+			res = append(res, i.parseSegmentEntry(k, patchVariant, version))
 		}
 	}
 	return res
 }
 
-func (i InventoryRepo) parseFlagEntry(flagString, variant string) domain.SSEMessage {
+func (i InventoryRepo) parseFlagEntry(flagString, variant string, version int64) domain.SSEMessage {
 	env, id, err := parseFlagString(flagString)
 	if err != nil {
 		i.log.Error("err", err)
@@ -356,10 +360,10 @@ func (i InventoryRepo) parseFlagEntry(flagString, variant string) domain.SSEMess
 		Event:       variant,
 		Identifier:  id,
 		Environment: env,
-		Version:     0,
+		Version:     int(version),
 	}
 }
-func (i InventoryRepo) parseSegmentEntry(segmentString, variant string) domain.SSEMessage {
+func (i InventoryRepo) parseSegmentEntry(segmentString, variant string, version int64) domain.SSEMessage {
 	env, id, err := parseSegmentString(segmentString)
 	if err != nil {
 		i.log.Error("err", err)
@@ -370,7 +374,7 @@ func (i InventoryRepo) parseSegmentEntry(segmentString, variant string) domain.S
 		Event:       variant,
 		Identifier:  id,
 		Environment: env,
-		Version:     0,
+		Version:     int(version),
 	}
 }
 

--- a/repository/inventory_repo_test.go
+++ b/repository/inventory_repo_test.go
@@ -30,7 +30,7 @@ func TestInventoryRepo_Add(t *testing.T) {
 
 	type args struct {
 		key   string
-		value map[string]string
+		value map[string]int64
 	}
 
 	type mocks struct {
@@ -50,7 +50,7 @@ func TestInventoryRepo_Add(t *testing.T) {
 		"Given I call set and the cache errors": {
 			args: args{
 				key:   "123",
-				value: map[string]string{"hello": "world"},
+				value: map[string]int64{"hello": 1},
 			},
 			mocks: mocks{
 				cache: &mCache{
@@ -68,7 +68,7 @@ func TestInventoryRepo_Add(t *testing.T) {
 		"Given I call set and the cache doesn't error": {
 			args: args{
 				key:   "123",
-				value: map[string]string{"hello": "world"},
+				value: map[string]int64{"hello": 1},
 			},
 			mocks: mocks{
 				cache: &mCache{
@@ -82,7 +82,7 @@ func TestInventoryRepo_Add(t *testing.T) {
 			shouldErr: false,
 			expected: expected{
 				data: map[string]interface{}{
-					"key-123-inventory": map[string]string{"hello": "world"},
+					"key-123-inventory": map[string]int64{"hello": 1},
 				},
 			},
 		},
@@ -113,13 +113,13 @@ func TestInventoryRepo_Cleanup(t *testing.T) {
 		key123 = "123"
 		key456 = "456"
 
-		assetsc22b78a0Map = map[string]string{
-			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-feature-config-flagOne": "",
-			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-feature-configs":        "",
-			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-segments":               "",
-			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-segment-segmentOne":     "",
-			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-api-configs":            "",
-			"auth-key-123": "",
+		assetsc22b78a0Map = map[string]int64{
+			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-feature-config-flagOne": 1,
+			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-feature-configs":        0,
+			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-segments":               0,
+			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-segment-segmentOne":     1,
+			"env-c22b78a0-4bbe-46dc-bc12-a0206c0d4ad7-api-configs":            0,
+			"auth-key-123": 0,
 		}
 
 		assetsc22b78a0 = []domain.ProxyConfig{
@@ -131,12 +131,14 @@ func TestInventoryRepo_Cleanup(t *testing.T) {
 						FeatureConfigs: []domain.FeatureFlag{
 							{
 								Feature: "flagOne",
+								Version: int64Ptr(1),
 							},
 						},
 						Segments: []domain.Segment{
 							{
 								Name:       "segmentOne",
 								Identifier: "segmentOne",
+								Version:    int64Ptr(1),
 							},
 						},
 					},
@@ -144,13 +146,13 @@ func TestInventoryRepo_Cleanup(t *testing.T) {
 			},
 		}
 
-		assetsd5c39e52Map = map[string]string{
-			"auth-key-456": "",
-			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-feature-config-flagTwo": "",
-			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-feature-configs":        "",
-			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-segments":               "",
-			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-segment-segmentTwo":     "",
-			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-api-configs":            "",
+		assetsd5c39e52Map = map[string]int64{
+			"auth-key-456": 0,
+			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-feature-config-flagTwo": 2,
+			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-feature-configs":        0,
+			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-segments":               0,
+			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-segment-segmentTwo":     2,
+			"env-d5c39e52-0f94-4a4b-a053-9ad842ffd692-api-configs":            0,
 		}
 
 		assetsd5c39e52 = []domain.ProxyConfig{
@@ -162,12 +164,14 @@ func TestInventoryRepo_Cleanup(t *testing.T) {
 						FeatureConfigs: []domain.FeatureFlag{
 							{
 								Feature: "flagTwo",
+								Version: int64Ptr(2),
 							},
 						},
 						Segments: []domain.Segment{
 							{
 								Name:       "segmentTwo",
 								Identifier: "segmentTwo",
+								Version:    int64Ptr(2),
 							},
 						},
 					},
@@ -185,7 +189,7 @@ func TestInventoryRepo_Cleanup(t *testing.T) {
 
 	type args struct {
 		oldKey    string
-		oldAssets map[string]string
+		oldAssets map[string]int64
 
 		newKey    string
 		newAssets []domain.ProxyConfig
@@ -195,7 +199,7 @@ func TestInventoryRepo_Cleanup(t *testing.T) {
 	}
 
 	type expected struct {
-		config map[string]string
+		config map[string]int64
 	}
 
 	testCases := map[string]struct {
@@ -251,7 +255,7 @@ func TestInventoryRepo_Cleanup(t *testing.T) {
 				assert.Nil(t, err)
 			}
 
-			var nilMap map[string]string
+			var nilMap map[string]int64
 
 			// Assert that we've removed data for the cleanup key
 			cleanupRes, err := ir.Get(ctx, tc.args.oldKey)
@@ -283,14 +287,14 @@ func TestInventoryRepo_BuildNotificatons(t *testing.T) {
 		"Given I have assets with no underscores": {
 			args: args{
 				assets: domain.Assets{
-					Deleted: map[string]string{
-						"env-1234-feature-config-foobar": "",
+					Deleted: map[string]int64{
+						"env-1234-feature-config-foobar": 1,
 					},
-					Created: map[string]string{
-						"env-1234-feature-config-helloworld": "",
+					Created: map[string]int64{
+						"env-1234-feature-config-helloworld": 2,
 					},
-					Patched: map[string]string{
-						"env-1234-segment-foobar": "",
+					Patched: map[string]int64{
+						"env-1234-segment-foobar": 3,
 					},
 				},
 			},
@@ -300,21 +304,21 @@ func TestInventoryRepo_BuildNotificatons(t *testing.T) {
 						Event:       "delete",
 						Domain:      "flag",
 						Identifier:  "foobar",
-						Version:     0,
+						Version:     1,
 						Environment: "1234",
 					},
 					{
 						Event:       "create",
 						Domain:      "flag",
 						Identifier:  "helloworld",
-						Version:     0,
+						Version:     2,
 						Environment: "1234",
 					},
 					{
 						Event:       "patch",
 						Domain:      "target-segment",
 						Identifier:  "foobar",
-						Version:     0,
+						Version:     3,
 						Environment: "1234",
 					},
 				},
@@ -323,14 +327,14 @@ func TestInventoryRepo_BuildNotificatons(t *testing.T) {
 		"Given I have assets with underscores": {
 			args: args{
 				assets: domain.Assets{
-					Deleted: map[string]string{
-						"env-1234-feature-config-PIE_ENABLE_THIS_THING": "",
+					Deleted: map[string]int64{
+						"env-1234-feature-config-PIE_ENABLE_THIS_THING": 1,
 					},
-					Created: map[string]string{
-						"env-1234-feature-config-_CDS__ENABLED___FLAG": "",
+					Created: map[string]int64{
+						"env-1234-feature-config-_CDS__ENABLED___FLAG": 2,
 					},
-					Patched: map[string]string{
-						"env-1234-segment-_SOME_SPECIAL_SEGMENT__": "",
+					Patched: map[string]int64{
+						"env-1234-segment-_SOME_SPECIAL_SEGMENT__": 3,
 					},
 				},
 			},
@@ -340,21 +344,21 @@ func TestInventoryRepo_BuildNotificatons(t *testing.T) {
 						Event:       "delete",
 						Domain:      "flag",
 						Identifier:  "PIE_ENABLE_THIS_THING",
-						Version:     0,
+						Version:     1,
 						Environment: "1234",
 					},
 					{
 						Event:       "create",
 						Domain:      "flag",
 						Identifier:  "_CDS__ENABLED___FLAG",
-						Version:     0,
+						Version:     2,
 						Environment: "1234",
 					},
 					{
 						Event:       "patch",
 						Domain:      "target-segment",
 						Identifier:  "_SOME_SPECIAL_SEGMENT__",
-						Version:     0,
+						Version:     3,
 						Environment: "1234",
 					},
 				},


### PR DESCRIPTION
**What**

- Updates the InventoryRepo so that it stores the version number of resources along with their redis key.
- When fetching config from Saas, we now compare the version of the new resource pulled down with the version stored in the Proxy's inventory. If the new version is greater then we'll add it to the list of notifications, if it isn't then it will be ignroed and no notifications will be sent.

**Why**

- Previously on startup or restart we would send SSE PATCH events for all events. This forced SDKs to reach out to the Proxy and ensured they had the most recent version incase changes were made in Saas while the Proxy was down.
- Now we'll only send patch events for resources that have actually changed while the Proxy was disconnected from Saas.

**Testing**

Manually went through the following AC 

**Acceptance Criteria**

**Proxy Running**

**Given** I toggle a flag
**Then** The Proxy should receive an SSE event from Saas, fetch the updated config and store it in redis
**And** A PATCH SSE event should be forwarded on to my SDK


**Given** I delete a flag
**Then** the Proxy should receive a DELETE SSE event and remove the flag from redis
**And** a DELETE SSE event should be forwarded on to my SDK


**Given** I create a flag
**Then** the Proxy should receive a CREATE SSE event from Saas, fetch the config & store it in redis
**And** a CREATE SSE event should be forwarded on to my SDK


**Proxy Disconnected From Saas**

**Given** I delete a flag
**When** the Proxy reconnects to Saas
**Then** It should remove the flag from redis & send a DELETE SSE event to SDKs

**Given** I create a flag
**When** the Proxy reconnects to Saas
**Then** it should add the new flag to redis & send a CREATE SSE event to SDKs

**Given** I patch a flag
**When** the proxy reconnects to Saas
**Then** it should update the flags config in redis & send s PATCH sse event