### PR TITLE
Fix default pool size value with additional config

### DIFF
--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -868,7 +868,7 @@ func newRedisClient(addr string, username string, password string, db int, logge
 	//
 	// However, if REDIS_POOL_SIZE_LITERAL is set then we will use it instead.
 	poolSize := redisPoolSize * runtime.NumCPU()
-	if redisPoolSizeLiteral >= 0 {
+	if redisPoolSizeLiteral > 0 {
 		poolSize = redisPoolSizeLiteral
 	}
 


### PR DESCRIPTION
**What**

Fixes an issue introduced in #408 where you couldn't use the old `REDIS_POOL_SIZE` env to configure the redis pool size anymore

**Why**

If `REDIS_POOL_SIZE_LITERAL` isn't set then we should default back to the value of `REDIS_POOL_SIZE` * num CPU.

**Testing**

- Ran Proxy locally with `REDIS_POOL_SIZE_LITERAL` set and ran it without it set. 