### PR TITLE
FFM-12750 - Fix issue where Proxy was dropping newly created

### DIFF
--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -381,16 +381,26 @@ func (s Refresher) handleFetchFeatureEvent(ctx context.Context, env, identifier 
 	})
 }
 
+// replaceFeatureConfig replaces the featureConfig in the featureConfigs array with the updated featureConfig. If the
+// featureConfig does not exist in the featureConfigs slice it is added to it.
 func replaceFeatureConfig(newConfig domain.FeatureFlag, featureConfigs *[]domain.FeatureFlag) {
 	if featureConfigs == nil {
 		return
 	}
 
+	flagUpdated := false
 	for i := range *featureConfigs {
 		if (*featureConfigs)[i].Feature == newConfig.Feature {
 			(*featureConfigs)[i] = newConfig
+			flagUpdated = true
 			break
 		}
+	}
+
+	// If we didn't update any featureConfigs then this must be a new one so we
+	// need to add it to the featureConfigs slice
+	if !flagUpdated {
+		*featureConfigs = append(*featureConfigs, newConfig)
 	}
 }
 
@@ -625,11 +635,16 @@ func replaceSegmentConfig(newConfig domain.Segment, segmentConfigs *[]domain.Seg
 	if segmentConfigs == nil {
 		return
 	}
+	segmentUpdated := false
 
 	for i := range *segmentConfigs {
 		if (*segmentConfigs)[i].Identifier == newConfig.Identifier {
 			(*segmentConfigs)[i] = newConfig
 			break
 		}
+	}
+
+	if !segmentUpdated {
+		*segmentConfigs = append(*segmentConfigs, newConfig)
 	}
 }

--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -640,6 +640,7 @@ func replaceSegmentConfig(newConfig domain.Segment, segmentConfigs *[]domain.Seg
 	for i := range *segmentConfigs {
 		if (*segmentConfigs)[i].Identifier == newConfig.Identifier {
 			(*segmentConfigs)[i] = newConfig
+			segmentUpdated = true
 			break
 		}
 	}

--- a/cache/refresher_test.go
+++ b/cache/refresher_test.go
@@ -962,13 +962,14 @@ func TestReplaceFeatureConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "no matching feature - no change",
+			name: "adding a new feature",
 			initialConfigs: []domain.FeatureFlag{
 				{Feature: "featA", Version: &version1},
 			},
-			newConfig: domain.FeatureFlag{Feature: "featB", Version: &version2},
+			newConfig: domain.FeatureFlag{Feature: "newFlag", Version: &version1},
 			expected: []domain.FeatureFlag{
 				{Feature: "featA", Version: &version1},
+				{Feature: "newFlag", Version: &version1},
 			},
 		},
 	}
@@ -1009,13 +1010,14 @@ func TestReplaceSegmentConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "no matching segment - no change",
+			name: "adding a new segment",
 			initialConfigs: []domain.Segment{
 				{Identifier: "featA", Version: &version1},
 			},
-			newConfig: domain.Segment{Identifier: "featB", Version: &version2},
+			newConfig: domain.Segment{Identifier: "newSegment", Version: &version1},
 			expected: []domain.Segment{
 				{Identifier: "featA", Version: &version1},
+				{Identifier: "newSegment", Version: &version1},
 			},
 		},
 	}


### PR DESCRIPTION
**What**

Fixes an issue introduced in 2.0.17 that would cause us to drop updates for newly created flags and segments. Existing flags/segments that were edited were still updated