### PR TITLE
fix: [FFM-12924]: refresh auth token in SSE event handlers

### DIFF
--- a/cache/refresher.go
+++ b/cache/refresher.go
@@ -349,9 +349,14 @@ func (s Refresher) handleRemoveAPIKeyEvent(ctx context.Context, env, apiKey stri
 func (s Refresher) handleFetchFeatureEvent(ctx context.Context, env, identifier string) error {
 	s.log.Debug("updating featureConfig entry", "environment", env, "identifier", identifier)
 
+	authToken, err := s.config.RefreshToken()
+	if err != nil {
+		return fmt.Errorf("failed to refresh auth token to fetch feature config: %s", err)
+	}
+
 	// Make a request to Harness Saas to fetch the updated featureConfig
 	fc, err := s.clientService.GetFeatureConfigByIdentifier(ctx, domain.GetFeatureConfigsByIdentifierInput{
-		AuthToken:  s.config.Token(),
+		AuthToken:  authToken,
 		Cluster:    s.config.ClusterIdentifier(),
 		EnvID:      env,
 		Identifier: identifier,
@@ -473,8 +478,13 @@ func (s Refresher) updateFeatureConfigsEntry(ctx context.Context, env string, id
 func (s Refresher) handleFetchSegmentEvent(ctx context.Context, env, identifier string) error {
 	s.log.Debug("updating featureConfig entry", "environment", env, "identifier", identifier)
 
+	authToken, err := s.config.RefreshToken()
+	if err != nil {
+		return fmt.Errorf("failed to refresh auth token to fetch segment config: %s", err)
+	}
+
 	sc, err := s.clientService.GetSegmentByIdentifier(ctx, domain.GetSegmentByIdentifierInput{
-		AuthToken:  s.config.Token(),
+		AuthToken:  authToken,
 		Cluster:    s.config.ClusterIdentifier(),
 		EnvID:      env,
 		Identifier: identifier,


### PR DESCRIPTION
## Summary
- handleFetchFeatureEvent and handleFetchSegmentEvent used s.config.Token() which returns a stale cached JWT
- After ~3hr 42min TTL expiry, SSE-triggered feature/segment updates silently fail with ErrUnauthorized (401)
- Added RefreshToken() calls matching the existing pattern in handleAddEnvironmentEvent

## Test plan
- [x] go build ./...
- [x] go test ./cache/...

Ticket: https://harness.atlassian.net/browse/FFM-12924

🤖 Generated with [Claude Code](https://claude.com/claude-code)