### PR TITLE
fix: [FFM-12924]: flush HashCache local cache on SSE reconnect

### DIFF
--- a/cache/hash_cache.go
+++ b/cache/hash_cache.go
@@ -97,6 +97,11 @@ func (hc HashCache) get(ctx context.Context, key string, value interface{}) (int
 	return value, err
 }
 
+// Flush clears all entries from the local in-memory cache
+func (hc HashCache) Flush() {
+	hc.localCache.Flush()
+}
+
 // Delete key from local cache as well as hash entry in the redis
 func (hc HashCache) Delete(ctx context.Context, key string) error {
 

--- a/cache/hash_cache_test.go
+++ b/cache/hash_cache_test.go
@@ -70,6 +70,8 @@ func (m *mockLocalCache) Get(key string) (interface{}, bool) {
 	return b, ok
 }
 
+func (m *mockLocalCache) Flush() {}
+
 func TestHashCache_Set(t *testing.T) {
 	fooSegment := domain.Segment{Identifier: "foo"}
 	fooFeature := domain.FeatureFlag{Feature: "foo"}

--- a/cache/memoize_cache.go
+++ b/cache/memoize_cache.go
@@ -31,6 +31,7 @@ type internalCache interface {
 	Get(key string) (interface{}, bool)
 	Set(key string, v interface{}, d time.Duration)
 	Delete(key string)
+	Flush()
 }
 
 // The Memoize Cache embeds the KeyValCache and adds an in-memory caching layer for serialised data.

--- a/cache/memoize_cache_test.go
+++ b/cache/memoize_cache_test.go
@@ -26,6 +26,8 @@ func (m *mockInternalCache) Set(key string, v interface{}, d time.Duration) {
 	m.data[key] = v
 }
 
+func (m *mockInternalCache) Flush() {}
+
 type mockMetrics struct {
 	cacheMarshal        int
 	cacheUnmarshal      int

--- a/cmd/ff-proxy/main.go
+++ b/cmd/ff-proxy/main.go
@@ -645,6 +645,9 @@ func main() {
 	}
 
 	reloadConfig := func() error {
+		if hashCache != nil {
+			hashCache.Flush()
+		}
 		return conf.FetchAndPopulate(ctx, inventoryRepo, authRepo, flagRepo, segmentRepo)
 	}
 


### PR DESCRIPTION
## Summary
- HashCache wraps Redis with an in-memory go-cache (10min TTL) but never flushes on disconnect/reconnect
- After SSE reconnect, FetchAndPopulate writes fresh data to Redis but stale local cache entries are served
- Added Flush() method to HashCache and call it in the reloadConfig path used by both disconnect and reconnect handlers

## Test plan
- [x] go build ./...
- [x] go test ./cache/...
- [x] go test ./repository/...

Ticket: https://harness.atlassian.net/browse/FFM-12924

🤖 Generated with [Claude Code](https://claude.com/claude-code)